### PR TITLE
This PR enables DAQ applications to be controlled by the controllers

### DIFF
--- a/data/controller0-conf.json
+++ b/data/controller0-conf.json
@@ -1,7 +1,5 @@
 {
-    "children_controllers": [],
-
-    "apps": [],
+    "children": [],
 
     "broadcaster": {
         "type": "kafka",

--- a/data/topcontroller-conf.json
+++ b/data/topcontroller-conf.json
@@ -1,13 +1,11 @@
 {
-    "children_controllers": [
+    "children": [
         {
             "name": "controller0",
             "type": "grpc",
             "uri": "localhost:3601"
         }
     ],
-
-    "apps": [],
 
     "authoriser": {
         "type": "dummy"

--- a/src/drunc/broadcast/server/broadcast_sender.py
+++ b/src/drunc/broadcast/server/broadcast_sender.py
@@ -98,6 +98,7 @@ class BroadcastSender:
 
         self.implementation._send(bm)
 
+    # def broadcast_stacktrace()?
 
     def _interrupt_with_message(self, message, context):
         from druncschema.generic_pb2 import PlainText

--- a/src/drunc/controller/children_interface/child_node.py
+++ b/src/drunc/controller/children_interface/child_node.py
@@ -39,7 +39,7 @@ class ChildNode(abc.ABC):
         pass
 
     @staticmethod
-    def get_from_file(name, conf:dict, token=None):
+    def get_from_file(name, conf:dict, token=None, **kwargs):
         from drunc.utils.conf_types import ConfTypes
 
         match conf['type'].lower():
@@ -50,7 +50,8 @@ class ChildNode(abc.ABC):
                     conf_type = ConfTypes.Json,
                     token = token,
                     name = name,
-                    node_type = ChildNodeType.gRPC
+                    node_type = ChildNodeType.gRPC,
+                    **kwargs,
                 )
             case 'rest-api':
                 from drunc.controller.children_interface.rest_api_child import RESTAPIChildNode
@@ -59,7 +60,8 @@ class ChildNode(abc.ABC):
                     conf_type = ConfTypes.Json,
                     token = token,
                     name = name,
-                    node_type = ChildNodeType.REST_API
+                    node_type = ChildNodeType.REST_API,
+                    **kwargs,
                 )
             case _:
                 raise ChildInterfaceTechnologyUnknown(conf['type'], name)

--- a/src/drunc/controller/children_interface/grpc_child.py
+++ b/src/drunc/controller/children_interface/grpc_child.py
@@ -81,12 +81,24 @@ class gRPCChildNode(ChildNode):
         pass
 
     def propagate_command(self, command, data, token):
-        response = send_command(
-            controller = self.controller,
-            token = token,
-            command = command,
-            rethrow = True,
-            data = data
-        )
+        success = False
+        try:
+            response = send_command(
+                controller = self.controller,
+                token = token,
+                command = command,
+                rethrow = True,
+                data = data
+            )
+            success = True
+        except Exception as e:
+            if command != 'execute_fsm_command':
+                raise e
 
-        return response
+
+        if command == 'execute_fsm_command':
+            from druncschema.controller_pb2 import FSMCommandResponseCode
+            return FSMCommandResponseCode.SUCCESSFUL if success else FSMCommandResponseCode.SUCCESSFUL
+        else:
+            return response
+

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -1,5 +1,40 @@
 from drunc.controller.children_interface.child_node import ChildNode
 
+import threading
+from typing import NoReturn
+
+class ResponseDispatcher(threading.Thread):
+
+    STOP="RESPONSE_QUEUE_STOP"
+
+    def __init__(self,listener):
+        threading.Thread.__init__(self)
+        self.listener = listener
+        from logging import getLogger
+        self.log = getLogger('ResponseDispatcher')
+
+    def run(self) -> NoReturn:
+        self.log.debug(f'ResponseDispatcher starting to run')
+
+        while True:
+            # self.log.debug(f'starting to iterating: {self.listener.queue.qsize()}')
+            # self.log.debug(f'Queue pointer {self.listener.queue}')
+            # try:
+            r = self.listener.queue.get()
+            #     self.log.debug(f'ResponseDispatcher got the following answer: {r}')
+            # except:
+            #     self.log.debug(f'ResponseDispatcher nothing')
+            #     continue
+
+            if r == self.STOP:
+                self.log.debug(f'ResponseDispatcher STOP')
+                break
+            self.listener.notify(r)
+
+    def stop(self) -> NoReturn:
+        self.listener.queue.put_nowait(self.STOP)
+        self.join()
+
 class ResponseListener:
     _instance = None
 
@@ -8,50 +43,428 @@ class ResponseListener:
 
     @classmethod
     def get(cls):
+        from logging import getLogger
+        log = getLogger('ResponseListener.get')
         if cls._instance is None:
             cls._instance = cls.__new__(cls)
             from drunc.utils.utils import get_new_port
             cls.port = get_new_port()
+            from flask import Flask
+            from flask_restful import Api
+            cls.app = Flask('response-listener')
+            cls.api = Api(cls.app)
+            from multiprocessing import Queue
+            cls.queue = Queue()
+            cls.handlers = {}
+            log.debug(f'Queue pointer {cls.queue}')
 
+            cls.dispatcher = ResponseDispatcher(cls)
+            cls.dispatcher.start()
 
+            from flask import request
+            def index():
+                from logging import getLogger
+                log = getLogger('ResponseListener.index')
+                json = request.get_json(force=True)
+                log.debug(f'Received {json}')
+                # enqueue command reply
+                cls.queue.put(json)
+                log.debug(f'Queue size {cls.queue.qsize()}')
+                log.debug(f'Queue pointer {cls.queue}')
+                return "Response received"
+
+            def get():
+                return "ready"
+
+            cls.app.add_url_rule("/response", "index", index, methods=["POST"])
+            cls.app.add_url_rule("/", "get", get, methods=["GET"])
+            from drunc.utils.flask_manager import FlaskManager
+            cls.manager = FlaskManager(
+                port = cls.port,
+                app = cls.app,
+                name = "response-listener-flaskmanager"
+            )
+
+            cls.manager.start()
+            while not cls.manager.is_ready():
+                from time import sleep
+                sleep(0.1)
 
         return cls._instance
+
+    @staticmethod
+    def exists(cls):
+        return (cls._instance is not None)
 
     @classmethod
     def get_port(cls):
         return cls.port
 
+    @classmethod
+    def __del__(cls):
+        cls.terminate()
+
+    @classmethod
+    def terminate(cls):
+        # if cls.is_ready
+        cls.manager.stop()
+
+    @classmethod
+    def register(cls, app: str, handler):
+        """
+        Register a new notification handler
+
+        :param      app:           The application
+        :type       app:           str
+        :param      handler:       The handler
+        :type       handler:       { type_description }
+
+        :rtype:     None
+
+        :raises     RuntimeError:  { exception_description }
+        """
+        if app in cls.handlers:
+            raise RuntimeError(f"Handler already registered with notification listerner for app {app}")
+
+        cls.handlers[app] = handler
+
+    @classmethod
+    def unregister(cls, app: str):
+        """
+        De-register a notification handler
+
+        Args:
+            app (str): application name
+
+        """
+        if not app in cls.handlers:
+            return RuntimeError(f"No handler registered for app {app}")
+        del cls.handlers[app]
+
+    @classmethod
+    def notify(cls, reply: dict):
+        if 'appname' not in reply:
+            raise RuntimeError(f"No 'appname' field in reply {reply}")
+
+        app = reply["appname"]
+
+        if not app in cls.handlers:
+            cls.log.warning(f"Received notification for unregistered app '{app}'")
+            return
+
+        cls.handlers[app].notify(reply)
+
+class ResponseTimeout(Exception):
+    pass
+class NoResponse(Exception):
+    pass
+
+class AppCommander:
+
+    def __init__(
+            self,
+            app_name: str,
+            app_host: str,
+            app_port: int,
+            response_host: str,
+            response_port: int,
+            proxy_host:str=None,
+            proxy_port:int=None,
+            ):
+
+        self.app_host = app_host
+        self.app_port = app_port
+        self.response_host = response_host
+        self.response_port = response_port
+        self.proxy_host = proxy_host
+        self.proxy_port = proxy_port
+
+        from logging import getLogger
+        self.app = app_name
+        self.log = getLogger(f'{self.app}-commander')
+        self.app_url = f"http://{self.app_host}:{self.app_port}/command"
+
+        from queue import Queue
+        self.response_queue = Queue()
+        self.sent_cmd = None
+
+    def notify(self, response):
+        self.response_queue.put(response)
+
+    def ping(self):
+        self.log.debug(f'Pinging \'{self.app}\'')
+        if self.proxy_host and self.proxy_port:
+            self.log.debug(f'Proxy: \'{self.proxy_host}:{self.proxy_port}\'')
+        self.log.debug(f'App: \'{self.app_host}:{self.app_port}\'')
+
+        import socket, socks
+
+        if not self.proxy_host and not self.proxy_port:
+            self.log.debug(f'NO proxy setup')
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(1)
+        else:
+            self.log.debug(f'Proxy setup')
+            s = socks.socksocket(socket.AF_INET, socket.SOCK_STREAM)
+            s.set_proxy(socks.SOCKS5, self.proxy_host, self.proxy_port)
+            s.settimeout(1)
+        try:
+            s.connect((self.app_host, self.app_port))
+            s.shutdown(2)
+            self.log.debug(f'\'{self.app}\' pings')
+            return True
+        except Exception as e:
+            self.log.debug(f'\'{self.app}\' does not ping, reason: \'{str(e)}\'')
+            return False
+
+    def send_command(
+            self,
+            cmd_id: str,
+            cmd_data: dict,
+            entry_state="ANY",
+            exit_state="ANY"):
+        # here we go again...
+        module_data = {
+            "modules": [
+                {
+                    "data": cmd_data,
+                    "match": ""
+                }
+            ]
+        }
+
+        cmd = {
+            "id": cmd_id,
+            "data": module_data,
+            "entry_state": entry_state,
+            "exit_state": exit_state,
+        }
+        import json
+        self.log.debug(json.dumps(cmd, sort_keys=True, indent=2))
+
+        headers = {
+            "content-type": "application/json",
+            "X-Answer-Port": str(self.response_port),
+        }
+        if not self.response_host is None:
+            headers['X-Answer-Host'] = self.response_host
+
+        self.log.debug(headers)
+        import requests
+        ack = requests.post(
+            self.app_url,
+            data=json.dumps(cmd),
+            headers=headers,
+            timeout=1.,
+            proxies={
+                'http': f'socks5h://{self.response_host}:{self.response_port}',
+                'https': f'socks5h://{self.response_host}:{self.response_port}'
+            } if self.proxy_host else None
+        )
+
+        self.log.debug(f"Ack to {self.app}: {ack.status_code}")
+        self.sent_cmd = cmd_id
+
+
+    def check_response(self, timeout:int=0) -> dict:
+        """Check if a response is present in the queue
+
+        Args:
+            timeout (int, optional): Timeout in seconds
+
+        Returns:
+            dict: Command response is json
+
+        Raises:
+            NoResponse: Description
+            ResponseTimeout: Description
+        """
+        import queue
+        try:
+            # self.log.info(f"Checking for answers from {self.app} {self.sent_cmd}")
+            r = self.response_queue.get(block=(timeout>0), timeout=timeout)
+            self.log.debug(f"Received reply from {self.app} to {self.sent_cmd}")
+            self.sent_cmd = None
+
+        except queue.Empty:
+            if not timeout:
+                raise NoResponse(f"No response available from {self.app} for command {self.sent_cmd}")
+            else:
+                self.log.error(f"Timeout while waiting for a reply from {self.app} for command {self.sent_cmd}")
+                raise ResponseTimeout(
+                    f"Timeout while waiting for a reply from {self.app} for command {self.sent_cmd}"
+                )
+
+        return r
+
+
+'''
+This is a very simple FSM, because it doesn't exist on the server side (appfwk),
+and hence cannot be figured from there
+'''
+class StateRESTAPI:
+
+    def __init__(self, initial_state='initial'):
+        # We'll wrap all these in a mutex for good measure
+        from threading import Lock
+        self._state_lock = Lock()
+        self._executing_command = False
+        self._assumed_operational_state = initial_state
+        self._included = True
+        self._errored = False
+
+
+    def executing_command_mark(self):
+        with self._state_lock:
+            self._executing_command = True
+
+    def end_command_execution_mark(self):
+        with self._state_lock:
+            self._executing_command = False
+
+    def new_operational_state(self, new_state):
+        with self._state_lock:
+            self._assumed_operational_state = new_state
+
+    def get_operational_state(self):
+        with self._state_lock:
+            return self._assumed_operational_state
+
+    def get_executing_command(self):
+        with self._state_lock:
+            return self._executing_command
+
+    def include(self):
+        with self._state_lock:
+            self._included = True
+
+    def exclude(self):
+        with self._state_lock:
+            self._included = False
+
+    def included(self):
+        with self._state_lock:
+            return self._included
+
+    def excluded(self):
+        with self._state_lock:
+            return not self._included
+
+    def to_error(self):
+        with self._state_lock:
+            self._errored = True
+
+    def fix_error(self):
+        with self._state_lock:
+            self._errored = False
+
+    def in_error(self):
+        with self._state_lock:
+            return self._errored
+
+
 class RESTAPIChildNode(ChildNode):
-    def __init__(self, child_conf, **kwargs):
+    def __init__(self, name, child_conf, conf_type, fsm_conf, **kwargs):
         super(RESTAPIChildNode, self).__init__(
+            name = name,
             **kwargs
         )
-        self.address = child_conf['address']
+
+        from logging import getLogger
+        self.log = getLogger(f'{name}-rest-api-child')
+
+        from drunc.utils.conf_types import ConfTypes, ConfTypeNotSupported
+        if conf_type != ConfTypes.Json:
+            raise ConfTypeNotSupported(conf_type, 'RESTAPIChildNode')
+
         self.response_listener = ResponseListener.get()
-        self.proxy = child_conf.get('proxy')
+
+        import socket
+        response_listener_host = socket.gethostname()
+
+        app_host, app_port = child_conf['uri'].split(":")
+        app_port = int(app_port)
+
+        proxy_host, proxy_port = child_conf.get('proxy', [None, None])
+        proxy_port = int(proxy_port) if proxy_port is not None else None
+
+        self.commander = AppCommander(
+            app_name = self.name,
+            app_host = app_host,
+            app_port = app_port,
+            response_host = response_listener_host,
+            response_port = self.response_listener.get_port(),
+            proxy_host = proxy_host,
+            proxy_port = proxy_port,
+        )
+
+        from drunc.fsm.fsm_core import FSM
+        self.fsm = FSM(
+            conf = fsm_conf,
+            conf_type=ConfTypes.Json
+        )
+
+        self.response_listener.register(self.name, self.commander)
+
+        self.state = StateRESTAPI()
 
     def close(self):
         pass
 
+    def get_status(self, token):
+        from druncschema.controller_pb2 import Status
 
-    def propagate_command(self, command, data, token):
-        headers = {
-            "content-type": "application/json",
-            "X-Answer-Port": str(ResponseListener.get().get_port()),
-        }
-
-
-        import requests, json
-
-        ack = requests.post(
-            self.address,
-            data=json.dumps(command),
-            headers=headers,
-            timeout=1.,
-            proxies={
-                'http': f'socks5h://{self.proxy}',
-                'https': f'socks5h://{self.proxy}'
-            } if self.proxy else None
+        return Status(
+            name = self.name,
+            state = self.state.get_operational_state(),
+            sub_state = 'idle' if not self.state.get_executing_command() else 'executing_cmd',
+            in_error = self.state.in_error() or not self.commander.ping(), # meh
+            included = self.state.included(),
         )
 
+    def propagate_command(self, command, data, token):
 
+        if command == 'exclude':
+            self.state.exclude()
+        elif command == 'include':
+            self.state.include()
+
+        if self.state.excluded():
+            return
+
+        # here lies the mother of all the problems
+        if command != 'execute_fsm_command':
+            self.log.info(f'Ignoring command \'{command}\' sent to \'{self.name}\'')
+            return None
+
+        self.log.info(f'Sending \'{command}\' to \'{self.name}\'')
+
+        # from drunc.utils.grpc_utils import unpack_any
+        # from druncschema.controller_pb2 import FSMCommand
+        # fsm_command = unpack_any(data, FSMCommand)
+        from druncschema.controller_pb2 import FSMCommandResponseCode
+
+        entry_state = self.state.get_operational_state()
+        transition = self.fsm.get_transition(data.command_name)
+        exit_state = self.fsm.get_destination_state(entry_state, transition)
+        self.state.executing_command_mark()
+        import json
+        try:
+            self.commander.send_command(
+                cmd_id = data.command_name,
+                cmd_data = json.loads(data.data),
+                entry_state = entry_state.upper(),
+                exit_state = exit_state.upper(),
+            )
+            r = self.commander.check_response(10)
+            if not r['success']:
+                self.log.error(r['result'])
+                self.state.to_error()
+                return FSMCommandResponseCode.UNSUCCESSFUL
+        except Exception as e:
+            self.log.error(str(e))
+            self.state.to_error()
+            return FSMCommandResponseCode.UNSUCCESSFUL
+        self.state.end_command_execution_mark()
+        self.state.new_operational_state(exit_state)
+        return FSMCommandResponseCode.SUCCESSFUL

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -80,16 +80,34 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
             token = 'broadcast_token' # massive hack here, controller should use user token to execute command, and have a "broadcasted to" token
         )
 
-        for child_controller_cfg in self.configuration.get('children_controllers', []):
-            self.children_nodes.append(
-                ChildNode.get_from_file(
-                        child_controller_cfg['name'],
-                        child_controller_cfg
-                    )
-                )
 
-        for app_cfg in self.configuration.get('applications', []):
-            self.children_nodes.append(ChildNode.get_from_file(app_cfg))
+        from copy import deepcopy as dc
+        fsm_conf = dc(self.configuration.data['statefulnode']['fsm'])
+        fsm_conf.update({
+            "interfaces": {},
+            "pre_transitions": {},
+            "post_transitions": {},
+        })
+
+        for child in self.configuration.get('children', []):
+            if child['type'] == 'rest-api': # already some hacking
+                self.children_nodes.append(
+                    ChildNode.get_from_file(
+                            name = child['name'],
+                            conf = child,
+                            fsm_conf = fsm_conf
+                        )
+                    )
+            else:
+                self.children_nodes.append(
+                    ChildNode.get_from_file(
+                            name = child['name'],
+                            conf = child,
+                        )
+                    )
+
+        # for app_cfg in self.configuration.get('applications', []):
+        #     self.children_nodes.append(ChildNode.get_from_file(app_cfg))
 
         from druncschema.request_response_pb2 import CommandDescription
         # TODO, probably need to think of a better way to do this?
@@ -191,6 +209,10 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
             self.logger.debug(f'Stopping {child.name}')
             child.terminate()
 
+        from drunc.controller.children_interface.rest_api_child import ResponseListener
+
+        if ResponseListener.exists():
+            ResponseListener.get().terminate()
 
     def propagate_to_list(self, command:str, data, token, node_to_execute):
 
@@ -198,7 +220,7 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
             btype = BroadcastType.COMMAND_EXECUTION_START,
             message = f'Propagating {command} to children',
         )
-
+        return_statuses = {}
         def propagate_to_child(child, command, data, token):
 
             self.broadcast(
@@ -207,15 +229,17 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
             )
 
             try:
-                child.propagate_command(command, data, token)
+                return_statuses[child.name] = child.propagate_command(command, data, token)
                 self.broadcast(
                     btype = BroadcastType.CHILD_COMMAND_EXECUTION_SUCCESS,
                     message = f'Propagating {command} to children ({child.name})',
                 )
-            except:
+            except Exception as e:
+                from druncschema.controller_pb2 import FSMCommandResponseCode
+                return_statuses[child.name] = FSMCommandResponseCode.UNSUCCESSFUL
                 self.broadcast(
                     btype = BroadcastType.CHILD_COMMAND_EXECUTION_FAILED,
-                    message = f'Failed to propagate {command} to {child.name} ({child.name})',
+                    message = f'Failed to propagate {command} to {child.name} ({child.name}): {str(e)}',
                 )
 
         threads = []
@@ -227,7 +251,7 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
 
         for thread in threads:
             thread.join()
-
+        return return_statuses
 
     def _should_execute_on_self(self, node_path) -> bool:
         if node_path == []:
@@ -331,7 +355,7 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
 
 
         self.logger.debug(f'{command} data: {fsm_command}')
-
+        child_statuses = {}
         try:
 
             fsm_args = self.decode_fsm_arguments(fsm_command)
@@ -348,10 +372,12 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
             children_fsm_command.CopyFrom(fsm_command)
             children_fsm_command.data = fsm_data
             children_fsm_command.ClearField("children_nodes") # we strip the children node, since when we feed them to the children they are meaningless
-            if fsm_command.HasField('children_nodes'):
-                self.propagate_to_list(command, children_fsm_command, request.token, fsm_command.children_nodes)
+            execute_on = fsm_command.children_nodes
+
+            if execute_on:
+                child_statuses = self.propagate_to_list(command, children_fsm_command, request.token, execute_on)
             else:
-                self.propagate_to_list(command, children_fsm_command, request.token, self.children_nodes)
+                child_statuses = self.propagate_to_list(command, children_fsm_command, request.token, self.children_nodes)
 
             self.finish_propagating_transition_mark(transition)
 
@@ -386,6 +412,7 @@ class Controller(StatefulNode, ControllerServicer, BroadcastSender):
         result = FSMCommandResponse(
             successful = FSMCommandResponseCode.SUCCESSFUL,
             command_name = fsm_command.command_name,
+            children_successful = child_statuses,
         )
 
         result_any = pack_to_any(result)

--- a/src/drunc/fsm/fsm_core.py
+++ b/src/drunc/fsm/fsm_core.py
@@ -115,7 +115,7 @@ class PreOrPostTransitionSequence:
                 default_value = ''
 
                 t = Argument.Type.INT
-                from druncschema.generic_pb2 import string_msg, float_msg, int_msg
+                from druncschema.generic_pb2 import string_msg, float_msg, int_msg, bool_msg
                 from drunc.utils.grpc_utils import pack_to_any
 
                 if p.annotation is str:
@@ -135,6 +135,12 @@ class PreOrPostTransitionSequence:
 
                     if p.default != Parameter.empty:
                         default_value = pack_to_any(int_msg(value = p.default))
+
+                elif p.annotation is bool:
+                    t = Argument.Type.BOOL
+
+                    if p.default != Parameter.empty:
+                        default_value = pack_to_any(bool_msg(value = p.default))
                 else:
                     raise RuntimeError(f'Annotation {p.annotation} is not handled.')
 
@@ -242,8 +248,8 @@ class JsonFSMConfigParser(FSMConfigParser):
                 else:
                     self.post_transitions[transition] = seq
 
-        for transition in self.transitions:
-            print(transition.name, transition.arguments, self.pre_transitions[transition], self.post_transitions[transition])
+        # for transition in self.transitions:
+        #     print(transition.name, transition.arguments, self.pre_transitions[transition], self.post_transitions[transition])
 
     def _parse_transitions(self, transitions):
         trs = [

--- a/src/drunc/fsm/interfaces/UserProvidedRunNumber.py
+++ b/src/drunc/fsm/interfaces/UserProvidedRunNumber.py
@@ -6,6 +6,8 @@ class UserProvidedRunNumber(FSMInterface):
             name = "run-number"
         )
 
-    def post_start(self, _input_data:dict, run_number:int=1, **kwargs):
-        _input_data["run_num"] = run_number
+    def pre_start(self, _input_data:dict, run_number:int=1, disable_data_storage:bool=False, trigger_rate:float=1.0, **kwargs):
+        _input_data["run"] = run_number
+        _input_data['disable_data_storage'] = disable_data_storage
+        _input_data['trigger_rate'] = trigger_rate
         return _input_data

--- a/src/drunc/fsm/utils.py
+++ b/src/drunc/fsm/utils.py
@@ -17,7 +17,7 @@ def convert_fsm_transition(transitions):
 def decode_fsm_arguments(arguments, arguments_format):
     from drunc.utils.grpc_utils import unpack_any
     import drunc.fsm.fsm_errors as fsme
-    from druncschema.generic_pb2 import int_msg, float_msg, string_msg
+    from druncschema.generic_pb2 import int_msg, float_msg, string_msg, bool_msg
     from druncschema.controller_pb2 import Argument
 
     def get_argument(name, arguments):
@@ -44,6 +44,8 @@ def decode_fsm_arguments(arguments, arguments_format):
                 out_dict[arg.name] = unpack_any(arg_value, float_msg).value
             case Argument.Type.STRING:
                 out_dict[arg.name] = unpack_any(arg_value, string_msg).value
+            case Argument.Type.BOOL:
+                out_dict[arg.name] = unpack_any(arg_value, bool_msg).value
             case _:
                 raise RuntimeError(f'Unhandled argument type {arg.type}')
     import logging

--- a/src/drunc/process_manager/boot_json_parser.py
+++ b/src/drunc/process_manager/boot_json_parser.py
@@ -1,0 +1,153 @@
+def process_env(env, rte):
+    new_env = {}
+
+    exclude = [
+        "CET_PLUGIN_PATH",
+        "DUNEDAQ_SHARE_PATH",
+        "LD_LIBRARY_PATH",
+        "PYTHONPATH",
+        "PATH"
+    ] if rte else []
+
+    import os
+
+    for name, value in env.items():
+        if name in exclude:
+            continue
+        if type(value) is not str:
+            new_env[name] = str(value)
+            continue
+        if value.startswith('getenv'):
+            if name in os.environ:
+                value = os.environ[name]
+            else:
+                if value == 'getenv_ifset':
+                    continue
+                else:
+                    value = value.removeprefix('getenv')
+                    value = value.removeprefix(':')
+        new_env[name] = value
+
+    return new_env
+
+# def process_env(env):
+#     new_env = {}
+#     from copy import deepcopy
+#     e = deepcopy(env)
+#     for name, value in env.items():
+#         if type(value) is str:
+#             new_env[name] = value.format(**e)
+#         else:
+#             new_env[name] = str(value)
+#     return new_env
+
+
+def process_args(args, env):
+    new_args = []
+    for arg in args:
+        if type(arg) is str:
+            new_args += [arg.format(**env)]
+        else:
+            new_args += [arg]
+    return new_args
+
+
+def process_exec(name, data, env, exec, hosts, **kwargs):
+    from druncschema.process_manager_pb2 import BootRequest, ProcessDescription, ProcessRestriction
+
+    from logging import getLogger
+    _log = getLogger('process_exec')
+
+    app_exec = exec[data['exec']]
+    app_env = app_exec['env']
+    app_env.update(env)
+    app_env.update({
+        'APP_PORT': data['port'],
+        'APP_NAME': name,
+        'APP_HOST': hosts[name],
+    })
+
+    if 'session' in kwargs:
+        app_env['DUNEDAQ_PARTITION'] = kwargs['session']
+
+    if 'conf' in kwargs:
+        app_env['CONF_LOC'] = kwargs['conf']
+
+    if 'TRACE_FILE' in app_env:
+        app_env.update({
+            'TRACE_FILE': app_env['TRACE_FILE'].format(**app_env),
+        })
+    if 'CMD_FAC' in app_env:
+        app_env.update({
+            'CMD_FAC': app_env['CMD_FAC'].format(**app_env),
+        })
+
+    if 'INFO_SVC' in app_env:
+        app_env.update({
+            'INFO_SVC': app_env['INFO_SVC'].format(**app_env)
+        })
+
+    exec_and_args = []
+
+    rte_present = False
+    if 'rte' in kwargs:
+        exec_and_args += [ProcessDescription.ExecAndArgs(
+                exec = 'source',
+                args = [kwargs['rte']]
+        )]
+        rte_present = True
+
+    app_env = process_env(
+        env = app_env,
+        rte = rte_present
+    )
+    _log.debug(app_env)
+
+
+    exec_and_args += [ProcessDescription.ExecAndArgs(
+        exec = app_exec['cmd'],
+        args = process_args(app_exec['args'], app_env)
+    )]
+
+    pd = ProcessDescription(
+        executable_and_arguments = exec_and_args,
+        env = app_env
+    )
+
+    pr = ProcessRestriction(
+        allowed_hosts = [hosts[name]]
+    )
+
+    return BootRequest(
+        process_description = pd,
+        process_restriction = pr,
+    )
+
+
+def parse_configuration(input_dir, output_dir):
+    import os
+    os.mkdir(output_dir)
+
+    import json
+
+    boot_configuration = {}
+
+    with open(input_dir/'boot.json') as f:
+        boot_configuration = json.loads(f.read())
+
+    for filename in os.listdir(input_dir/'data'):
+        with open(input_dir/'data'/filename) as f:
+            data = json.loads(f.read())
+            if not 'connections' in data:
+                json.dump(data, open(output_dir/filename,'w'))
+                continue
+
+            new_connections = []
+            for c in data['connections']:
+                nc = c
+                nc['uri'] = nc['uri'].format(**boot_configuration['hosts-data'])
+                new_connections += [nc]
+            data['connections'] = new_connections
+
+            json.dump(data, open(output_dir/filename,'w'))
+

--- a/src/drunc/process_manager/boot_json_parser.py
+++ b/src/drunc/process_manager/boot_json_parser.py
@@ -1,3 +1,5 @@
+
+
 def process_env(env, rte):
     new_env = {}
 
@@ -30,17 +32,6 @@ def process_env(env, rte):
 
     return new_env
 
-# def process_env(env):
-#     new_env = {}
-#     from copy import deepcopy
-#     e = deepcopy(env)
-#     for name, value in env.items():
-#         if type(value) is str:
-#             new_env[name] = value.format(**e)
-#         else:
-#             new_env[name] = str(value)
-#     return new_env
-
 
 def process_args(args, env):
     new_args = []
@@ -57,7 +48,8 @@ def process_exec(name, data, env, exec, hosts, **kwargs):
 
     from logging import getLogger
     _log = getLogger('process_exec')
-
+    from copy import deepcopy as dc
+    exec = dc(exec)
     app_exec = exec[data['exec']]
     app_env = app_exec['env']
     app_env.update(env)
@@ -149,5 +141,5 @@ def parse_configuration(input_dir, output_dir):
                 new_connections += [nc]
             data['connections'] = new_connections
 
-            json.dump(data, open(output_dir/filename,'w'))
+            json.dump(data, open(output_dir/filename,'w'), indent=4)
 

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -68,7 +68,7 @@ def update_log_level(loglevel):
 
     logging.basicConfig(
         level=log_level,
-        format="%(message)s",
+        format="\"%(name)s\": %(message)s",
         datefmt="[%X]",
         handlers=[
             #logging.StreamHandler(),


### PR DESCRIPTION
We'll start with the good bits:
 - `drunc-process-manager` is now able to understand `boot.json`. What it does is adding _on the fly_ a controller on top of it to control all the applications it started.
 - I used Python's `requests` module to send `POST` commands to `daq_application`, very similar to `nanorc`, one notable difference is that I use a Gunicorn server for the `ResponseListener`, and the singleton pattern for it. The response listener's port is automatically found by the OS and passed on to the applications.
 - All commands are sent asynchronously rather than in a sequence, this is the same as in any recent version of `nanorc`.
 - A report of command execution is sent back to the client, it contains the command execution status for each direct descendent of the controller that executed the command.
 - I fixed the run start FSM interface to ask it to provide the usual-suspect arguments (`run-number`, `disable-data-storage` and `trigger-rate`), and format it correctly for `daq_application` to start. Along the way, I needed to introduce a generic boolean protobuf message and argument type. This was an oversight from previously.

Improvements on the side:
 - Log messages now contain a bit more information with the logger name (this is very handy, especially in combination with the next line).
 - One can pass `--grep` to the `logs` command on the process manager to filter specific patterns in the logs.
 - One can pass the `--log-level` to the `boot` command so that controllers started by the process manager have the desired amount of logs.

Things that are not nice:
 - The FSM is affixed to the REST-API-child. `appfwk` doesn't know anything about FSM, or its status, so we are essentially "flying blind" as far as the run control is aware. The only things that the run control (`drunc` or `nanorc`) knows are the general FSM (that it created itself), and whether the commands were successful. This enables it to _infer_ the FSM but really the `appfwk` should know about its `FSM` and add some status `GET` routes to query its state.
 - Well, we use a REST-API, we should at least try adding gRPC hooks into `appfwk`.
 - The controller configuration started by the process manager is **static and hardcoded**.  I suppose with a bit more time, I should have added this to `daqconf`.