### PR TITLE
Add support for starting and cleaning terminating infrastructure applications

### DIFF
--- a/src/drunc/controller/interface/controller.py
+++ b/src/drunc/controller/interface/controller.py
@@ -76,7 +76,7 @@ def controller_cli(configuration:str, command_facility:str, name:str, session:st
         os.kill(os.getpid(), signal.SIGQUIT)
 
 
-    terminate_signals = [signal.SIGHUP, signal.SIGPIPE]
+    terminate_signals = [signal.SIGHUP, signal.SIGTERM, signal.SIGPIPE]
     # terminate_signals = set(signal.Signals) - set([signal.SIGKILL, signal.SIGSTOP])
     for sig in terminate_signals:
         signal.signal(sig, shutdown)

--- a/src/drunc/process_manager/oks_parser.py
+++ b/src/drunc/process_manager/oks_parser.py
@@ -36,7 +36,7 @@ def collect_apps(db, session, segment):
   # Add controller for this segment to list of apps
   controller = segment.controller
   appenv = defenv
-  collect_variables(controller.applicationEnvironment, appenv)
+  collect_variables(controller.application_environment, appenv)
   from drunc.process_manager.configuration import get_cla
   host = controller.runs_on.runs_on.id
 
@@ -76,7 +76,7 @@ def collect_apps(db, session, segment):
     appenv = defenv
 
     # Override with any app specific environment from Application
-    collect_variables(app.applicationEnvironment, appenv)
+    collect_variables(app.application_environment, appenv)
 
     host = app.runs_on.runs_on.id
     log.warn(app.id)

--- a/src/drunc/process_manager/oks_parser.py
+++ b/src/drunc/process_manager/oks_parser.py
@@ -98,8 +98,6 @@ def collect_apps(db, session, segment) -> List[Dict]:
     collect_variables(app.application_environment, appenv)
 
     host = app.runs_on.runs_on.id
-    log.warn(app.id)
-    log.warn(app)
     apps.append(
       {
         "name": app.id,
@@ -123,7 +121,7 @@ def collect_infra_apps(session) -> List[Dict]:
   
   """
   import logging
-  log = logging.getLogger('collect_apps')
+  log = logging.getLogger('collect_infra_apps')
 
   defenv = {}
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -26,7 +26,7 @@ class ProcessManagerDriver(GRPCDriver):
 
 
     async def _convert_oks_to_boot_request(self, oks_conf, user, session, override_logs) -> BootRequest:
-        from drunc.process_manager.oks_parser import collect_apps
+        from drunc.process_manager.oks_parser import collect_apps, collect_infra_apps
         import conffwk
         from drunc.utils.configuration import find_configuration
         oks_conf = find_configuration(oks_conf)
@@ -37,6 +37,9 @@ class ProcessManagerDriver(GRPCDriver):
         session_dal = db.get_dal(class_name="Session", uid=session)
 
         apps = collect_apps(db, session_dal, session_dal.segment)
+        iapps = collect_infra_apps(session_dal)
+
+        apps += iapps
 
         def get_controller_address(top_controller_conf):
             service_id = top_controller_conf.id + "_control"
@@ -55,6 +58,8 @@ class ProcessManagerDriver(GRPCDriver):
         self._log.debug(f"{apps=}")
         import os
         pwd = os.getcwd()
+
+            
 
         for app in apps:
             host = app['restriction']
@@ -84,12 +89,12 @@ class ProcessManagerDriver(GRPCDriver):
             else:
                 self._log.warning(f'RTE was not supplied in the OKS configuration or in the environment, running without it')
 
-            executable_and_arguments.append(
-                ProcessDescription.ExecAndArgs(
-                    exec = "env",
-                    args = []
-                )
-            )
+            # executable_and_arguments.append(
+            #     ProcessDescription.ExecAndArgs(
+            #         exec = "env",
+            #         args = []
+            #     )
+            # )
 
             executable_and_arguments.append(ProcessDescription.ExecAndArgs(
                 exec=exe,

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -37,9 +37,9 @@ class ProcessManagerDriver(GRPCDriver):
         session_dal = db.get_dal(class_name="Session", uid=session)
 
         apps = collect_apps(db, session_dal, session_dal.segment)
-        iapps = collect_infra_apps(session_dal)
-
-        apps += iapps
+        infra_apps = collect_infra_apps(session_dal)
+        
+        apps += infra_apps
 
         def get_controller_address(top_controller_conf):
             service_id = top_controller_conf.id + "_control"
@@ -58,8 +58,6 @@ class ProcessManagerDriver(GRPCDriver):
         self._log.debug(f"{apps=}")
         import os
         pwd = os.getcwd()
-
-            
 
         for app in apps:
             host = app['restriction']

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -212,6 +212,7 @@ class SSHProcessManager(ProcessManager):
                     cmd = cmd[:-1]
 
                 arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no", f'{{ {cmd} ; }} &> {log_file}']
+                self._log.warning(f"{arguments}")
                 # arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no", f'{{ {cmd} ; }} > >(tee -a {log_file}) 2> >(tee -a {log_file} >&2)']
                 # I'm gonna bail now and read that log file, anyway, it's probably better that heavy logger applications don't clog up the process manager CPU.
                 self.process_store[uuid] = self.ssh (


### PR DESCRIPTION
- Added infrastructure application to the list of apps started by process manager (likely to be revisited in the future)
- Added a default EXIT trap to issue an additional SIGTERM to children to applications started with the ssh_process managet to ensure clean termination of processes (gunicorn workers in particular)