### PR TITLE
Back propagate FSM errors

### DIFF
--- a/src/drunc/authoriser/decorators.py
+++ b/src/drunc/authoriser/decorators.py
@@ -15,19 +15,20 @@ def authentified_and_authorised(action, system):
             if not obj.authoriser.is_authorised(request.token, action, system, cmd.__name__):
                 from drunc.authoriser.exceptions import Unauthorised
                 return Response(
+                    name = obj.name,
                     token = request.token,
                     data = PlainText(
-                        text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.__class__.__name__} (action type is {action}, system is {system})"
+                        text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.name} (action type is {action}, system is {system})"
                     ),
-                    response_flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
-                    children_responses = {}
+                    flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
+                    responses = []
                 )
 
                 # raise Unauthorised(
                 #     user = request.token.user_name,
                 #     action = action,
                 #     command = cmd.__name__,
-                #     drunc_system = obj.__class__.__name__,
+                #     drunc_system = obj.name,
                 # )
             log.debug('Executing wrapped function')
             ret = cmd(obj, request)
@@ -50,12 +51,13 @@ def async_authentified_and_authorised(action, system):
             log.debug('Entering')
             if not obj.authoriser.is_authorised(request.token, action, system, cmd.__name__):
                 yield Response(
+                    name = obj.name,
                     token = request.token,
                     data = PlainText(
-                        text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.__class__.__name__} (action type is {action}, system is {system})"
+                        text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.name} (action type is {action}, system is {system})"
                     ),
-                    response_flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
-                    response_children = {}
+                    flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
+                    children = []
                 )
             log.debug('Executing wrapped function')
             async for a in cmd(obj, request):

--- a/src/drunc/authoriser/decorators.py
+++ b/src/drunc/authoriser/decorators.py
@@ -19,7 +19,7 @@ def authentified_and_authorised(action, system):
                     data = PlainText(
                         text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.__class__.__name__} (action type is {action}, system is {system})"
                     ),
-                    flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
+                    response_flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
                     children_responses = {}
                 )
 
@@ -54,8 +54,8 @@ def async_authentified_and_authorised(action, system):
                     data = PlainText(
                         text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.__class__.__name__} (action type is {action}, system is {system})"
                     ),
-                    flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
-                    children_responses = {}
+                    response_flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
+                    response_children = {}
                 )
             log.debug('Executing wrapped function')
             async for a in cmd(obj, request):

--- a/src/drunc/authoriser/decorators.py
+++ b/src/drunc/authoriser/decorators.py
@@ -1,4 +1,5 @@
-
+from druncschema.request_response_pb2 import Response, ResponseFlag
+from druncschema.generic_pb2 import PlainText
 
 def authentified_and_authorised(action, system):
 
@@ -13,12 +14,21 @@ def authentified_and_authorised(action, system):
             log.debug('Entering')
             if not obj.authoriser.is_authorised(request.token, action, system, cmd.__name__):
                 from drunc.authoriser.exceptions import Unauthorised
-                raise Unauthorised(
-                    user = request.token.user_name,
-                    action = action,
-                    command = cmd.__name__,
-                    drunc_system = obj.__class__.__name__,
+                return Response(
+                    token = request.token,
+                    data = PlainText(
+                        text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.__class__.__name__} (action type is {action}, system is {system})"
+                    ),
+                    flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
+                    children_responses = {}
                 )
+
+                # raise Unauthorised(
+                #     user = request.token.user_name,
+                #     action = action,
+                #     command = cmd.__name__,
+                #     drunc_system = obj.__class__.__name__,
+                # )
             log.debug('Executing wrapped function')
             ret = cmd(obj, request)
             log.debug('Exiting')
@@ -39,12 +49,13 @@ def async_authentified_and_authorised(action, system):
             log = getLogger('authentified_and_authorised_decorator')
             log.debug('Entering')
             if not obj.authoriser.is_authorised(request.token, action, system, cmd.__name__):
