### PR TITLE
No longer attempting to format arguments when none are present

### DIFF
--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -97,6 +97,8 @@ def controller_setup(ctx, controller_address):
 
         if ret.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
             ctx.info('You are in control.')
+            from rich import print as rprint
+            rprint(f"Current FSM status is [green]initial[/green]. Available transitions are [green]conf terminate[/green]")
             ctx.took_control = True
         else:
             ctx.warn(f'You are NOT in control.')
@@ -159,6 +161,9 @@ def validate_and_format_fsm_arguments(arguments:dict, command_arguments:list[Arg
     out_dict = {}
 
     arguments_left = arguments
+    # If the argument dict is empty, don't bother trying to read it
+    if not arguments:
+        return
 
     for argument_desc in command_arguments:
         aname = argument_desc.name

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -1,3 +1,4 @@
+from rich import print
 
 def controller_cleanup_wrapper(ctx):
     def controller_cleanup():
@@ -97,7 +98,6 @@ def controller_setup(ctx, controller_address):
 
         if ret.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
             ctx.info('You are in control.')
-            from rich import print
             print(f"Current FSM status is [green]initial[/green]. Available transitions are [green]conf terminate[/green]")
             ctx.took_control = True
         else:

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -97,8 +97,8 @@ def controller_setup(ctx, controller_address):
 
         if ret.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
             ctx.info('You are in control.')
-            from rich import print as rprint
-            rprint(f"Current FSM status is [green]initial[/green]. Available transitions are [green]conf terminate[/green]")
+            from rich import print
+            print(f"Current FSM status is [green]initial[/green]. Available transitions are [green]conf terminate[/green]")
             ctx.took_control = True
         else:
             ctx.warn(f'You are NOT in control.')


### PR DESCRIPTION
The hard coded `rprint` in line 101 prints the options when running `boot`. This is hard coded for now, will be imported from the controller driver in the next release. Issue created - https://github.com/DUNE-DAQ/drunc/issues/148
The corrections in line 164-166 remove the `'NoneType' object has no attribute 'get'` issues observed today.