### PR TITLE
Exception handling

### DIFF
--- a/src/drunc/apps/__main_controller_shell__.py
+++ b/src/drunc/apps/__main_controller_shell__.py
@@ -10,11 +10,8 @@ def main() -> None:
     except Exception as e:
         from rich import print as rprint
         rprint(f'[red bold]:fire::fire: Exception thrown :fire::fire:')
-        if context.print_traceback:
-            from drunc.utils.utils import print_traceback
-            print_traceback()
-        else:
-            rprint(f'[yellow]{e}[/]\nUse [blue]--traceback[/] for more information')
+        from drunc.utils.utils import print_traceback
+        print_traceback()
         rprint(f'Exiting...')
         exit(1)
 

--- a/src/drunc/apps/__main_pm_shell__.py
+++ b/src/drunc/apps/__main_pm_shell__.py
@@ -11,11 +11,8 @@ def main():
     except Exception as e:
         from rich import print as rprint
         rprint(f'[red bold]:fire::fire: Exception thrown :fire::fire:')
-        if context.print_traceback:
-            from drunc.utils.utils import print_traceback
-            print_traceback()
-        else:
-            rprint(f'[yellow]{e}[/]\nUse [blue]--traceback[/] for more information')
+        from drunc.utils.utils import print_traceback
+        print_traceback()
         rprint(f'Exiting...')
         exit(1)
 

--- a/src/drunc/apps/__main_unified_shell__.py
+++ b/src/drunc/apps/__main_unified_shell__.py
@@ -10,11 +10,8 @@ def main():
     except Exception as e:
         from rich import print as rprint
         rprint(f'[red bold]:fire::fire: Exception thrown :fire::fire:')
-        if context.print_traceback:
-            from drunc.utils.utils import print_traceback
-            print_traceback()
-        else:
-            rprint(f'[yellow]{e}[/]\nUse [blue]--traceback[/] for more information')
+        from drunc.utils.utils import print_traceback
+        print_traceback()
         rprint(f'Exiting...')
 
         if context.pm_process and context.pm_process.is_alive():

--- a/src/drunc/broadcast/server/decorators.py
+++ b/src/drunc/broadcast/server/decorators.py
@@ -1,6 +1,8 @@
 from druncschema.request_response_pb2 import Response, ResponseFlag
 from druncschema.generic_pb2 import Stacktrace
 from drunc.utils.grpc_utils import pack_to_any
+import traceback
+
 def broadcasted(cmd):
 
     import functools
@@ -26,19 +28,19 @@ def broadcasted(cmd):
         try:
             log.debug('Executing wrapped function')
             ret = cmd(obj, request) # we strip the context here, no need for that anymore
-
         except DruncCommandException as e:
             # obj.interrupt_with_exception(
             #     exception = e,
             #     context = context
             # )
+            stack = traceback.format_exc().split("\n")
 
             return Response(
                 name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
-                        text = [str(e)]
+                        text = stack,
                     )
                 ),
                 flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
@@ -52,12 +54,13 @@ def broadcasted(cmd):
             #     stack = traceback.format_exc(),
             #     context = context
             # )
+            stack = traceback.format_exc().split("\n")
             return Response(
                 name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
-                        text = [str(e)]
+                        text = stack,
                     )
                 ),
                 flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
@@ -95,6 +98,7 @@ def async_broadcasted(cmd):
         try:
             log.debug('Executing wrapped function')
             async for a in cmd(obj, request):
+                raise RuntimeError("BLBABLABLAB")
                 yield a
 
         except DruncCommandException as e:
@@ -102,12 +106,14 @@ def async_broadcasted(cmd):
             #     exception = e,
             #     context = context
             # )
+            stack = traceback.format_exc().split("\n")
+
             yield Response(
                 name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
-                        text = [str(e)]
+                        text = stack,
                     )
                 ),
                 flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
@@ -122,12 +128,14 @@ def async_broadcasted(cmd):
             #     stack = traceback.format_exc(),
             #     context = context
             # )
+            stack = traceback.format_exc().split("\n")
+
             yield Response(
                 name = obj.name,
                 token = request.token,
                 data = pack_to_any(
                     Stacktrace(
-                        text = [str(e)]
+                        text = stack
                     )
                 ),
                 flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,

--- a/src/drunc/broadcast/server/decorators.py
+++ b/src/drunc/broadcast/server/decorators.py
@@ -98,7 +98,6 @@ def async_broadcasted(cmd):
         try:
             log.debug('Executing wrapped function')
             async for a in cmd(obj, request):
-                raise RuntimeError("BLBABLABLAB")
                 yield a
 
         except DruncCommandException as e:

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -286,6 +286,7 @@ class Controller(ControllerServicer):
             )
 
             from drunc.exceptions import DruncException