-                from drunc.authoriser.exceptions import Unauthorised
-                raise Unauthorised(
-                    user = request.token.user_name,
-                    action = action,
-                    command = cmd.__name__,
-                    drunc_system = obj.__class__.__name__,
+                yield Response(
+                    token = request.token,
+                    data = PlainText(
+                        text = f"User {request.token.user_name} is not authorised to execute {cmd.__name__} on {obj.__class__.__name__} (action type is {action}, system is {system})"
+                    ),
+                    flag = ResponseFlag.NOT_EXECUTED_NOT_AUTHORISED,
+                    children_responses = {}
                 )
             log.debug('Executing wrapped function')
             async for a in cmd(obj, request):

--- a/src/drunc/broadcast/server/decorators.py
+++ b/src/drunc/broadcast/server/decorators.py
@@ -1,6 +1,6 @@
 from druncschema.request_response_pb2 import Response, ResponseFlag
 from druncschema.generic_pb2 import Stacktrace
-
+from drunc.utils.grpc_utils import pack_to_any
 def broadcasted(cmd):
 
     import functools
@@ -35,11 +35,13 @@ def broadcasted(cmd):
 
             return Response(
                 token = request.token,
-                data = Stacktrace(
-                    text = [str(e)]
+                data = pack_to_any(
+                    Stacktrace(
+                        text = [str(e)]
+                    )
                 ),
-                flag = ResponseFlag.EXCEPTION_THROWN,
-                children_responses = {}
+                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
+                response_children = {}
             )
 
         except Exception as e:
@@ -51,11 +53,13 @@ def broadcasted(cmd):
             # )
             return Response(
                 token = request.token,
-                data = Stacktrace(
-                    text = [str(e)]
+                data = pack_to_any(
+                    Stacktrace(
+                        text = [str(e)]
+                    )
                 ),
-                flag = ResponseFlag.EXCEPTION_THROWN,
-                children_responses = {}
+                response_flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
+                response_children = {}
             )
 
         obj.broadcast(
@@ -98,11 +102,13 @@ def async_broadcasted(cmd):
             # )
             yield Response(
                 token = request.token,
-                data = Stacktrace(
-                    text = [str(e)]
+                data = pack_to_any(
+                    Stacktrace(
+                        text = [str(e)]
+                    )
                 ),
-                flag = ResponseFlag.EXCEPTION_THROWN,
-                children_responses = {}
+                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
+                response_children = {}
             )
 
 
@@ -115,11 +121,13 @@ def async_broadcasted(cmd):
             # )
             yield Response(
                 token = request.token,
-                data = Stacktrace(
-                    text = [str(e)]
+                data = pack_to_any(
+                    Stacktrace(
+                        text = [str(e)]
+                    )
                 ),
-                flag = ResponseFlag.EXCEPTION_THROWN,
-                children_responses = {}
+                response_flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
+                response_children = {}
             )
 
         obj.broadcast(

--- a/src/drunc/broadcast/server/decorators.py
+++ b/src/drunc/broadcast/server/decorators.py
@@ -34,14 +34,15 @@ def broadcasted(cmd):
             # )
 
             return Response(
+                name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
                         text = [str(e)]
                     )
                 ),
-                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
-                response_children = {}
+                flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
+                children = []
             )
 
         except Exception as e:
@@ -52,14 +53,15 @@ def broadcasted(cmd):
             #     context = context
             # )
             return Response(
+                name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
                         text = [str(e)]
                     )
                 ),
-                response_flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
-                response_children = {}
+                flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
+                children = []
             )
 
         obj.broadcast(
@@ -101,14 +103,15 @@ def async_broadcasted(cmd):
             #     context = context
             # )
             yield Response(
+                name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
                         text = [str(e)]
                     )
                 ),
-                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
-                response_children = {}
+                flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
+                children = []
             )
 
 
@@ -120,14 +123,15 @@ def async_broadcasted(cmd):
             #     context = context
             # )
             yield Response(
+                name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
                         text = [str(e)]
                     )
                 ),
-                response_flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
-                response_children = {}
+                flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
+                children = []
             )
 
         obj.broadcast(

--- a/src/drunc/broadcast/server/decorators.py
+++ b/src/drunc/broadcast/server/decorators.py
@@ -1,4 +1,5 @@
-
+from druncschema.request_response_pb2 import Response, ResponseFlag
+from druncschema.generic_pb2 import Stacktrace
 
 def broadcasted(cmd):
 
@@ -27,17 +28,34 @@ def broadcasted(cmd):
             ret = cmd(obj, request) # we strip the context here, no need for that anymore
 
         except DruncCommandException as e:
-            obj.interrupt_with_exception(
-                exception = e,
-                context = context
+            # obj.interrupt_with_exception(
+            #     exception = e,
+            #     context = context
+            # )
+
+            return Response(
+                token = request.token,
+                data = Stacktrace(
+                    text = [str(e)]
+                ),
+                flag = ResponseFlag.EXCEPTION_THROWN,
+                children_responses = {}
             )
 
         except Exception as e:
-            import traceback
-            obj.interrupt_with_exception(
-                exception = e,
-                stack = traceback.format_exc(),
-                context = context
+            # import traceback
+            # obj.interrupt_with_exception(
+            #     exception = e,
+            #     stack = traceback.format_exc(),
+            #     context = context
+            # )
+            return Response(
+                token = request.token,
+                data = Stacktrace(
+                    text = [str(e)]
+                ),
+                flag = ResponseFlag.EXCEPTION_THROWN,
+                children_responses = {}
             )
 
         obj.broadcast(
@@ -74,17 +92,34 @@ def async_broadcasted(cmd):
                 yield a
 
         except DruncCommandException as e:
-            await obj.async_interrupt_with_exception(
-                exception = e,
-                context = context
+            # await obj.async_interrupt_with_exception(
+            #     exception = e,
+            #     context = context
+            # )
+            yield Response(
+                token = request.token,
+                data = Stacktrace(
+                    text = [str(e)]
+                ),
+                flag = ResponseFlag.EXCEPTION_THROWN,
+                children_responses = {}
             )
 
+
         except Exception as e:
-            import traceback
-            await obj.async_interrupt_with_exception(
-                exception = e,
-                stack = traceback.format_exc(),
-                context = context
+            # import traceback
+            # await obj.async_interrupt_with_exception(
+            #     exception = e,
+            #     stack = traceback.format_exc(),
+            #     context = context
+            # )
+            yield Response(
+                token = request.token,
+                data = Stacktrace(
+                    text = [str(e)]
+                ),
+                flag = ResponseFlag.EXCEPTION_THROWN,
+                children_responses = {}
             )
 
         obj.broadcast(

--- a/src/drunc/controller/children_interface/grpc_child.py
+++ b/src/drunc/controller/children_interface/grpc_child.py
@@ -112,7 +112,7 @@ class gRPCChildNode(ChildNode):
             return Response(
                 token = token,
                 data = pack_to_any(Stacktrace(text=str(e)),
-                response_flag = ResponseFlag.UNSUCCESSFUL
+                response_flag = ResponseFlag.EXCEPTION_THROWN
                 response_children = {}
             )
 

--- a/src/drunc/controller/children_interface/grpc_child.py
+++ b/src/drunc/controller/children_interface/grpc_child.py
@@ -112,7 +112,7 @@ class gRPCChildNode(ChildNode):
             return Response(
                 token = token,
                 data = pack_to_any(Stacktrace(text=str(e)),
-                response_flag = ResponseFlag.EXCEPTION_THROWN
+                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN
                 response_children = {}
             )
 

--- a/src/drunc/controller/children_interface/grpc_child.py
+++ b/src/drunc/controller/children_interface/grpc_child.py
@@ -3,7 +3,7 @@ from drunc.controller.utils import send_command
 from drunc.utils.configuration import ConfHandler
 import grpc as grpc
 from drunc.exceptions import DruncSetupException
-from druncschema.controller_pb2 import Response
+from druncschema.request_response_pb2 import Response
 
 
 class gRCPChildConfHandler(ConfHandler):
@@ -98,7 +98,7 @@ class gRPCChildNode(ChildNode):
 
     def propagate_command(self, command, data, token) -> Response:
         from druncschema.generic_pb2 import PlainText, Stacktrace
-        from drunc.grpc_utils import pack_to_any
+        from drunc.utils.grpc_utils import pack_to_any
 
         try:
             return send_command(
@@ -111,8 +111,12 @@ class gRPCChildNode(ChildNode):
         except DruncException as e:
             return Response(
                 token = token,
-                data = pack_to_any(Stacktrace(text=str(e)),
-                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN
+                data = pack_to_any(
+                    Stacktrace(
+                        text=[str(e)]
+                    )
+                ),
+                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
                 response_children = {}
             )
 

--- a/src/drunc/controller/children_interface/grpc_child.py
+++ b/src/drunc/controller/children_interface/grpc_child.py
@@ -110,14 +110,15 @@ class gRPCChildNode(ChildNode):
             )
         except DruncException as e:
             return Response(
+                name = self.name,
                 token = token,
                 data = pack_to_any(
                     Stacktrace(
                         text=[str(e)]
                     )
                 ),
-                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
-                response_children = {}
+                flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
+                children = []
             )
 
 

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -451,7 +451,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = None,
-                response_flag = ResponseFlag.SUCCESSFUL
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY
                 response_children = {}
             )
         elif command == 'include':
@@ -459,7 +459,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = None,
-                response_flag = ResponseFlag.SUCCESSFUL
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY
                 response_children = {}
             )
 
@@ -524,14 +524,14 @@ class RESTAPIChildNode(ChildNode):
             response = Response(
                 token = token,
                 data = fsm_data,
-                response_flag = ResponseFlag.SUCCESSFUL
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY
                 response_children = {}
             )
 
             if not success:
                 self.log.error(r['result'])
                 self.state.to_error()
-                response.response_flag = ResponseFlag.UNSUCCESSFUL # arguably, we succesfully sent the command, and it returned bad, so maybe this shouldn't be unsucessful for the command (FSM should be unsuccessful)
+                response.response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY # /!\ The command executed successfully, but the FSM command was not successful
                 return response
 
         except ChildError as e:
@@ -540,7 +540,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = pack_to_any(Stacktrace(text=str(e)),
-                response_flag = ResponseFlag.UNSUCCESSFUL
+                response_flag = ResponseFlag.EXCEPTION_THROWN
                 response_children = {}
             )
 

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -447,13 +447,19 @@ class RESTAPIChildNode(ChildNode):
 
     def propagate_command(self, command:str, data, token:Token) -> Response:
         from druncschema.request_response_pb2 import ResponseFlag
+        from druncschema.generic_pb2 import PlainText, Stacktrace
+        from drunc.utils.grpc_utils import pack_to_any
 
         if command == 'exclude':
             self.state.exclude()
             return Response(
                 name = self.name,
                 token = token,
-                data = None,
+                data = pack_to_any(
+                    PlainText(
+                        text=f"\'{self.name}\' excluded"
+                    )
+                ),
                 flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
                 children = []
             )
@@ -462,12 +468,15 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 name = self.name,
                 token = token,
-                data = None,
+                data = pack_to_any(
+                    PlainText(
+                        text=f"\'{self.name}\' included"
+                    )
+                ),
                 flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
                 children = []
             )
 
-        from drunc.utils.grpc_utils import pack_to_any
         from druncschema.controller_pb2 import FSMCommandResponse, FSMResponseFlag
 
         if self.state.excluded():
@@ -504,7 +513,6 @@ class RESTAPIChildNode(ChildNode):
         import json
         self.log.info(f'Sending \'{data.command_name}\' to \'{self.name}\'')
 
-        from druncschema.generic_pb2 import PlainText, Stacktrace
 
         try:
             self.commander.send_command(

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -1,5 +1,6 @@
 from drunc.controller.children_interface.child_node import ChildNode, ChildNodeType
-from druncschema.controller_pb2 import Response
+from druncschema.request_response_pb2 import Response
+from druncschema.token_pb2 import Token
 import threading
 from typing import NoReturn
 
@@ -451,7 +452,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = None,
-                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
                 response_children = {}
             )
         elif command == 'include':
@@ -459,7 +460,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = None,
-                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
                 response_children = {}
             )
 
@@ -469,7 +470,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = None,
-                response_flag = ResponseFlag.NOT_EXECUTED_EXCLUDED
+                response_flag = ResponseFlag.NOT_EXECUTED_EXCLUDED,
                 response_children = {}
             )
 
@@ -479,7 +480,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = None,
-                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED
+                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
                 response_children = {}
             )
 
@@ -524,7 +525,7 @@ class RESTAPIChildNode(ChildNode):
             response = Response(
                 token = token,
                 data = fsm_data,
-                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
                 response_children = {}
             )
 
@@ -539,8 +540,12 @@ class RESTAPIChildNode(ChildNode):
             self.state.to_error()
             return Response(
                 token = token,
-                data = pack_to_any(Stacktrace(text=str(e)),
-                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN
+                data = pack_to_any(
+                    Stacktrace(
+                        text=[str(e)]
+                    )
+                ),
+                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
                 response_children = {}
             )
 

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -540,7 +540,7 @@ class RESTAPIChildNode(ChildNode):
             return Response(
                 token = token,
                 data = pack_to_any(Stacktrace(text=str(e)),
-                response_flag = ResponseFlag.EXCEPTION_THROWN
+                response_flag = ResponseFlag.DRUNC_EXCEPTION_THROWN
                 response_children = {}
             )
 

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -446,6 +446,7 @@ class RESTAPIChildNode(ChildNode):
         )
 
     def propagate_command(self, command:str, data, token:Token) -> Response:
+        from druncschema.request_response_pb2 import ResponseFlag
 
         if command == 'exclude':
             self.state.exclude()
@@ -466,7 +467,6 @@ class RESTAPIChildNode(ChildNode):
                 children = []
             )
 
-        from druncschema.request_response_pb2 import ResponseFlag
         from drunc.utils.grpc_utils import pack_to_any
         from druncschema.controller_pb2 import FSMCommandResponse, FSMResponseFlag
 

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -374,7 +374,7 @@ class Controller(ControllerServicer):
         system=SystemType.CONTROLLER
     ) # 2nd step
     @unpack_request_data_to(pass_token=True) # 3rd step
-    def get_children_status(self, token:Token) -> ChildrenStatus:
+    def get_children_status(self, token:Token) -> Response:
         #from drunc.controller.utils import get_status_message
         response =  ChildrenStatus(
             children_status = [n.get_status(token) for n in self.children_nodes]
@@ -423,7 +423,7 @@ class Controller(ControllerServicer):
 
         return Response (
             token = None,
-            data = pack_to_any(response),,
+            data = pack_to_any(response),
             response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
             response_children = {},
         )

--- a/src/drunc/controller/decorators.py
+++ b/src/drunc/controller/decorators.py
@@ -7,12 +7,13 @@ def in_control(cmd):
     def wrap(obj, request):
         if not obj.actor.token_is_current_actor(request.token):
             return Response(
+                name = self.obj.name,
                 token = request.token,
                 data = PlainText(
                     text = f"User {request.token.user_name} is not in control of {obj.__class__.__name__}",
                 ),
-                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
-                response_children = {}
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
+                children = []
             )
 
         return cmd(obj, request)

--- a/src/drunc/controller/decorators.py
+++ b/src/drunc/controller/decorators.py
@@ -11,8 +11,8 @@ def in_control(cmd):
                 data = PlainText(
                     text = f"User {request.token.user_name} is not in control of {obj.__class__.__name__}",
                 ),
-                flag = ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
-                children_responses = {}
+                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
+                response_children = {}
             )
 
         return cmd(obj, request)

--- a/src/drunc/controller/decorators.py
+++ b/src/drunc/controller/decorators.py
@@ -6,8 +6,15 @@ def in_control(cmd):
     @wraps(cmd)
     def wrap(obj, request):
         if not obj.actor.token_is_current_actor(request.token):
-            from drunc.controller.exceptions import OtherUserAlreadyInControl
-            raise OtherUserAlreadyInControl()
+            return Response(
+                token = request.token,
+                data = PlainText(
+                    text = f"User {request.token.user_name} is not in control of {obj.__class__.__name__}",
+                ),
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
+                children_responses = {}
+            )
+
         return cmd(obj, request)
 
     return wrap

--- a/src/drunc/controller/exceptions.py
+++ b/src/drunc/controller/exceptions.py
@@ -3,6 +3,9 @@ from drunc.exceptions import DruncCommandException
 class ControllerException(DruncCommandException):
     pass
 
+class ChildError(ControllerException):
+    pass
+
 class CannotSurrenderControl(ControllerException):
     pass
 

--- a/src/drunc/controller/interface/commands.py
+++ b/src/drunc/controller/interface/commands.py
@@ -227,8 +227,6 @@ def fsm(obj:ControllerContext, command, arguments, traceback:bool) -> None:
     from drunc.controller.interface.shell_utils import format_bool, tree_prefix
     from drunc.utils.grpc_utils import unpack_any
     from druncschema.controller_pb2 import FSMResponseFlag, FSMCommandResponse
-    if result.data.flag != FSMResponseFlag.FSM_EXECUTED_SUCCESSFULLY:
-        return
 
     from rich.table import Table
     t = Table(title=f'{command} execution report')

--- a/src/drunc/controller/interface/commands.py
+++ b/src/drunc/controller/interface/commands.py
@@ -13,9 +13,9 @@ def describe(obj:ControllerContext, command:str, traceback:bool) -> None:
     from drunc.utils.shell_utils import InterruptedCommand
 
     if command == 'fsm':
-        desc = obj.get_driver('controller').describe_fsm(rethrow=traceback)
+        desc = obj.get_driver('controller').describe_fsm(rethrow=traceback).data
     else:
-        desc = obj.get_driver('controller').describe(rethrow=traceback)
+        desc = obj.get_driver('controller').describe(rethrow=traceback).data
 
     if not desc: return
 
@@ -82,7 +82,7 @@ def describe(obj:ControllerContext, command:str, traceback:bool) -> None:
 @add_traceback_flag()
 @click.pass_obj
 def ls(obj:ControllerContext, traceback:bool) -> None:
-    children = obj.get_driver('controller').ls(rethrow=traceback)
+    children = obj.get_driver('controller').ls(rethrow=traceback).data
     if not children: return
     obj.print(children.text)
 
@@ -92,7 +92,7 @@ def ls(obj:ControllerContext, traceback:bool) -> None:
 @click.pass_obj
 def status(obj:ControllerContext, traceback:bool) -> None:
     from druncschema.controller_pb2 import Status, ChildrenStatus
-    status = obj.get_driver('controller').get_status(traceback)
+    status = obj.get_driver('controller').get_status(traceback).data
 
     if not status: return
 
@@ -156,14 +156,14 @@ def connect(obj:ControllerContext, traceback:bool, controller_address:str) -> No
 @add_traceback_flag()
 @click.pass_obj
 def take_control(obj:ControllerContext, traceback:bool) -> None:
-    obj.get_driver('controller').take_control(traceback)
+    obj.get_driver('controller').take_control(traceback).data
 
 
 @click.command('surrender-control')
 @add_traceback_flag()
 @click.pass_obj
 def surrender_control(obj:ControllerContext, traceback:bool) -> None:
-    obj.get_driver('controller').surrender_control(traceback)
+    obj.get_driver('controller').surrender_control(traceback).data
 
 
 @click.command('who-am-i')
@@ -176,7 +176,7 @@ def who_am_i(obj:ControllerContext) -> None:
 @add_traceback_flag()
 @click.pass_obj
 def who_is_in_charge(obj:ControllerContext, traceback:bool) -> None:
-    who = obj.get_driver('controller').who_is_in_charge(traceback)
+    who = obj.get_driver('controller').who_is_in_charge(traceback).data
     if who:
         obj.print(who.text)
 
@@ -191,7 +191,7 @@ def fsm(obj:ControllerContext, command, arguments, traceback:bool) -> None:
 
     if len(arguments) % 2 != 0:
         raise click.BadParameter('Arguments are pairs of key-value!')
-    desc = obj.get_driver('controller').describe_fsm(traceback)
+    desc = obj.get_driver('controller').describe_fsm(traceback).data
 
     from drunc.controller.interface.shell_utils import search_fsm_command, validate_and_format_fsm_arguments, ArgumentException
 
@@ -225,25 +225,32 @@ def fsm(obj:ControllerContext, command, arguments, traceback:bool) -> None:
     if not result: return
 
     from drunc.controller.interface.shell_utils import format_bool, tree_prefix
-    from druncschema.controller_pb2 import FSMCommandResponseCode
+    from drunc.utils.grpc_utils import unpack_any
+    from druncschema.controller_pb2 import FSMCommandResponseCode, FSMCommandResponse
+    if result.successful != FSMCommandResponseCode.SUCCESSFUL:
+        return
 
     from rich.table import Table
     t = Table(title=f'{command} execution report')
     t.add_column('Name')
     t.add_column('Command success')
-    t.add_row(
-        '<root>',
-        format_bool(result.successful == FSMCommandResponseCode.SUCCESSFUL),
-    )
+    # t.add_row(
+    #     '<root>',
+    #     format_bool(result.successful == FSMCommandResponseCode.SUCCESSFUL),
+    # )
 
-    i=0
-    n=len(result.children_successful)
-    for name, sucess in result.children_successful.items():
-        t.add_row(
-            tree_prefix(i, n)+name,
-            format_bool(sucess == FSMCommandResponseCode.SUCCESSFUL),
-        )
-        i += 1
+    # i=0
+    def add_to_table(table, response, name, prefix):
+        table.add_row(prefix+name, format_bool(response.successful == FSMCommandResponseCode.SUCCESSFUL))
+        for c_name, c_response in response.response_children.items():
+            add_to_table(table, c_response, c_name, "  "+prefix)
+    # for name, sucess in result.children_successful.items():
+    #     t.add_row(
+    #         tree_prefix(i, n)+name,
+    #         format_bool(sucess == FSMCommandResponseCode.SUCCESSFUL),
+    #     )
+    #     i += 1
+    add_to_table(t, result, '<root>', '')
     obj.print(t)
 
 
@@ -255,7 +262,7 @@ def include(obj:ControllerContext, traceback:bool) -> None:
     data = FSMCommand(
         command_name = 'include',
     )
-    result = obj.get_driver('controller').include(rethrow=traceback, arguments=data)
+    result = obj.get_driver('controller').include(rethrow=traceback, arguments=data).data
     if not result: return
     obj.print(result.text)
 
@@ -268,6 +275,6 @@ def exclude(obj:ControllerContext, traceback:bool) -> None:
     data = FSMCommand(
         command_name = 'exclude',
     )
-    result = obj.get_driver('controller').exclude(rethrow=traceback, arguments=data)
+    result = obj.get_driver('controller').exclude(rethrow=traceback, arguments=data).data
     if not result: return
     obj.print(result.text)

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -64,7 +64,7 @@ def controller_setup(ctx, controller_address):
             progress.update(waiting, completed=time.time()-start_time)
 
             try:
-                desc = ctx.get_driver('controller').describe(rethrow=True)
+                desc = ctx.get_driver('controller').describe(rethrow=True).data
                 stored_exception = None
                 break
             except ServerUnreachable as e:
@@ -87,12 +87,12 @@ def controller_setup(ctx, controller_address):
 
     ctx.print('Connected to the controller')
 
-    children = ctx.get_driver('controller').ls(rethrow=False)
+    children = ctx.get_driver('controller').ls(rethrow=False).data
     ctx.print(f'{desc.name}.{desc.session}\'s children :family:: {children.text}')
 
     ctx.info(f'Taking control of the controller as {ctx.get_token()}')
     try:
-        ctx.get_driver('controller').take_control(rethrow=True)
+        ctx.get_driver('controller').take_control(rethrow=True).data
         ctx.took_control = True
 
     except Exception as e:

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -92,15 +92,21 @@ def controller_setup(ctx, controller_address):
 
     ctx.info(f'Taking control of the controller as {ctx.get_token()}')
     try:
-        ctx.get_driver('controller').take_control(rethrow=True).data
-        ctx.took_control = True
+        ret = ctx.get_driver('controller').take_control(rethrow=True)
+        from druncschema.request_response_pb2 import ResponseFlag
+
+        if ret.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
+            ctx.info('You are in control.')
+            ctx.took_control = True
+        else:
+            ctx.warn(f'You are NOT in control.')
+            ctx.took_control = False
+
 
     except Exception as e:
         ctx.warn('You are NOT in control.')
         ctx.took_control = False
-        return
-
-    ctx.info('You are in control.')
+        raise e
 
 
 

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -30,7 +30,7 @@ async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_confi
         )
         async for result in results:
             if not result: break
-            obj.print(f'\'{result.process_description.metadata.name}\' ({result.uuid.uuid}) process started')
+            obj.print(f'\'{result.data.process_description.metadata.name}\' ({result.data.uuid.uuid}) process started')
     except InterruptedCommand:
         return
 
@@ -59,7 +59,7 @@ async def kill(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) ->
     if not result: return
 
     from drunc.process_manager.utils import tabulate_process_instance_list
-    obj.print(tabulate_process_instance_list(result, 'Killed process', False))
+    obj.print(tabulate_process_instance_list(result.data, 'Killed process', False))
 
 
 @click.command('flush')
@@ -76,7 +76,7 @@ async def flush(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -
     if not result: return
 
     from drunc.process_manager.utils import tabulate_process_instance_list
-    obj.print(tabulate_process_instance_list(result, 'Flushed process', False))
+    obj.print(tabulate_process_instance_list(result.data, 'Flushed process', False))
 
 
 @click.command('logs')
@@ -105,10 +105,10 @@ async def logs(obj:ProcessManagerContext, how_far:int, grep:str, query:ProcessQu
         if not result: break
 
         if uuid is None:
-            uuid = result.uuid.uuid
+            uuid = result.data.uuid.uuid
             obj.rule(f'[yellow]{uuid}[/yellow] logs')
 
-        line = result.line
+        line = result.data.line
         if line == "":
             obj.print('')
             continue
@@ -142,7 +142,7 @@ async def restart(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool)
 
     if not result: return
 
-    obj.print(result)
+    obj.print(result.data)
 
 
 @click.command('ps')
@@ -160,6 +160,6 @@ async def ps(obj:ProcessManagerContext, query:ProcessQuery, long_format:bool, tr
     if not results: return
 
     from drunc.process_manager.utils import tabulate_process_instance_list
-    obj.print(tabulate_process_instance_list(results, title='Processes running', long=long_format))
+    obj.print(tabulate_process_instance_list(results.data, title='Processes running', long=long_format))
 
 

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -167,18 +167,20 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     def boot(self, br:BootRequest) -> Response:
         try:
             resp = self._boot_impl(br)
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
-                response_children = {},
+                flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                children = [],
             )
         except NotImplementedError:
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                response_children = {},
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                children = [],
             )
 
 
@@ -196,18 +198,20 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     def restart(self, q:ProcessQuery)-> Response:
         try:
             resp = self._restart_impl(q)
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
-                response_children = {},
+                flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                children = [],
             )
         except NotImplementedError:
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                response_children = {},
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                children = [],
             )
 
 
@@ -225,18 +229,20 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     def kill(self, q:ProcessQuery) -> Response:
         try:
             resp = self._kill_impl(q)
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
-                response_children = {},
+                flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                children = [],
             )
         except NotImplementedError:
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                response_children = {},
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                children = [],
             )
 
 
