### PR TITLE
Added standard process manager configs to setuptools package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description = file: docs/README.md
 long_description_content_type = text/markdown
 
 [options]
-packages = find:
+packages = find_namespace:
 package_dir = =src
 include_package_data = true
 python_requires = >= 3.6
@@ -16,8 +16,9 @@ python_requires = >= 3.6
 where = src
 include_package_data = true
 
-# [options.data_files]
-# * = ['confdata/*', 'webuidata/*']
+[options.package_data]
+drunc.data = *
+drunc.data.process_manager = *
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="drunc",
-    package_data={
-        'drunc': []
-    },
     install_requires=[
         "click",
         "click_shell",

--- a/src/drunc/data/process_manager/k8s.json
+++ b/src/drunc/data/process_manager/k8s.json
@@ -1,0 +1,15 @@
+{
+    "type": "k8s",
+    "name": "K8sProcessManager",
+    "command_address": "0.0.0.0:10054",
+
+    "authoriser": {
+        "type": "dummy"
+    },
+
+    "broadcaster": {
+        "type": "kafka",
+        "kafka_address": "localhost:30092",
+        "publish_timeout": 2
+    }
+}

--- a/src/drunc/data/process_manager/ssh-CERN-kafka.json
+++ b/src/drunc/data/process_manager/ssh-CERN-kafka.json
@@ -1,0 +1,16 @@
+{
+    "type": "ssh",
+    "name": "SSHProcessManager",
+    "command_address": "localhost:0",
+    "kill_timeout": 0.5,
+
+    "authoriser": {
+        "type": "dummy"
+    },
+
+    "broadcaster": {
+        "type": "kafka",
+        "kafka_address": "monkafka.cern.ch:30092",
+        "publish_timeout": 2
+    }
+}

--- a/src/drunc/data/process_manager/ssh-kafka.json
+++ b/src/drunc/data/process_manager/ssh-kafka.json
@@ -1,0 +1,9 @@
+{
+    "type": "ssh",
+    "name": "SSHProcessManager",
+    "command_address": "0.0.0.0:10054",
+
+    "authoriser": {
+        "type": "dummy"
+    }
+}

--- a/src/drunc/data/process_manager/ssh-standalone.json
+++ b/src/drunc/data/process_manager/ssh-standalone.json
@@ -1,0 +1,9 @@
+{
+    "type": "ssh",
+    "name": "SSHProcessManager",
+    "command_address": "0.0.0.0:10054",
+
+    "authoriser": {
+        "type": "dummy"
+    }
+}

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -22,6 +22,21 @@ def unified_shell(ctx, process_manager_configuration:str, log_level:str) -> None
     ready_event = mp.Event()
     port = mp.Value('i', 0)
 
+    # Check if process_manager_configuration is a packaged config
+    from urllib.parse import urlparse
+    if urlparse(process_manager_configuration).scheme == "":
+        # Make the configuration name finding easier
+        if process_manager_configuration.find(".json") == -1:
+            process_manager_configuration+=".json"
+
+        # Check if the configuration is packaged. If it is, use it
+        from importlib.resources import path
+        from os import listdir
+        if process_manager_configuration in listdir(path('drunc.data.process_manager', '')):
+            process_manager_configuration = "file://" + str(path('drunc.data.process_manager', '')) + '/' + process_manager_configuration
+
+        # Exception not raised here as CLI_to_ConfTypes handles it.
+
     ctx.obj.pm_process = mp.Process(
         target = run_pm,
         kwargs = {


### PR DESCRIPTION
Default process manager configurations have been added to the setuptools drunc package to allow using them w/o having to keep a local drunc copy.

See #103 