### PR TITLE
Fixed oks_parser and configurator logic to skip disabled apps

### DIFF
--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -39,7 +39,7 @@ class ControllerConfHandler(ConfHandler):
         self.children = []
         self.data = self._grab_segment_conf_from_controller(self.data)
 
-    def get_children(self, init_token, without_excluded=False):
+    def get_children(self, init_token, enabled_only=True):
 
         if self.children != []:
             return self.get_children
@@ -51,9 +51,9 @@ class ControllerConfHandler(ConfHandler):
             session = self.db.get_dal(class_name="Session", uid=self.oks_key.session)
 
         except ImportError as e:
-            if without_excluded:
+            if enabled_only:
                 self.log.error('OKS was not set up, so configuration does not know about include/exclude. All the children nodes will be returned')
-                without_excluded=True
+                enabled_only=True
 
 
         self.log.debug(f'looping over children\n{self.data.segments}')
@@ -61,7 +61,7 @@ class ControllerConfHandler(ConfHandler):
         for segment in self.data.segments:
             self.log.debug(segment)
 
-            if without_excluded:
+            if enabled_only:
                 if confmodel.component_disabled(self.db._obj, session.id, segment.id):
                     continue
 
@@ -77,7 +77,7 @@ class ControllerConfHandler(ConfHandler):
         for app in self.data.applications:
             self.log.debug(app)
 
-            if without_excluded:
+            if enabled_only:
                 if confmodel.component_disabled(self.db._obj, session.id, app.id):
                     continue
 

--- a/src/drunc/fsm/actions/thread_pinning.py
+++ b/src/drunc/fsm/actions/thread_pinning.py
@@ -13,11 +13,11 @@ class ThreadPinning(FSMAction):
         self.conf_dict = {p.name: p.value for p in configuration.parameters}
 
     def pin_thread(self, thread_pinning_file, configuration, session):
-        from drunc.process_manager.oks_parser import process_segment
+        from drunc.process_manager.oks_parser import collect_apps
         import conffwk
         db = conffwk.Configuration(f"oksconflibs:{configuration}")
         session_dal = db.get_dal(class_name="Session", uid=session)
-        apps = process_segment(db, session_dal, session_dal.segment)
+        apps = collect_apps(db, session_dal, session_dal.segment)
 
         import os 
         rte=session_dal.rte_script

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -26,7 +26,7 @@ class ProcessManagerDriver(GRPCDriver):
 
 
     async def _convert_oks_to_boot_request(self, oks_conf, user, session, override_logs) -> BootRequest:
-        from drunc.process_manager.oks_parser import process_segment
+        from drunc.process_manager.oks_parser import collect_apps
         import conffwk
         from drunc.utils.configuration import find_configuration
         oks_conf = find_configuration(oks_conf)
@@ -36,7 +36,7 @@ class ProcessManagerDriver(GRPCDriver):
         db = conffwk.Configuration(f"oksconflibs:{oks_conf}")
         session_dal = db.get_dal(class_name="Session", uid=session)
 
-        apps = process_segment(db, session_dal, session_dal.segment)
+        apps = collect_apps(db, session_dal, session_dal.segment)
 
         def get_controller_address(top_controller_conf):
             service_id = top_controller_conf.id + "_control"

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -229,7 +229,7 @@ class SSHProcessManager(ProcessManager):
                     session = meta.session,
                     process = self.process_store[uuid]
                 )
-                self._log.info(f'Command:\nssh \'{" ".join(arguments)}\'')
+                self._log.debug(f'Command:\nssh \'{" ".join(arguments)}\'')
                 break
 
             except Exception as e:


### PR DESCRIPTION
Drunc seemed to boot and configure disabled applications.
The cause was tracked back to 
- `oks_parser.process_segment`: correctly detected disabled apps but did not discard them. A `continue` statement was missing. Added.
- `configuration`: The `ControllerConfHandler.get_children` method defaulted to returning all children, not just the enabled ones. (`get_children` is used by `Controller` to determine what apps to control). Flipped the default to returning only enabled apps. This should be safe for now since `Controller` is the only user

Also renamed `oks_parser.process_*` methods to `oks_parser.collect_*`. `process` seemed too generic and hard to interpret.