@@ -254,18 +260,20 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     def ps(self, q:ProcessQuery) -> Response:
         try:
             resp = self._ps_impl(q)
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
-                response_children = {},
+                flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                children = [],
             )
         except NotImplementedError:
-            return Response (
+            return Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                response_children = {},
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                children = [],
             )
 
     # ORDER MATTERS!
@@ -320,11 +328,12 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
             values=ret
         )
 
-        return Response (
+        return Response(
+            name = self.name,
             token = None,
             data = pack_to_any(pil),
-            response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
-            response_children = {},
+            flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+            children = [],
         )
 
 
@@ -348,11 +357,12 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         if bd:
             d.broadcast.CopyFrom(pack_to_any(bd))
 
-        return Response (
+        return Response(
+            name = self.name,
             token = None,
             data = pack_to_any(d),
-            response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
-            response_children = {},
+            flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+            children = [],
         )
 
 
@@ -371,18 +381,20 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     async def logs(self, lr:LogRequest) -> Response:
         try:
             async for r in self._logs_impl(lr):
-                yield Response (
+                yield Response(
+                    name = self.name,
                     token = None,
                     data = pack_to_any(r),
-                    response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
-                    response_children = {},
+                    flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                    children = [],
                 )
         except NotImplementedError:
-            yield Response (
+            yield Response(
+                name = self.name,
                 token = None,
                 data = pack_to_any(resp),
-                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                response_children = {},
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                children = [],
             )
 
     def _ensure_one_process(self, uuids:[str], in_boot_request:bool=False) -> str:

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -1,11 +1,11 @@
-from druncschema.request_response_pb2 import Request, Response
+from druncschema.request_response_pb2 import Request, Response, ResponseFlag
 from druncschema.broadcast_pb2 import BroadcastType
 from druncschema.authoriser_pb2 import ActionType, SystemType
 
-from druncschema.process_manager_pb2 import BootRequest, ProcessQuery, ProcessInstance, ProcessRestriction, ProcessDescription, ProcessUUID, ProcessInstanceList, LogRequest
+from druncschema.process_manager_pb2 import BootRequest, ProcessQuery, ProcessInstance, ProcessRestriction, ProcessDescription, ProcessUUID, ProcessInstanceList, LogRequest, LogLine
 from druncschema.process_manager_pb2_grpc import ProcessManagerServicer
 from drunc.broadcast.server.decorators import broadcasted, async_broadcasted
-from drunc.utils.grpc_utils import unpack_request_data_to, async_unpack_request_data_to, pack_response, async_pack_response
+from drunc.utils.grpc_utils import unpack_request_data_to, async_unpack_request_data_to,pack_to_any
 import abc
 
 from drunc.authoriser.decorators import authentified_and_authorised, async_authentified_and_authorised
@@ -164,13 +164,26 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
     @unpack_request_data_to(BootRequest) # 3rd step
-    @pack_response # 4th step
     def boot(self, br:BootRequest) -> Response:
-        return self._boot_impl(br)
+        try:
+            resp = self._boot_impl(br)
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                response_children = {},
+            )
+        except NotImplementedError:
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                response_children = {},
+            )
 
 
     @abc.abstractmethod
-    def _restart_impl(self, q:ProcessQuery) -> ProcessInstance:
+    def _restart_impl(self, q:ProcessQuery) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -180,13 +193,26 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
     @unpack_request_data_to(ProcessQuery) # 3rd step
-    @pack_response # 4th step
     def restart(self, q:ProcessQuery)-> Response:
-        return self._restart_impl(q)
+        try:
+            resp = self._restart_impl(q)
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                response_children = {},
+            )
+        except NotImplementedError:
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                response_children = {},
+            )
 
 
     @abc.abstractmethod
