### PR TITLE
Rolling back the changes that caused the zombie controller apocalypse

### DIFF
--- a/src/drunc/controller/interface/controller.py
+++ b/src/drunc/controller/interface/controller.py
@@ -76,7 +76,7 @@ def controller_cli(configuration:str, command_facility:str, name:str, session:st
         os.kill(os.getpid(), signal.SIGQUIT)
 
 
-    terminate_signals = [signal.SIGHUP, signal.SIGTERM, signal.SIGPIPE]
+    terminate_signals = [signal.SIGHUP, signal.SIGPIPE]
     # terminate_signals = set(signal.Signals) - set([signal.SIGKILL, signal.SIGSTOP])
     for sig in terminate_signals:
         signal.signal(sig, shutdown)

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -199,9 +199,6 @@ class SSHProcessManager(ProcessManager):
                 
                 # Add EXIT trap and use it kill child processes on the ssh client side when the ssh connection is closed
                 cmd =f'echo "SSHPM: Starting process $$ on host $HOSTNAME as user $USER";'
-                # cmd +='trap "kill -SIGTERM -- -$$" EXIT;'
-                cmd +='trap "pkill -SIGINT -g $$" EXIT;'
-                # cmd = ''
 
                 # Add exported environment variables
                 cmd_env = ';'.join([ f"export {n}=\"{v}\"" for n,v in env_var.items()])


### PR DESCRIPTION
- No default signal trap
- No trapping of sigterm in controllers