### PR TITLE
Set Kafka groups

### DIFF
--- a/src/drunc/broadcast/client/kafka_stdout_broadcast_handler.py
+++ b/src/drunc/broadcast/client/kafka_stdout_broadcast_handler.py
@@ -26,11 +26,15 @@ class KafkaStdoutBroadcastHandler(BroadcastHandlerImplementation):
         import logging
         self._log = logging.getLogger(f'{self.topic} message')
 
+        from drunc.utils.utils import get_random_string, now_str
+        import getpass
+        group_id = f'kafka-stdout-broadcasthandler-{getpass.getuser()}-{now_str(True)}'
         from kafka import KafkaConsumer
         self.consumer = KafkaConsumer(
             self.topic,
             client_id = 'run_control',
             bootstrap_servers = [self.kafka_address],
+            group_id = group_id,
             #value_deserializer = lambda m: self.message_format().ParseFromString(m)
         )
 

--- a/src/drunc/broadcast/client/kafka_stdout_broadcast_handler.py
+++ b/src/drunc/broadcast/client/kafka_stdout_broadcast_handler.py
@@ -26,16 +26,16 @@ class KafkaStdoutBroadcastHandler(BroadcastHandlerImplementation):
         import logging
         self._log = logging.getLogger(f'{self.topic} message')
 
-        from drunc.utils.utils import get_random_string, now_str
+        from drunc.utils.utils import now_str, get_random_string
         import getpass
-        group_id = f'kafka-stdout-broadcasthandler-{getpass.getuser()}-{now_str(True)}'
+        group_id = f'drunc-stdout-broadcasthandler-{getpass.getuser()}-{now_str(True)}-{get_random_string(5)}'
+
         from kafka import KafkaConsumer
         self.consumer = KafkaConsumer(
             self.topic,
             client_id = 'run_control',
             bootstrap_servers = [self.kafka_address],
             group_id = group_id,
-            #value_deserializer = lambda m: self.message_format().ParseFromString(m)
         )
 
         self.run = True

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -17,15 +17,17 @@ from google.protobuf.any_pb2 import Any
 
 class ProcessManager(abc.ABC, ProcessManagerServicer, BroadcastSender):
 
-    def __init__(self, pm_conf, name, **kwargs):
+    def __init__(self, pm_conf, name, session=None, **kwargs):
+
         super(ProcessManager, self).__init__(
             name = name,
             broadcast_configuration = pm_conf['broadcaster'],
+            session = session,
             **kwargs
         )
-        self.name = name
-        self.session = None
 
+        self.name = name
+        self.session = session
         from logging import getLogger
         self.log = getLogger("process_manager")
         # ProcessManagerServicer.__init__(self)
@@ -301,7 +303,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer, BroadcastSender):
         return Description(
             type = 'process_manager',
             name = self.name,
-            session = 'no_session',
+            session = 'no_session' if not self.session else self.session,
             commands = self.commands,
             broadcast = pack_to_any(self.describe_broadcast()),
         )

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -58,8 +58,13 @@ class AppProcessWatcherThread(threading.Thread):
 
 class SSHProcessManager(ProcessManager):
     def __init__(self, pm_conf, **kwargs):
+
+        import getpass
+        self.session = getpass.getuser() # unfortunate
+
         super(SSHProcessManager, self).__init__(
             pm_conf = pm_conf,
+            session = self.session,
             **kwargs
         )
 

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -16,6 +16,11 @@ log_levels = {
     'NOTSET'  : logging.NOTSET,
 }
 
+def get_random_string(length):
+    import random
+    import string
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for i in range(length))
 
 def regex_match(regex, string):
     import re


### PR DESCRIPTION
Add the session (identical to username) in the ssh process manager. Bad but otherwise we'll get Kafka message stumping over each other. Anyway, everybody needs to have their own process manager for ssh.

Add a descriptive groupid for the consumer (timestamped, user-aware and which roughly shows what is consuming).