-    def _kill_impl(self, q:ProcessQuery) -> Response:
+    def _kill_impl(self, q:ProcessQuery) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -196,13 +222,26 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
     @unpack_request_data_to(ProcessQuery) # 3rd step
-    @pack_response # 4th step
     def kill(self, q:ProcessQuery) -> Response:
-        return self._kill_impl(q)
+        try:
+            resp = self._kill_impl(q)
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                response_children = {},
+            )
+        except NotImplementedError:
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                response_children = {},
+            )
 
 
     @abc.abstractmethod
-    def _ps_impl(self, q:ProcessQuery) -> Response:
+    def _ps_impl(self, q:ProcessQuery) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -212,10 +251,22 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
     @unpack_request_data_to(ProcessQuery) # 3rd step
-    @pack_response # 4th step
     def ps(self, q:ProcessQuery) -> Response:
-        return self._ps_impl(q)
-
+        try:
+            resp = self._ps_impl(q)
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                response_children = {},
+            )
+        except NotImplementedError:
+            return Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                response_children = {},
+            )
 
     # ORDER MATTERS!
     @broadcasted # outer most wrapper 1st step
@@ -224,7 +275,6 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
     @unpack_request_data_to(ProcessQuery) # 3rd step
-    @pack_response # 4th step
     def flush(self, query:ProcessQuery) -> Response:
         ret = []
 
