### PR TITLE
Fix disabled segment handling

### DIFF
--- a/src/drunc/process_manager/oks_parser.py
+++ b/src/drunc/process_manager/oks_parser.py
@@ -55,6 +55,7 @@ def collect_apps(db, session, segment):
   for seg in segment.segments:
     if confmodel.component_disabled(db._obj, session.id, seg.id):
       log.info(f'Ignoring segment \'{seg.id}\' as it is disabled')
+      continue
 
     for app in collect_apps(db, session, seg):
       apps.append(app)


### PR DESCRIPTION
Disabled segments were logged as ignored but processed anyway. Added a continue statement after the log message