+            import traceback
 
             try:
                 response = child.propagate_command(command, command_data, token)
@@ -306,16 +307,14 @@ class Controller(ControllerServicer):
                 with response_lock:
                     from druncschema.request_response_pb2 import Response
                     from druncschema.generic_pb2 import PlainText, Stacktrace
+                    stack = traceback.format_exc().split("\n")
                     response_children.append(
                         Response(
                             name = child.name,
                             token = token,
                             data = pack_to_any(
                                 Stacktrace(
-                                    text=[
-                                        "Exception throw", # poor man's stack trace
-                                        str(e)
-                                    ]
+                                    text=stack
                                 )
                             ),
                             flag = ResponseFlag.DRUNC_EXCEPTION_THROWN,
@@ -326,16 +325,14 @@ class Controller(ControllerServicer):
                 with response_lock:
                     from druncschema.request_response_pb2 import Response
                     from druncschema.generic_pb2 import PlainText, Stacktrace
+                    stack = traceback.format_exc().split("\n")
                     response_children.append(
                         Response(
                             name = child.name,
                             token = token,
                             data = pack_to_any(
                                 Stacktrace(
-                                    text=[
-                                        "Exception throw", # poor man's stack trace
-                                        str(e)
-                                    ]
+                                    text=stack
                                 )
                             ),
                             flag = ResponseFlag.UNHANDLED_EXCEPTION_THROWN,

--- a/src/drunc/controller/controller_driver.py
+++ b/src/drunc/controller/controller_driver.py
@@ -19,42 +19,42 @@ class ControllerDriver(GRPCDriver):
         from druncschema.controller_pb2_grpc import ControllerStub
         return ControllerStub(channel)
 
-    def describe(self, rethrow=None) -> Description:
-        return self.send_command('describe', rethrow = rethrow, outformat = Description)
+    def describe(self) -> Description:
+        return self.send_command('describe', outformat = Description)
 
-    def describe_fsm(self, rethrow=None) -> Description:
+    def describe_fsm(self) -> Description:
         from druncschema.controller_pb2 import FSMCommandsDescription
-        return self.send_command('describe_fsm', rethrow = rethrow, outformat = FSMCommandsDescription)
+        return self.send_command('describe_fsm', outformat = FSMCommandsDescription)
 
-    def ls(self, rethrow=None) -> Description:
-        return self.send_command('ls', rethrow = rethrow, outformat = PlainTextVector)
+    def ls(self) -> Description:
+        return self.send_command('ls', outformat = PlainTextVector)
 
-    def get_status(self, rethrow=None) -> Description:
-        return self.send_command('get_status', rethrow = rethrow, outformat = Status)
+    def get_status(self) -> Description:
+        return self.send_command('get_status', outformat = Status)
 
-    def get_children_status(self, rethrow=None) -> Description:
-        return self.send_command('get_children_status', rethrow = rethrow, outformat = ChildrenStatus)
+    def get_children_status(self) -> Description:
+        return self.send_command('get_children_status', outformat = ChildrenStatus)
 
-    def take_control(self, rethrow=None) -> Description:
-        return self.send_command('take_control', rethrow = rethrow, outformat = PlainText)
+    def take_control(self) -> Description:
+        return self.send_command('take_control', outformat = PlainText)
 
     def who_is_in_charge(self, rethrow=None) -> Description:
-        return self.send_command('who_is_in_charge', rethrow = rethrow, outformat = PlainText)
+        return self.send_command('who_is_in_charge', outformat = PlainText)
 
-    def surrender_control(self, rethrow=None) -> Description:
-        return self.send_command('surrender_control', rethrow = rethrow)
+    def surrender_control(self) -> Description:
+        return self.send_command('surrender_control')
 
-    def execute_fsm_command(self, arguments, rethrow=None) -> Description:
+    def execute_fsm_command(self, arguments) -> Description:
         from druncschema.controller_pb2 import FSMCommandResponse
-        return self.send_command('execute_fsm_command', data = arguments, rethrow = rethrow, outformat = FSMCommandResponse)
+        return self.send_command('execute_fsm_command', data = arguments, outformat = FSMCommandResponse)
 
-    def include(self, arguments, rethrow=None) -> Description:
+    def include(self, arguments) -> Description:
         from druncschema.controller_pb2 import FSMCommandResponse
-        return self.send_command('include', data = arguments, rethrow = rethrow, outformat = PlainText)
+        return self.send_command('include', data = arguments, outformat = PlainText)
 
-    def exclude(self, arguments, rethrow=None) -> Description:
+    def exclude(self, arguments) -> Description:
         from druncschema.controller_pb2 import FSMCommandResponse
-        return self.send_command('exclude', data = arguments, rethrow = rethrow, outformat = PlainText)
+        return self.send_command('exclude', data = arguments, outformat = PlainText)
 
 
 

--- a/src/drunc/controller/interface/context.py
+++ b/src/drunc/controller/interface/context.py
@@ -6,10 +6,9 @@ class ControllerContext(ShellContext): # boilerplatefest
     status_receiver = None
     took_control = False
 
-    def reset(self, address:str=None, print_traceback:bool=False):
+    def reset(self, address:str=None):
         self.address = address
         super(ControllerContext, self)._reset(
-            print_traceback = print_traceback,
             name = 'controller',
             token_args = {},
             driver_args = {},

--- a/src/drunc/controller/interface/shell.py
+++ b/src/drunc/controller/interface/shell.py
@@ -8,16 +8,14 @@ from drunc.utils.utils import log_levels, validate_command_facility
 
 @click_shell.shell(prompt='drunc-controller > ', chain=True, hist_file=os.path.expanduser('~')+'/.drunc-controller-shell.history')
 @click.argument('controller-address', type=str, callback=validate_command_facility)
-@click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--log-level', type=click.Choice(log_levels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.pass_context
-def controller_shell(ctx, controller_address:str, log_level:str, traceback:bool) -> None:
+def controller_shell(ctx, controller_address:str, log_level:str) -> None:
     from drunc.utils.utils import update_log_level
 
     update_log_level(log_level)
 
     ctx.obj.reset(
-        print_traceback = traceback,
         address = controller_address,
     )
 

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -7,7 +7,7 @@ def controller_cleanup_wrapper(ctx):
         who = ''
         from drunc.utils.grpc_utils import unpack_any
         try:
-            who = ctx.get_driver('controller').who_is_in_charge(rethrow=True).text
+            who = ctx.get_driver('controller').who_is_in_charge().text
 
         except grpc.RpcError as e:
             dead = grpc.StatusCode.UNAVAILABLE == e.code()
@@ -23,7 +23,7 @@ def controller_cleanup_wrapper(ctx):
         if who == ctx.get_token().user_name and ctx.took_control:
             ctx.info('You are in control. Surrendering control.')
             try:
-                ctx.get_driver('controller').surrender_control(rethrow=True)
+                ctx.get_driver('controller').surrender_control()
             except Exception as e:
                 ctx.error('Could not surrender control.')
                 ctx.error(e)
@@ -64,7 +64,7 @@ def controller_setup(ctx, controller_address):
             progress.update(waiting, completed=time.time()-start_time)
 
             try:
-                desc = ctx.get_driver('controller').describe(rethrow=True).data
+                desc = ctx.get_driver('controller').describe().data
                 stored_exception = None
                 break
             except ServerUnreachable as e:
@@ -87,12 +87,12 @@ def controller_setup(ctx, controller_address):
 
     ctx.print('Connected to the controller')
 
-    children = ctx.get_driver('controller').ls(rethrow=False).data
+    children = ctx.get_driver('controller').ls().data
     ctx.print(f'{desc.name}.{desc.session}\'s children :family:: {children.text}')
 
     ctx.info(f'Taking control of the controller as {ctx.get_token()}')
     try:
-        ret = ctx.get_driver('controller').take_control(rethrow=True)
+        ret = ctx.get_driver('controller').take_control()
         from druncschema.request_response_pb2 import ResponseFlag
 
         if ret.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:

--- a/src/drunc/exceptions.py
+++ b/src/drunc/exceptions.py
@@ -18,3 +18,12 @@ class DruncCommandException(DruncException): # Exceptions that gets thrown when 
     def __init__(self, txt, grpc_error_code=code_pb2.INTERNAL, *args, **kwargs):
         self.grpc_error_code = grpc_error_code
         super().__init__(txt, *args, **kwargs)
+
+class DruncServerSideError(DruncException): # Exceptions that gets thrown when commands run
+    def __init__(self, error_txt, stack_txt, *args, **kwargs):
+        self.error_txt = error_txt
+        self.stack_txt = stack_txt
+        super().__init__(error_txt, stack_txt, *args, **kwargs)
+
+    def __str__(self):
+        return f'{self.stack_txt}\n{self.error_txt}'

--- a/src/drunc/exceptions.py
+++ b/src/drunc/exceptions.py
@@ -20,10 +20,11 @@ class DruncCommandException(DruncException): # Exceptions that gets thrown when 
         super().__init__(txt, *args, **kwargs)
 
 class DruncServerSideError(DruncException): # Exceptions that gets thrown when commands run
-    def __init__(self, error_txt, stack_txt, *args, **kwargs):
+    def __init__(self, error_txt, stack_txt, server_response, *args, **kwargs):
         self.error_txt = error_txt
         self.stack_txt = stack_txt
-        super().__init__(error_txt, stack_txt, *args, **kwargs)
+        self.server_response = server_response
+        super().__init__(error_txt, stack_txt, server_response, *args, **kwargs)
 
     def __str__(self):
-        return f'{self.stack_txt}\n{self.error_txt}'
+        return f'{self.stack_txt}\n{self.error_txt}\n{self.server_response}'

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -27,7 +27,6 @@ async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_confi
             user = user,
             session_name = session_name,
             log_level = log_level,
-            rethrow = traceback,
             override_logs = override_logs,
         )
         async for result in results:
@@ -55,7 +54,6 @@ async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_confi
 async def kill(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -> None:
     result = await obj.get_driver('process_manager').kill(
         query = query,
-        rethrow = traceback,
     )
 
     if not result: return
@@ -72,7 +70,6 @@ async def kill(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) ->
 async def flush(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -> None:
     result = await obj.get_driver('process_manager').flush(
         query = query,
-        rethrow = traceback,
     )
 
     if not result: return
@@ -102,7 +99,6 @@ async def logs(obj:ProcessManagerContext, how_far:int, grep:str, query:ProcessQu
 
     async for result in obj.get_driver('process_manager').logs(
         log_req,
-        rethrow = traceback,
         ):
         if not result: break
 
@@ -139,7 +135,6 @@ async def logs(obj:ProcessManagerContext, how_far:int, grep:str, query:ProcessQu
 async def restart(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -> None:
     result = await obj.get_driver('process_manager').restart(
         query = query,
-        rethrow = traceback,
     )
 
     if not result: return
@@ -156,7 +151,6 @@ async def restart(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool)
 async def ps(obj:ProcessManagerContext, query:ProcessQuery, long_format:bool, traceback:bool) -> None:
     results = await obj.get_driver('process_manager').ps(
         query=query,
-        rethrow = traceback,
     )
 
     if not results: return

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -1,7 +1,6 @@
 import click
 import getpass
 
-from drunc.utils.shell_utils import add_traceback_flag
 from drunc.utils.utils import run_coroutine, log_levels
 from drunc.process_manager.interface.cli_argument import add_query_options
 from drunc.process_manager.interface.context import ProcessManagerContext
@@ -13,12 +12,11 @@ from drunc.process_manager.interface.cli_argument import validate_conf_string
 @click.option('-u','--user', type=str, default=getpass.getuser(), help='Select the process of a particular user (default $USER)')
 @click.option('-l', '--log-level', type=click.Choice(log_levels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.option('--override-logs/--no-override-logs', default=True)
-@add_traceback_flag()
 @click.argument('boot-configuration', type=str, callback=validate_conf_string)
 @click.argument('session-name', type=str)
 @click.pass_obj
 @run_coroutine
-async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_configuration:str, log_level:str, traceback:bool, override_logs:bool) -> None:
+async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_configuration:str, log_level:str, override_logs:bool) -> None:
 
     from drunc.utils.shell_utils import InterruptedCommand
     try:
@@ -48,10 +46,9 @@ async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_confi
 
 @click.command('kill')
 @add_query_options(at_least_one=False)
-@add_traceback_flag()
 @click.pass_obj
 @run_coroutine
-async def kill(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -> None:
+async def kill(obj:ProcessManagerContext, query:ProcessQuery) -> None:
     result = await obj.get_driver('process_manager').kill(
         query = query,
     )
@@ -64,10 +61,9 @@ async def kill(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) ->
 
 @click.command('flush')
 @add_query_options(at_least_one=False, all_processes_by_default=True)
-@add_traceback_flag()
 @click.pass_obj
 @run_coroutine
-async def flush(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -> None:
+async def flush(obj:ProcessManagerContext, query:ProcessQuery) -> None:
     result = await obj.get_driver('process_manager').flush(
         query = query,
     )
@@ -82,10 +78,9 @@ async def flush(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -
 @add_query_options(at_least_one=True)
 @click.option('--how-far', type=int, default=100, help='How many lines one wants')
 @click.option('--grep', type=str, default=None)
-@add_traceback_flag()
 @click.pass_obj
 @run_coroutine
-async def logs(obj:ProcessManagerContext, how_far:int, grep:str, query:ProcessQuery, traceback:bool) -> None:
+async def logs(obj:ProcessManagerContext, how_far:int, grep:str, query:ProcessQuery) -> None:
     from druncschema.process_manager_pb2 import LogRequest, LogLine
 
     log_req = LogRequest(
@@ -129,10 +124,9 @@ async def logs(obj:ProcessManagerContext, how_far:int, grep:str, query:ProcessQu
 
 @click.command('restart')
 @add_query_options(at_least_one=True)
-@add_traceback_flag()
 @click.pass_obj
 @run_coroutine
-async def restart(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool) -> None:
+async def restart(obj:ProcessManagerContext, query:ProcessQuery) -> None:
     result = await obj.get_driver('process_manager').restart(
         query = query,
     )
@@ -145,10 +139,9 @@ async def restart(obj:ProcessManagerContext, query:ProcessQuery, traceback:bool)
 @click.command('ps')
 @add_query_options(at_least_one=False, all_processes_by_default=True)
 @click.option('-l','--long-format', is_flag=True, type=bool, default=False, help='Whether to have a long output')
-@add_traceback_flag()
 @click.pass_obj
 @run_coroutine
-async def ps(obj:ProcessManagerContext, query:ProcessQuery, long_format:bool, traceback:bool) -> None:
+async def ps(obj:ProcessManagerContext, query:ProcessQuery, long_format:bool) -> None:
     results = await obj.get_driver('process_manager').ps(
         query=query,
     )

--- a/src/drunc/process_manager/interface/context.py
+++ b/src/drunc/process_manager/interface/context.py
@@ -6,18 +6,15 @@ from drunc.utils.shell_utils import ShellContext, GRPCDriver
 class ProcessManagerContext(ShellContext): # boilerplatefest
     status_receiver = None
 
-    def reset(self, address:str=None, print_traceback:bool=False):
+    def reset(self, address:str=None):
         self.address = address
         super(ProcessManagerContext, self)._reset(
-            print_traceback = print_traceback,
             name = 'process_manager',
             token_args = {},
-            driver_args = {
-                'print_traceback': print_traceback
-            },
+            driver_args = {},
         )
 
-    def create_drivers(self, print_traceback, **kwargs) -> Mapping[str, GRPCDriver]:
+    def create_drivers(self, **kwargs) -> Mapping[str, GRPCDriver]:
         if not self.address:
             return {}
 
@@ -28,7 +25,6 @@ class ProcessManagerContext(ShellContext): # boilerplatefest
                 self.address,
                 self._token,
                 aio_channel = True,
-                rethrow_by_default = print_traceback
             )
         }
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -121,83 +121,64 @@ class ProcessManagerDriver(GRPCDriver):
             yield breq
 
 
-    async def boot(self, conf:str, user:str, session_name:str, log_level:str, rethrow=None, override_logs=True) -> ProcessInstance:
-        from drunc.exceptions import DruncShellException
-        if rethrow is None:
-            rethrow = self.rethrow_by_default
+    async def boot(self, conf:str, user:str, session_name:str, log_level:str, override_logs=True) -> ProcessInstance:
 
-        try:
-            async for br in self._convert_oks_to_boot_request(
-                oks_conf = conf,
-                user = user,
-                session = session_name,
-                # log_level = log_level
-                override_logs = override_logs,
-                ):
-                yield await self.send_command_aio(
-                    'boot',
-                    data = br,
-                    outformat = ProcessInstance,
-                    rethrow = rethrow,
-                )
-        except DruncShellException as e:
-            if rethrow:
-                raise e
-            else:
-                self._log.error(e)
-                from drunc.utils.shell_utils import InterruptedCommand
-                raise InterruptedCommand()
+        async for br in self._convert_oks_to_boot_request(
+            oks_conf = conf,
+            user = user,
+            session = session_name,
+            override_logs = override_logs,
+            ):
+            yield await self.send_command_aio(
+                'boot',
+                data = br,
+                outformat = ProcessInstance,
+            )
 
-
-    async def kill(self, query:ProcessQuery, rethrow=None) -> ProcessInstance:
+    async def kill(self, query:ProcessQuery) -> ProcessInstance:
         return await self.send_command_aio(
             'kill',
             data = query,
             outformat = ProcessInstanceList,
-            rethrow = rethrow,
         )
 
 
-    async def logs(self, req:LogRequest, rethrow=None) -> LogLine:
+    async def logs(self, req:LogRequest) -> LogLine:
         async for stream in self.send_command_for_aio(
             'logs',
             data = req,
             outformat = LogLine,
-            rethrow = rethrow,):
+            ):
             yield stream
 
 
-    async def ps(self, query:ProcessQuery, rethrow=None) -> ProcessInstanceList:
+    async def ps(self, query:ProcessQuery) -> ProcessInstanceList:
         return await self.send_command_aio(
             'ps',
             data = query,
             outformat = ProcessInstanceList,
-            rethrow = rethrow,
         )
 
 
 
-    async def flush(self, query:ProcessQuery, rethrow=None) -> ProcessInstanceList:
+    async def flush(self, query:ProcessQuery) -> ProcessInstanceList:
         return await self.send_command_aio(
             'flush',
             data = query,
             outformat = ProcessInstanceList,
-            rethrow = rethrow,
         )
 
 
-    async def restart(self, query:ProcessQuery, rethrow=None) -> ProcessInstance:
+    async def restart(self, query:ProcessQuery) -> ProcessInstance:
         return await self.send_command_aio(
             'restart',
             data = query,
             outformat = ProcessInstance,
-            rethrow = rethrow,
         )
 
 
-    async def describe(self, rethrow=None) -> Description:
+    async def describe(self) -> Description:
         return await self.send_command_aio(
             'describe',
             outformat = Description,
-            rethrow = rethrow,
         )

--- a/src/drunc/unified_shell/commands.py
+++ b/src/drunc/unified_shell/commands.py
@@ -1,7 +1,6 @@
 import click
 import getpass
 
-from drunc.utils.shell_utils import add_traceback_flag
 from drunc.utils.utils import run_coroutine, log_levels
 from drunc.process_manager.interface.context import ProcessManagerContext
 from drunc.process_manager.interface.cli_argument import validate_conf_string
@@ -10,12 +9,11 @@ from drunc.process_manager.interface.cli_argument import validate_conf_string
 @click.option('-u','--user', type=str, default=getpass.getuser(), help='Select the process of a particular user (default $USER)')
 @click.option('-l', '--log-level', type=click.Choice(log_levels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.option('--override-logs/--no-override-logs', default=True)
-@add_traceback_flag()
 @click.argument('boot-configuration', type=str, callback=validate_conf_string)
 @click.argument('session-name', type=str)
 @click.pass_obj
 @run_coroutine
-async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_configuration:str, log_level:str, traceback:bool, override_logs:bool) -> None:
+async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_configuration:str, log_level:str, override_logs:bool) -> None:
 
     from drunc.utils.shell_utils import InterruptedCommand
     try:
@@ -24,7 +22,6 @@ async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_confi
             user = user,
             session_name = session_name,
             log_level = log_level,
-            rethrow = traceback,
             override_logs = override_logs,
         )
         async for result in results:
@@ -37,16 +34,9 @@ async def boot(obj:ProcessManagerContext, user:str, session_name:str, boot_confi
     if controller_address:
         obj.print(f'Controller endpoint is \'{controller_address}\'')
         obj.print(f'Connecting this shell to it...')
-        from drunc.exceptions import DruncException
-        try:
-            obj.set_controller_driver(controller_address, obj.print_traceback)
-            from drunc.controller.interface.shell_utils import controller_setup
-            controller_setup(obj, controller_address)
-        except DruncException as de:
-            if traceback:
-                raise de
-            else:
-                obj.error(de)
+        obj.set_controller_driver(controller_address)
+        from drunc.controller.interface.shell_utils import controller_setup
+        controller_setup(obj, controller_address)
 
     else:
         obj.error(f'Could not understand where the controller is!')

--- a/src/drunc/unified_shell/context.py
+++ b/src/drunc/unified_shell/context.py
@@ -10,18 +10,15 @@ class UnifiedShellContext(ShellContext): # boilerplatefest
     address_pm = ''
     address_controller = ''
 
-    def reset(self, address_pm:str='', print_traceback:bool=False):
+    def reset(self, address_pm:str=''):
         self.address_pm = address_pm
         super(UnifiedShellContext, self)._reset(
-            print_traceback = print_traceback,
             name = 'unified',
             token_args = {},
-            driver_args = {
-                'print_traceback': print_traceback
-            },
+            driver_args = {},
         )
 
-    def create_drivers(self, print_traceback, **kwargs) -> Mapping[str, GRPCDriver]:
+    def create_drivers(self, **kwargs) -> Mapping[str, GRPCDriver]:
         ret = {}
 
         if self.address_pm != '':
@@ -30,7 +27,6 @@ class UnifiedShellContext(ShellContext): # boilerplatefest
                 self.address_pm,
                 self._token,
                 aio_channel = True,
-                rethrow_by_default = print_traceback
             )
 
         if self.address_controller != '':
@@ -39,12 +35,11 @@ class UnifiedShellContext(ShellContext): # boilerplatefest
                 self.address,
                 self._token,
                 aio_channel = False,
-                rethrow_by_default = print_traceback
             )
 
         return ret
 
-    def set_controller_driver(self, address_controller, print_traceback, **kwargs) -> None:
+    def set_controller_driver(self, address_controller, **kwargs) -> None:
         self.address_controller = address_controller
 
         from drunc.controller.controller_driver import ControllerDriver
@@ -53,7 +48,6 @@ class UnifiedShellContext(ShellContext): # boilerplatefest
             self.address_controller,
             self._token,
             aio_channel = False,
-            rethrow_by_default = print_traceback
         )
 
 

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -43,7 +43,7 @@ class DecodedResponse:
 
 
 class GRPCDriver:
-    def __init__(self, name:str, address:str, token:Token, aio_channel=False, rethrow_by_default=False):
+    def __init__(self, name:str, address:str, token:Token, aio_channel=False):
         import logging
         self._log = logging.getLogger(name)
         import grpc
@@ -63,7 +63,6 @@ class GRPCDriver:
         self.stub = self.create_stub(self.channel)
         self.token = Token()
         self.token.CopyFrom(token)
-        self.rethrow_by_default = rethrow_by_default
 
     @abc.abstractmethod
     def create_stub(self, channel):
@@ -88,50 +87,21 @@ class GRPCDriver:
                 token = token2
             )
 
-    def __handle_grpc_error(self, error, command, rethrow):
-        if rethrow is None:
-            rethrow = self.rethrow_by_default
+    def __handle_grpc_error(self, error, command):
+        from drunc.utils.grpc_utils import rethrow_if_unreachable_server#, interrupt_if_unreachable_server
+        rethrow_if_unreachable_server(error)
+        # else:
+        #     text = interrupt_if_unreachable_server(error)
+        #     if text:
+        #         self._log.error(text)
 
-        from drunc.utils.grpc_utils import rethrow_if_unreachable_server, interrupt_if_unreachable_server
-        if rethrow:
-            rethrow_if_unreachable_server(error)
-        else:
-            text = interrupt_if_unreachable_server(error)
-            if text:
-                self._log.error(text)
+        # if hasattr(error, 'details'): #ARGG asyncio gRPC so different from synchronous one!!
+        #     self._log.error(error.details())
 
-        # from grpc_status import rpc_status
-        # status = rpc_status.from_call(error)
-
-        # self._log.error(f'Error sending command "{command}" to stub')
-
-        # from druncschema.generic_pb2 import Stacktrace, PlainText
-        # from drunc.utils.grpc_utils import unpack_any
-
-        # if hasattr(status, 'details'):
-        #     for detail in status.details:
-        #         if detail.Is(Stacktrace.DESCRIPTOR):
-        #             stack = unpack_any(detail, Stacktrace)
-        #             text = ''
-        #             if rethrow:
-        #                 text += 'Stacktrace [bold red]on remote server![/]\n'
-        #                 for l in stack.text:
-        #                     text += l+"\n"
-        #             else:
-        #                 text += 'Error [bold red]on remote server![/]\n'+'\n'.join(stack.text[:-2])
-        #             self._log.error(text, extra={"markup": True})
-        #             return
-        #         elif detail.Is(PlainText.DESCRIPTOR):
-        #             txt = unpack_any(detail, PlainText)
-        #             self._log.error(txt)
-
-        if hasattr(error, 'details'): #ARGG asyncio gRPC so different from synchronous one!!
-            self._log.error(error.details())
-
-            # of course, right now asyncio servers are not able to reply with a stacktrace (yet)
-            # we just throw the client-side error and call it a day for now
-            if rethrow:
-                raise error
+        #     # of course, right now asyncio servers are not able to reply with a stacktrace (yet)
+        #     # we just throw the client-side error and call it a day for now
+        #     if rethrow:
+        #         raise error
 
     def handle_response(self, response, command, outformat):
         from druncschema.request_response_pb2 import ResponseFlag, Response
@@ -167,28 +137,34 @@ class GRPCDriver:
             from druncschema.generic_pb2 import Stacktrace, PlainText, PlainTextVector
             from drunc.utils.grpc_utils import unpack_any
 
+            error_txt = ''
+            stack_txt = None
+
             if response.data.Is(Stacktrace.DESCRIPTOR):
                 stack = unpack_any(response.data, Stacktrace)
-                txt = 'Stacktrace [bold red]on remote server![/]\n'
+                stack_txt = 'Stacktrace [bold red]on remote server![/]\n'
+                last_one = ""
                 for l in stack.text:
-                    txt += l+"\n"
-                self._log.error(txt, extra={"markup": True})
+                    stack_txt += l+"\n"
+                    if l != "":
+                        last_one = l
+                error_txt = last_one
 
             elif response.data.Is(PlainText.DESCRIPTOR):
                 txt = unpack_any(response.data, PlainText)
-                self._log.error(txt.text)
+                error_txt = txt.text
 
-            elif response.data.Is(PlainTextVector.DESCRIPTOR):
-                txt = unpack_any(response.data, PlainTextVector)
-                for t in txt.text:
-                    self._log.error(t)
+            if rethrow:
+                from drunc.exceptions import DruncServerSideError
+                raise DruncServerSideError(error_txt, stack_txt)
+
 
             dr.data = response.data
             for c_response in response.children:
                 dr.children.append(self.handle_response(c_response, command, outformat))
             return dr
 
-    def send_command(self, command:str, data=None, rethrow=None, outformat=None, decode_children=False):
+    def send_command(self, command:str, data=None, outformat=None, decode_children=False):
         import grpc
         if not self.stub:
             raise DruncShellException('No stub initialised')
@@ -200,11 +176,11 @@ class GRPCDriver:
         try:
             response = cmd(request)
         except grpc.RpcError as e:
-            self.__handle_grpc_error(e, command, rethrow = rethrow)
+            self.__handle_grpc_error(e, command)
         return self.handle_response(response, command, outformat)
 
 
-    async def send_command_aio(self, command:str, data=None, rethrow=None, outformat=None):
+    async def send_command_aio(self, command:str, data=None, outformat=None):
         import grpc
         if not self.stub:
             raise DruncShellException('No stub initialised')
@@ -217,11 +193,11 @@ class GRPCDriver:
             response = await cmd(request)
 
         except grpc.aio.AioRpcError as e:
-            self.__handle_grpc_error(e, command, rethrow = rethrow)
+            self.__handle_grpc_error(e, command)
         return self.handle_response(response, command, outformat)
 
 
-    async def send_command_for_aio(self, command:str, data=None, rethrow=None, outformat=None):
+    async def send_command_for_aio(self, command:str, data=None, outformat=None):
         import grpc
         if not self.stub:
             raise DruncShellException('No stub initialised')
@@ -235,13 +211,12 @@ class GRPCDriver:
                 yield self.handle_response(s, command, outformat)
 
         except grpc.aio.AioRpcError as e:
-            self.__handle_grpc_error(e, command, rethrow = rethrow)
+            self.__handle_grpc_error(e, command)
 
 
 
 class ShellContext:
-    def _reset(self, name:str, print_traceback:bool=False, token_args:dict={}, driver_args:dict={}):
-        self.print_traceback = print_traceback
+    def _reset(self, name:str, token_args:dict={}, driver_args:dict={}):
         from rich.console import Console
         self._console = Console()
         from logging import getLogger


### PR DESCRIPTION
This PR fixes some of the weirdness in exception handling:
 - Assumes that the user always wants a traceback, and remove all the`--traceback` shenanigans.
 - Server commands that throw error now return the full traceback as a `Stacktrace` message, or at least it tries to.
 - When the server side throws, the client reconstructs an exception (`DruncServerSideError`) from the `Stacktrace`, and, importantly, the message that was originally returned. This means that if one of the child controller throws after a command, the CLI client will still be able to understand what was ran on the other children (albeit not doing anything very interesting right now).