@@ -269,7 +319,14 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         pil = ProcessInstanceList(
             values=ret
         )
-        return pil
+
+        return Response (
+            token = None,
+            data = pack_to_any(pil),
+            response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+            response_children = {},
+        )
+
 
     # ORDER MATTERS!
     @broadcasted # outer most wrapper 1st step
@@ -278,7 +335,6 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
     @unpack_request_data_to(None) # 3rd step
-    @pack_response # 4th step
     def describe(self) -> Response:
         from druncschema.request_response_pb2 import Description
         from drunc.utils.grpc_utils import pack_to_any
@@ -291,10 +347,18 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         )
         if bd:
             d.broadcast.CopyFrom(pack_to_any(bd))
-        return d
+
+        return Response (
+            token = None,
+            data = pack_to_any(d),
+            response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+            response_children = {},
+        )
+
+
 
     @abc.abstractmethod
-    async def _logs_impl(self, req:Request, context) -> Response:
+    async def _logs_impl(self, req:Request, context) -> LogLine:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -304,11 +368,22 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
     @async_unpack_request_data_to(LogRequest) # 3rd step
-    @async_pack_response # 4th step
     async def logs(self, lr:LogRequest) -> Response:
-        async for r in self._logs_impl(lr):
-            yield r
-
+        try:
+            async for r in self._logs_impl(lr):
+                yield Response (
+                    token = None,
+                    data = pack_to_any(r),
+                    response_flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                    response_children = {},
+                )
+        except NotImplementedError:
+            yield Response (
+                token = None,
+                data = pack_to_any(resp),
+                response_flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                response_children = {},
+            )
 
     def _ensure_one_process(self, uuids:[str], in_boot_request:bool=False) -> str:
         if uuids == []:

