### PR TITLE
Start the ProcessManager in the unified shell

### DIFF
--- a/data/process-manager.json
+++ b/data/process-manager.json
@@ -1,7 +1,7 @@
 {
     "type": "ssh",
     "name": "SSHProcessManager",
-    "command_address": "localhost:10054",
+    "command_address": "localhost:0",
 
     "authoriser": {
         "type": "dummy"

--- a/data/process-manager.json
+++ b/data/process-manager.json
@@ -1,7 +1,7 @@
 {
     "type": "ssh",
     "name": "SSHProcessManager",
-    "command_address": "0.0.0.0:10054",
+    "command_address": "localhost:10054",
 
     "authoriser": {
         "type": "dummy"

--- a/src/drunc/apps/__main_unified_shell__.py
+++ b/src/drunc/apps/__main_unified_shell__.py
@@ -16,6 +16,10 @@ def main():
         else:
             rprint(f'[yellow]{e}[/]\nUse [blue]--traceback[/] for more information')
         rprint(f'Exiting...')
+
+        if context.pm_process and context.pm_process.is_alive():
+            context.pm_process.kill() # We're in an exception handler, so we are not going to do it half-heartedly, send a good ol' SIGKILL
+
         exit(1)
 
 

--- a/src/drunc/process_manager/interface/process_manager.py
+++ b/src/drunc/process_manager/interface/process_manager.py
@@ -7,7 +7,7 @@ from drunc.utils.utils import log_levels
 
 _cleanup_coroutines = []
 
-def run_pm(pm_conf, log_level, ready_event=None, signal_handler=None):
+def run_pm(pm_conf, log_level, ready_event=None, signal_handler=None, generated_port=None):
     if signal_handler is not None:
         signal_handler()
 
@@ -46,6 +46,8 @@ def run_pm(pm_conf, log_level, ready_event=None, signal_handler=None):
         server = grpc.aio.server()
         add_ProcessManagerServicer_to_server(pm, server)
         port = server.add_insecure_port(address)
+        if generated_port is not None:
+            generated_port.value = port
 
         await server.start()
         import socket

--- a/src/drunc/process_manager/interface/process_manager.py
+++ b/src/drunc/process_manager/interface/process_manager.py
@@ -11,6 +11,9 @@ def run_pm(pm_conf, log_level, ready_event=None, signal_handler=None):
     if signal_handler is not None:
         signal_handler()
 
+    from drunc.utils.utils import parent_death_pact
+    parent_death_pact() # If the parent dies (for example unified shell), we die too
+
     from rich.console import Console
     console = Console()
     console.print(f'Using \'{pm_conf}\' as the ProcessManager configuration')

--- a/src/drunc/process_manager/interface/process_manager.py
+++ b/src/drunc/process_manager/interface/process_manager.py
@@ -7,7 +7,10 @@ from drunc.utils.utils import log_levels
 
 _cleanup_coroutines = []
 
-def run_pm(pm_conf, log_level, ready_event=None):
+def run_pm(pm_conf, log_level, ready_event=None, signal_handler=None):
+    if signal_handler is not None:
+        signal_handler()
+
     from rich.console import Console
     console = Console()
     console.print(f'Using \'{pm_conf}\' as the ProcessManager configuration')
@@ -56,6 +59,7 @@ def run_pm(pm_conf, log_level, ready_event=None):
         _cleanup_coroutines.append(server_shutdown())
         if ready_event is not None:
             ready_event.set()
+
         await server.wait_for_termination()
 
 

--- a/src/drunc/process_manager/interface/process_manager.py
+++ b/src/drunc/process_manager/interface/process_manager.py
@@ -45,11 +45,13 @@ def run_pm(pm_conf, log_level, ready_event=None, signal_handler=None):
 
         server = grpc.aio.server()
         add_ProcessManagerServicer_to_server(pm, server)
-        server.add_insecure_port(address)
+        port = server.add_insecure_port(address)
 
         await server.start()
+        import socket
+        hostname = socket.gethostname()
+        console.print(f'ProcessManager was started on {hostname}:{port}')
 
-        console.print(f'ProcessManager was started on {address}')
 
         async def server_shutdown():
             console.print("Starting shutdown...")

--- a/src/drunc/unified_shell/commands.py
+++ b/src/drunc/unified_shell/commands.py
@@ -3,26 +3,23 @@ import getpass
 
 from drunc.utils.shell_utils import add_traceback_flag
 from drunc.utils.utils import run_coroutine, log_levels
-from drunc.process_manager.interface.cli_argument import accept_configuration_type
 from drunc.process_manager.interface.context import ProcessManagerContext
 from drunc.process_manager.interface.cli_argument import validate_conf_string
 
 @click.command('boot')
 @click.option('-u','--user', type=str, default=getpass.getuser(), help='Select the process of a particular user (default $USER)')
 @click.option('-l', '--log-level', type=click.Choice(log_levels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
-@accept_configuration_type()
 @add_traceback_flag()
 @click.argument('boot-configuration', type=str, callback=validate_conf_string)
 @click.argument('session-name', type=str)
 @click.pass_obj
 @run_coroutine
-async def boot(obj:ProcessManagerContext, user:str, conf_type:str, session_name:str, boot_configuration:str, log_level:str, traceback:bool) -> None:
+async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_configuration:str, log_level:str, traceback:bool) -> None:
 
     from drunc.utils.shell_utils import InterruptedCommand
     try:
         results = obj.get_driver('process_manager').boot(
             conf = boot_configuration,
-            conf_type = conf_type,
             user = user,
             session_name = session_name,
             log_level = log_level,

--- a/src/drunc/unified_shell/context.py
+++ b/src/drunc/unified_shell/context.py
@@ -6,6 +6,7 @@ class UnifiedShellContext(ShellContext): # boilerplatefest
     status_receiver_pm = None
     status_receiver_controller = None
     took_control = False
+    pm_process = None
     address_pm = ''
     address_controller = ''
 

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -3,15 +3,46 @@ import click_shell
 from drunc.utils.utils import log_levels
 import os
 from drunc.utils.utils import validate_command_facility
+import pathlib
 
 @click_shell.shell(prompt='drunc-unified-shell > ', chain=True, hist_file=os.path.expanduser('~')+'/.drunc-unified-shell.history')
 @click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--log-level', type=click.Choice(log_levels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
-@click.argument('process-manager-address', type=str, callback=validate_command_facility)
+@click.argument('process-manager-configuration', type=str)# callback=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path, resolve_path=True))
 @click.pass_context
-def unified_shell(ctx, process_manager_address:str, log_level:str, traceback:bool) -> None:
-    from drunc.utils.utils import update_log_level
+def unified_shell(ctx, process_manager_configuration:str, log_level:str, traceback:bool) -> None:
+    ctx.obj.print_traceback = traceback,
+
+    from drunc.utils.utils import update_log_level, pid_info_str
     update_log_level(log_level)
+    from logging import getLogger
+    logger = getLogger('unified_shell')
+    logger.debug(pid_info_str())
+
+    from drunc.process_manager.interface.process_manager import run_pm
+    import multiprocessing as mp
+    ready_event = mp.Event()
+    pm_proc = mp.Process(
+        target = run_pm,
+        kwargs = {
+            "pm_conf": process_manager_configuration,
+            "log_level": log_level,
+            "ready_event": ready_event,
+        }
+    )
+    ctx.obj.print(f'Starting process manager with configuration {process_manager_configuration}')
+    pm_proc.start()
+
+    for _ in range(100):
+        if ready_event.is_set():
+            break
+        from time import sleep
+        sleep(0.1)
+
+    from drunc.utils.configuration import parse_conf_url
+    conf_path, conf_type = parse_conf_url(process_manager_configuration)
+    import json
+    process_manager_address = json.load(open(conf_path, 'r'))['command_address']
 
     ctx.obj.reset(
         print_traceback = traceback,
@@ -19,6 +50,7 @@ def unified_shell(ctx, process_manager_address:str, log_level:str, traceback:boo
     )
 
     from drunc.utils.grpc_utils import ServerUnreachable
+    desc = None
 
     try:
         import asyncio
@@ -27,6 +59,8 @@ def unified_shell(ctx, process_manager_address:str, log_level:str, traceback:boo
         )
     except ServerUnreachable as e:
         ctx.obj.critical(f'Could not connect to the process manager')
+        if not pm_proc.is_alive():
+            ctx.obj.critical(f'The process manager is dead, exit code {pm_proc.exitcode}')
         raise e
 
     ctx.obj.info(f'{process_manager_address} is \'{desc.name}.{desc.session}\' (name.session), starting listening...')
@@ -37,6 +71,8 @@ def unified_shell(ctx, process_manager_address:str, log_level:str, traceback:boo
 
     def cleanup():
         ctx.obj.terminate()
+        pm_proc.terminate()
+        pm_proc.join()
 
     ctx.call_on_close(cleanup)
 

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -29,10 +29,12 @@ def unified_shell(ctx, process_manager_configuration:str, log_level:str, traceba
             "log_level": log_level,
             "ready_event": ready_event,
             "signal_handler": ignore_sigint_sighandler,
-        }
+            # sigint gets sent to the PM, so we need to ignore it, otherwise everytime the user ctrl-c on the shell, the PM goes down
+        },
     )
     ctx.obj.print(f'Starting process manager with configuration {process_manager_configuration}')
     ctx.obj.pm_process.start()
+
 
     from time import sleep
     for _ in range(100):

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -46,6 +46,7 @@ def unified_shell(ctx, process_manager_configuration:str, log_level:str, traceba
         sleep(0.1)
 
     if not ready_event.is_set():
+        from drunc.exceptions import DruncSetupException
         raise DruncSetupException('Process manager did not start in time')
 
     import socket

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -132,3 +132,11 @@ def validate_command_facility(ctx, param, value):
         case _:
             raise BadParameter(message=f'Command factory for drunc-controller only allows \'grpc\'', ctx=ctx, param=param)
 
+
+
+
+
+def pid_info_str():
+    import os
+    return f'Parent\'s PID: {os.getppid()} | This PID: {os.getpid()}'
+

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -140,3 +140,9 @@ def pid_info_str():
     import os
     return f'Parent\'s PID: {os.getppid()} | This PID: {os.getpid()}'
 
+def noop(*args, **kwargs):
+    pass
+
+def ignore_sigint_sighandler():
+    import signal
+    signal.signal(signal.SIGINT, noop)


### PR DESCRIPTION
With this PR, one doesn't need to have 2 terminal windows open simultaneously to start the `drunc-unified-shell`, as the shell directly starts the process manager in a `multiprocess.Process`. To get this to work correctly, there is quite a bit of bookkeeping of the signal that needs to happen (not that on Linux the `multiprocess.Process` are forks):

1. I tied the Process Manager's fate to the drunc-unified-shell's main thread by using the code [here](https://gist.github.com/qxcv/fe5be4d14f855fedf7a5db723aad22c2). This uses magic incantations I don't fully understand, but it works correctly (and is close to a snippet at the top of `nanorc`'s SSHPM), and sends `SIGKILL` to the forked process when the main gets one.
2. When an exception gets thrown in the drunc-unified-shell's main, I SIGKILL the forked process, if it exists.
3. When the main gets a `SIGINT` (for example, `ctrl-c` from a user in the shell), this signal gets propagated to the forked process, so the fork needs to catch and ignore that signal in the case it runs with the unified shell.

That's all folks!
