### PR TITLE
Updated integration tests

### DIFF
--- a/data/fsm/fsm_configuration.json
+++ b/data/fsm/fsm_configuration.json
@@ -47,6 +47,6 @@
     },
     "post_transitions": {
         "start": {"order": ["run-number", "logbook"], "mandatory": ["run-number"]},
-        "stop":  {"order": ["logbook"], "mandatory": []}
+        "stop":  {"order": ["logbook"],               "mandatory": []}
     }
 }

--- a/data/fsm/fsm_test_args.json
+++ b/data/fsm/fsm_test_args.json
@@ -1,0 +1,48 @@
+{
+    "fsm_configuration": {
+        "conf":                     "fsm_conf",
+        "start":                    "fsm_start",
+        "stop":                     "fsm_stop",
+        "start_run": {
+            "conf":                 "fsm_conf",
+            "start":                "fsm_start",
+            "enable_triggers":      "no_args"
+        },
+        "stop_run": {
+            "disable_triggers":     "no_args",
+            "drain_dataflow":       "no_args",
+            "stop_trigger_sources": "no_args",
+            "stop":                 "fsm_stop"
+        },
+        "shutdown": {
+            "disable_triggers":     "no_args",
+            "drain_dataflow":       "no_args",
+            "stop_trigger_sources": "no_args",
+            "stop":                 "fsm_stop",
+            "scrap":                "no_args",
+            "terminate":            "no_args"
+        }
+    },
+    "no_interfaces": {
+        "conf":                     "noint_conf",
+        "start_run": {
+            "conf":                 "noint_conf",
+            "start":                "no_args",
+            "enable_triggers":      "no_args"
+        },
+        "stop_run": {
+            "disable_triggers":     "no_args",
+            "drain_dataflow":       "no_args",
+            "stop_trigger_sources": "no_args",
+            "stop":                 "no_args"
+            },
+        "shutdown": {
+            "disable_triggers":     "no_args",
+            "drain_dataflow":       "no_args",
+            "stop_trigger_sources": "no_args",
+            "stop":                 "no_args",
+            "scrap":                "no_args",
+            "terminate":            "no_args"
+        }
+    }
+}