--- a/src/drunc/unified_shell/commands.py
+++ b/src/drunc/unified_shell/commands.py
@@ -27,7 +27,7 @@ async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_confi
         )
         async for result in results:
             if not result: break
-            obj.print(f'\'{result.process_description.metadata.name}\' ({result.uuid.uuid}) process started')
+            obj.print(f'\'{result.data.process_description.metadata.name}\' ({result.data.uuid.uuid}) process started')
     except InterruptedCommand:
         return
 

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -65,6 +65,7 @@ def unified_shell(ctx, process_manager_configuration:str, log_level:str, traceba
         desc = asyncio.get_event_loop().run_until_complete(
             ctx.obj.get_driver().describe(rethrow=True)
         )
+        desc = desc.data
     except ServerUnreachable as e:
         ctx.obj.critical(f'Could not connect to the process manager')
         if not ctx.obj.pm_process.is_alive():

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -54,8 +54,8 @@ def unpack_request_data_to(data_type=None, pass_token=False):
                         data = PlainText(
                             text = str(e)
                         ),
-                        flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
-                        children_responses = {}
+                        response_flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
+                        response_children = {}
                     )
 
             if data is not None:
@@ -94,13 +94,13 @@ def async_unpack_request_data_to(data_type=None, pass_token=False):
                 try:
                     data = unpack_any(request.data, data_type)
                 except UnpackingError as e:
