### PR TITLE
Adding thread pinning over SSH

### DIFF
--- a/src/drunc/fsm/action_factory.py
+++ b/src/drunc/fsm/action_factory.py
@@ -66,6 +66,9 @@ class FSMActionFactory:
             case "file-run-registry":
                 from drunc.fsm.actions.file_run_registry import FileRunRegistry
                 iface = FileRunRegistry(configuration)
+            case "thread-pinning":
+                from drunc.fsm.actions.thread_pinning import ThreadPinning
+                iface = ThreadPinning(configuration)
             case _:
                 raise fsme.UnknownAction(action_name)
 

--- a/src/drunc/fsm/actions/file_logbook.py
+++ b/src/drunc/fsm/actions/file_logbook.py
@@ -6,7 +6,9 @@ class FileLogbook(FSMAction):
         super().__init__(
             name = "file-logbook"
         )
-        self.file = configuration.file_name
+        self.conf_dict = {p.name: p.value for p in configuration.parameters}
+        print(f'{self.conf_dict=}')
+        self.file = self.conf_dict['file_name']
 
     def post_start(self, _input_data, _context, message:str="", **kwargs):
 

--- a/src/drunc/fsm/actions/thread_pinning.py
+++ b/src/drunc/fsm/actions/thread_pinning.py
@@ -1,0 +1,77 @@
+from drunc.fsm.core import FSMAction
+from drunc.utils.configuration import find_configuration
+from drunc.fsm.exceptions import ThreadPinningFailed
+
+
+class ThreadPinning(FSMAction):
+    def __init__(self, configuration):
+        super().__init__(
+            name = "thread-pinning"
+        )
+        import logging
+        self.log = logging.getLogger("thread-pinning")
+        self.conf_dict = {p.name: p.value for p in configuration.parameters}
+
+    def pin_thread(self, thread_pinning_file, configuration, session):
+        from drunc.process_manager.oks_parser import process_segment
+        import conffwk
+        db = conffwk.Configuration(f"oksconflibs:{configuration}")
+        session_dal = db.get_dal(class_name="Session", uid=session)
+        apps = process_segment(db, session_dal, session_dal.segment)
+
+        import os 
+        rte=session_dal.rte_script
+        if not rte and os.getenv("DBT_INSTALL_DIR"):
+            rte = os.getenv("DBT_INSTALL_DIR") + "/daq_app_rte.sh"
+        elif not rte:
+            self.log.error(f'RTE was not supplied in the OKS configuration or in the environment, running without it')
+
+        cmd = f"source {rte}; " if rte else ""
+        cmd += f"readout-affinity.py --pinfile {thread_pinning_file}"
+
+        import getpass
+        user = getpass.getuser()
+
+        hosts = set()
+        for app in apps:
+            hosts.add(app["host"])
+        hosts.add("abc")
+        from sh import ssh, ErrorReturnCode, Command
+        my_ssh = Command('/usr/bin/ssh')
+
+        failed_hosts = set()
+
+        for host in hosts:
+            arguments = [user+"@"+host, "-tt", "-o StrictHostKeyChecking=no", f'{{ {cmd} ; }}']
+            try:
+                self.log.info(f"Executing thread pinning file {thread_pinning_file} on {host}")
+                proc = my_ssh(*arguments)
+            except ErrorReturnCode as e:
+                self.log.error(e.stdout.decode('ascii'))
+                self.log.error(e.stderr.decode('ascii'))
+                failed_hosts.add(host)
+                continue
+            except Exception as e:
+                self.log.critical(str(e))
+                failed_hosts.add(host)
+                continue
+            self.log.debug(proc)
+
+        failed_hosts_error_str = ", ".join(failed_hosts)
+        if failed_hosts:
+            raise ThreadPinningFailed(failed_hosts_error_str)
+
+    def post_conf(self, _input_data, _context, **kwargs):
+        run_configuration = find_configuration(_context.configuration.initial_data)
+        self.pin_thread(self.conf_dict['post_conf'], run_configuration, session=_context.session)
+        return _input_data
+
+    def post_start(self, _input_data, _context, **kwargs):
+        run_configuration = find_configuration(_context.configuration.initial_data)
+        self.pin_thread(self.conf_dict['post_start'], run_configuration, session=_context.session)
+        return _input_data
+
+    def pre_conf(self, _input_data, _context, **kwargs):
+        run_configuration = find_configuration(_context.configuration.initial_data)
+        self.pin_thread(self.conf_dict['pre_conf'], run_configuration, session=_context.session)
+        return _input_data

--- a/src/drunc/fsm/core.py
+++ b/src/drunc/fsm/core.py
@@ -66,6 +66,7 @@ class PreOrPostTransitionSequence:
                 input_data = callback.method(_input_data=input_data, _context=ctx, **transition_args)
                 self._log.debug(f'data after callback: {input_data}')
             except Exception as e:
+                import traceback
                 self._log.error(traceback.format_exc())
                 if callback.mandatory:
                     raise e

--- a/src/drunc/fsm/exceptions.py
+++ b/src/drunc/fsm/exceptions.py
@@ -80,3 +80,9 @@ class TransitionDataOfIncorrectFormat(FSMException):
     def __init__(self, data):
         self.message = f'The data "{data}" could not be interpreted as json'
         super().__init__(self.message)
+
+        
+class ThreadPinningFailed(FSMException):
+    def __init__(self, host):
+        self.message = f'The thread pinning on "{host}" failed'
+        super().__init__(self.message)

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -73,6 +73,7 @@ class ProcessManagerDriver(GRPCDriver):
                     args=[session_dal.rte_script]))
 
             elif os.getenv("DBT_INSTALL_DIR") is not None:
+                env['DBT_INSTALL_DIR'] = os.getenv("DBT_INSTALL_DIR")
                 self._log.info(f'RTE script was not supplied in the OKS configuration, using the one from local enviroment instead')
                 rte = os.getenv("DBT_INSTALL_DIR") + "/daq_app_rte.sh"
 


### PR DESCRIPTION
Can connect to all the hosts and execute the required thread pinning. Uses example thread pinning json in 
`/cvmfs/dunedaq.opensciencegrid.org/spack/releases/coredaq-v5.0.0-a9-1/spack-0.20.0/opt/spack/linux-almalinux9-x86_64/gcc-12.1.0/readoutlibs-v2.1.0-kkwlcckeyl7ltarpbd5bn6fn2nczjqmp/share/config/cpupins/cpupin-example.json`
as an example. 

Requires:
Coredal https://github.com/DUNE-DAQ/coredal/pull/24
Appdal https://github.com/DUNE-DAQ/appdal/pull/66