--- a/src/drunc/fsm/fsm_core.py
+++ b/src/drunc/fsm/fsm_core.py
@@ -145,9 +145,9 @@ class FSM:
         '''
         if transition in self.config.sequences: 
             #TODO check nanorc.common_commands.py, should be like that
-            for command in self.config.sequences[transition]:   #Format is {"cmd": "conf", "optional": true }
+            for command in self.config.sequences[transition]:   #"command" has format {"cmd": "conf", "optional": true }
                 try:                                            #Attempt every transition in the sequence
-                    self.execute_transition(command['cmd'], transition_data[command])
+                    self.execute_transition(command['cmd'], transition_data[command['cmd']])
                 except Exception as e:
                     if not command["optional"]:                 #If it fails and isn't optional
                         raise e                                 #Pass the error up and stop

--- a/src/drunc/fsm/interfaces/DummyLogbookInterface.py
+++ b/src/drunc/fsm/interfaces/DummyLogbookInterface.py
@@ -1,6 +1,5 @@
 from drunc.fsm.fsm_core import FSMInterface
 
-
 class LogbookInterface(FSMInterface):
     def __init__(self, configuration):
         super().__init__("logbook")

--- a/src/drunc/tests/__main_fsm__.py
+++ b/src/drunc/tests/__main_fsm__.py
@@ -2,9 +2,6 @@ import sys
 import os
 import json
 from .fake_controller import FakeController
-#fsm_dir = os.path.join(this_dir, '..', 'fsm')
-#sys.path.append(fsm_dir)
-#from fsm_core import validate_arguments
 
 def request_args(controller, name, i_name=None):
     if i_name:
@@ -75,7 +72,6 @@ def main():
             controller.do_command(cmd, all_args)
         except Exception as e:
             print(e)
-
 
 if __name__ == '__main__':
     main()

--- a/src/drunc/tests/fake_controller.py
+++ b/src/drunc/tests/fake_controller.py
@@ -1,7 +1,7 @@
 import os
 import sys
-this_dir = os.path.dirname(__file__)
-fsm_dir = os.path.join(this_dir, '..', 'fsm')
+top_dir = os.environ['DRUNC_DIR']
+fsm_dir = os.path.join(top_dir, 'src', 'drunc', 'fsm')
 sys.path.append(fsm_dir)
 from fsm_core import FSM
 

--- a/src/drunc/tests/test_fsm.py
+++ b/src/drunc/tests/test_fsm.py
@@ -71,8 +71,8 @@ arglist = {
 @pytest.fixture(params = filelist)
 def make_controller(request):
     '''Generate a controller for each config provided.'''
-    this_dir = os.path.dirname(__file__)
-    path = os.path.join(this_dir, '..', '..', '..', 'data', 'fsm')
+    top_dir = os.environ['DRUNC_DIR']
+    path = os.path.join(top_dir, 'data', 'fsm')
     filename = f"{request.param}.json"
     filepath = path + '/' + filename
     print(filepath)

--- a/src/drunc/tests/test_fsm.py
+++ b/src/drunc/tests/test_fsm.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import json
-from fake_controller import FakeController
+from .fake_controller import FakeController
 
 #Some command sequences for the controller to run
 fsm_loop = ["boot", "conf", "start", "enable_triggers", "disable_triggers", 
@@ -9,26 +9,89 @@ fsm_loop = ["boot", "conf", "start", "enable_triggers", "disable_triggers",
 repeat = ["boot", "terminate", "boot", "terminate", "boot", "terminate", "boot", "terminate", "boot", "terminate"]
 sequences = ["boot", "start_run", "stop_run", "shutdown"]
 #A list of config files that the test should be run on
-filelist = ["fsm_configuration.json", "fake_controller.json"]
+filelist = ["fsm_configuration", "no_interfaces"]
+
+#We define the argument dicts up here to avoid repetiton
+no_args   =  {'tr': {}}
+fsm_conf  =  {'tr': {'a_number':77}, 'pre_test-interface': {}}
+noint_conf = {'tr': {'a_number':77}}
+fsm_start =  {'tr': {}, 'post_run-number': {}, 'post_logbook': {'message': "hello!"}}
+fsm_stop  =  {'tr': {}, 'post_logbook': {}}
+#This dict maps commands to the arguments that should be provided.
+#The sequences make this very big, so there is hopefully a better way of doing it.
+arglist = {
+    'fsm_configuration': {
+        'conf':                     fsm_conf,
+        'start':                    fsm_start,
+        'stop':                     fsm_stop,
+        'start_run': {
+            'conf':                 fsm_conf,
+            'start':                fsm_start,
+            'enable_triggers':      no_args
+        },
+        'stop_run': {
+            'disable_triggers':     no_args,
+            'drain_dataflow':       no_args,
+            'stop_trigger_sources': no_args,
+            'stop':                 fsm_stop
+        },
+        'shutdown': {
+            'disable_triggers':     no_args,
+            'drain_dataflow':       no_args,
+            'stop_trigger_sources': no_args,
+            'stop':                 fsm_stop,
+            'scrap':                no_args,
+            'terminate':            no_args
+        }
+    },
+    'no_interfaces': {
+        'conf': noint_conf,
+        'start_run': {
+            'conf':                 noint_conf,
+            'start':                no_args,
+            'enable_triggers':      no_args
+        },
+        'stop_run': {
+            'disable_triggers':     no_args,
+            'drain_dataflow':       no_args,
+            'stop_trigger_sources': no_args,
+            'stop':                 no_args
+            },
+        'shutdown': {
+            'disable_triggers':     no_args,
+            'drain_dataflow':       no_args,
+            'stop_trigger_sources': no_args,
+            'stop':                 no_args,
+            'scrap':                no_args,
+            'terminate':            no_args
+        }
+    }
+}
 
 @pytest.fixture(params = filelist)
-def make_controller():
+def make_controller(request):
+    '''Generate a controller for each config provided.'''
     this_dir = os.path.dirname(__file__)
     path = os.path.join(this_dir, '..', '..', '..', 'data', 'fsm')
-    filename = "fsm_configuration.json"
+    filename = f"{request.param}.json"
     filepath = path + '/' + filename
     print(filepath)
     f = open(filepath, 'r')
     config = json.loads(f.read())
     f.close()
-    return FakeController(config)
+    return FakeController(config), request.param
 
 @pytest.fixture(params = [fsm_loop, repeat, sequences])
 def run_commands(make_controller, request):
     err_list = []
+    controller = make_controller[0]
+    this_conf = make_controller[1]
     for cmd in request.param:
         try:
-            make_controller.do_command(cmd, None)
+            if cmd in arglist[this_conf]:
+                controller.do_command(cmd, arglist[this_conf][cmd])
+            else:
+                controller.do_command(cmd, no_args)
         except Exception as e:
             err_list.append(e)
     return err_list


### PR DESCRIPTION
The integ test can now provide arguments to the transitions it executes, getting them from a dict defined in the code. There was also a bug in the fsm_code that meant the transition_data was getting passed a dict as a key, it is now getting passed a string as intended.