-                    return Response(
+                    yield Response(
                         token = request.token,
                         data = PlainText(
                             text = str(e)
                         ),
-                        flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
-                        children_responses = {}
+                        response_flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
+                        response_children = {}
                     )
 
             if data is not None:
@@ -118,6 +118,7 @@ def async_unpack_request_data_to(data_type=None, pass_token=False):
 
 
 def pack_response(cmd, with_children_responses=False):
+    raise DeprecationWarning('This function is deprecated, pack your responses yourself')
 
     import functools
 
@@ -147,7 +148,6 @@ def pack_response(cmd, with_children_responses=False):
         ret = Response(
             token = new_token,
             data = data,
-            response_flag
             response_children = response_children,
         )
 
@@ -159,6 +159,7 @@ def pack_response(cmd, with_children_responses=False):
 
 
 def async_pack_response(cmd, with_children_responses=False):
+    raise DeprecationWarning('This function is deprecated, pack your responses yourself')
 
     import functools
 

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -44,8 +44,21 @@ def unpack_request_data_to(data_type=None, pass_token=False):
             if pass_token:
                 kwargs = {'token': request.token}
 
+            data = None
             if data_type is not None:
-                data = unpack_any(request.data, data_type)
+                try:
+                    data = unpack_any(request.data, data_type)
+                except UnpackingError as e:
+                    return Response(
+                        token = request.token,
+                        data = PlainText(
+                            text = str(e)
+                        ),
+                        flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
+                        children_responses = {}
+                    )
+
+            if data is not None:
                 ret = cmd(obj, data, **kwargs)
             else:
                 ret = cmd(obj, **kwargs)
@@ -76,8 +89,21 @@ def async_unpack_request_data_to(data_type=None, pass_token=False):
             if pass_token:
                 kwargs = {'token': request.token}
 
+            data = None
             if data_type is not None:
-                data = unpack_any(request.data, data_type)
+                try:
+                    data = unpack_any(request.data, data_type)
+                except UnpackingError as e:
+                    return Response(
+                        token = request.token,
+                        data = PlainText(
+                            text = str(e)
+                        ),
+                        flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
+                        children_responses = {}
+                    )
+
+            if data is not None:
                 async for a in cmd(obj, data, **kwargs):
                     yield a
             else:
@@ -117,7 +143,7 @@ def pack_response(cmd, with_children_responses=False):
 
         new_token = Token() # empty token
         data = Any()
-        data.Pack(ret)
+        data.Pack(self_response)
         ret = Response(
             token = new_token,
             data = data,

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -91,7 +91,7 @@ def async_unpack_request_data_to(data_type=None, pass_token=False):
     return decor
 
 
-def pack_response(cmd):
+def pack_response(cmd, with_children_responses=False):
 
     import functools
 
@@ -106,14 +106,23 @@ def pack_response(cmd):
         from google.protobuf.any_pb2 import Any
 
         log.debug('Executing wrapped function')
-        ret = cmd(obj, *arg, **kwargs)
+        out = cmd(obj, *arg, **kwargs)
+        self_response = out
+        response_children = {}
+
+        if with_children_responses:
+            self_response = out[0]
+            response_children = out[1]
+
 
         new_token = Token() # empty token
         data = Any()
         data.Pack(ret)
         ret = Response(
             token = new_token,
-            data = data
+            data = data,
+            response_flag
+            response_children = response_children,
         )
 
         log.debug('Exiting')
@@ -123,7 +132,7 @@ def pack_response(cmd):
 
 
 
-def async_pack_response(cmd):
+def async_pack_response(cmd, with_children_responses=False):
 
     import functools
 

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -50,12 +50,13 @@ def unpack_request_data_to(data_type=None, pass_token=False):
                     data = unpack_any(request.data, data_type)
                 except UnpackingError as e:
                     return Response(
+                        name = obj.__class__.__name__,
                         token = request.token,
                         data = PlainText(
                             text = str(e)
                         ),
-                        response_flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
-                        response_children = {}
+                        flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
+                        children = []
                     )
 
             if data is not None:
@@ -95,12 +96,13 @@ def async_unpack_request_data_to(data_type=None, pass_token=False):
                     data = unpack_any(request.data, data_type)
                 except UnpackingError as e:
                     yield Response(
+                        name = obj.__class__.__name__,
                         token = request.token,
                         data = PlainText(
                             text = str(e)
                         ),
-                        response_flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
-                        response_children = {}
+                        flag = ResponseFlag.NOT_EXECUTED_BAD_REQUEST_FORMAT,
+                        children = []
                     )
 
             if data is not None:
@@ -146,9 +148,11 @@ def pack_response(cmd, with_children_responses=False):
         data = Any()
         data.Pack(self_response)
         ret = Response(
+            name = obj.__class__.__name__,
             token = new_token,
             data = data,
-            response_children = response_children,
+            flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+            children = response_children,
         )
 
         log.debug('Exiting')

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -31,7 +31,7 @@ class DecodedResponse:
 
     @staticmethod
     def str(obj, prefix=""):
-        text = f'{prefix} {obj.name}\n'
+        text = f'{prefix} {obj.name} -> {obj.flag}\n'
         for v in obj.children:
             if v is None:
                 continue
@@ -141,14 +141,12 @@ class GRPCDriver:
             token = response.token,
             flag = response.flag,
         )
-
         if response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
-            if response.HasField("data"):
+            if response.data not in [None, ""]:
                 dr.data = unpack_any(response.data, outformat)
 
             for c_response in response.children:
                 dr.children.append(self.handle_response(c_response, command, outformat))
-
             return dr
 
         else:

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -143,7 +143,8 @@ class GRPCDriver:
         )
 
         if response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
-            dr.data = unpack_any(response.data, outformat)
+            if response.HasField("data"):
+                dr.data = unpack_any(response.data, outformat)
 
             for c_response in response.children:
                 dr.children.append(self.handle_response(c_response, command, outformat))


### PR DESCRIPTION
Changes in this PR:
 - Make the schema hierarchical, so the response of a command from a parent contains the responses of all the children
 - Implement `ResponseFlag`, a simple Enum which says whether the command was successful or not, it also provides debugging informations
 - Do the same as above for the FSM transitions (and standardised the flag name and order between `ResponseFlag` and `FSMResponseFlag`)
 - In general, throw less exceptions make the decorator return the correct ResponseFlag when something goes wrong
 - ditch the `pack_response` decorator, as it was becoming too complicated.