### PR TITLE
Fixing `terminate`

### DIFF
--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -68,6 +68,16 @@ async def dummy_boot(obj:ProcessManagerContext, user:str, n_processes:int, sleep
         return
 
 
+@click.command('terminate')
+@add_query_options(at_least_one=False)
+@click.pass_obj
+@run_coroutine
+async def terminate(obj:ProcessManagerContext, query:ProcessQuery) -> None:
+    result = await obj.get_driver('process_manager').terminate(
+        query = query,
+    )
+
+    return
 
 @click.command('kill')
 @add_query_options(at_least_one=False)

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -5,7 +5,7 @@ from drunc.utils.utils import run_coroutine, log_levels
 from drunc.process_manager.interface.cli_argument import add_query_options
 from drunc.process_manager.interface.context import ProcessManagerContext
 
-from druncschema.process_manager_pb2 import ProcessQuery
+from druncschema.process_manager_pb2 import ProcessQuery, ProcessInstanceList
 from drunc.process_manager.interface.cli_argument import validate_conf_string
 
 @click.command('boot')
@@ -76,8 +76,10 @@ async def terminate(obj:ProcessManagerContext, query:ProcessQuery) -> None:
     result = await obj.get_driver('process_manager').terminate(
         query = query,
     )
+    if not result: return
 
-    return
+    from drunc.process_manager.utils import tabulate_process_instance_list
+    obj.print(tabulate_process_instance_list(result.data, 'Terminated process', False))
 
 @click.command('kill')
 @add_query_options(at_least_one=False)

--- a/src/drunc/process_manager/interface/shell.py
+++ b/src/drunc/process_manager/interface/shell.py
@@ -36,8 +36,9 @@ def process_manager_shell(ctx, process_manager_address:str, log_level:str) -> No
 
     ctx.call_on_close(cleanup)
 
-    from drunc.process_manager.interface.commands import boot, kill, flush, logs, restart, ps, dummy_boot
+    from drunc.process_manager.interface.commands import boot, terminate, kill, flush, logs, restart, ps, dummy_boot
     ctx.command.add_command(boot, 'boot')
+    ctx.command.add_command(terminate, 'terminate')
     ctx.command.add_command(kill, 'kill')
     ctx.command.add_command(flush, 'flush')
     ctx.command.add_command(logs, 'logs')

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -97,6 +97,13 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
             ),
 
             CommandDescription(
+                name = 'terminate',
+                data_type = ['process_manager_pb2.ProcessQuery'],
+                help = 'Kill all processes in session.',
+                return_type = 'process_manager_pb2.ProcessInstance'
+            ),
+
+            CommandDescription(
                 name = 'flush',
                 data_type = ['process_manager_pb2.ProcessQuery'],
                 help = 'Remove the processes from the list that are dead',
@@ -183,6 +190,36 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 children = [],
             )
 
+
+    @abc.abstractmethod
+    def _terminate_impl(self, q:ProcessQuery) -> ProcessInstanceList:
+        raise NotImplementedError
+
+    # ORDER MATTERS!
+    @broadcasted # outer most wrapper 1st step
+    @authentified_and_authorised(
+        action=ActionType.DELETE,
+        system=SystemType.PROCESS_MANAGER
+    ) # 2nd step
+    @unpack_request_data_to(ProcessQuery) # 3rd step
+    def terminate(self, q:ProcessQuery) -> Response:
+        try:
+            resp = self._terminate_impl(q)
+            return Response(
+                name = self.name,
+                token = None,
+                data = pack_to_any(resp),
+                flag = ResponseFlag.EXECUTED_SUCCESSFULLY,
+                children = [],
+            )
+        except NotImplementedError:
+            return Response(
+                name = self.name,
+                token = None,
+                data = pack_to_any(resp),
+                flag = ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
+                children = [],
+            )
 
     @abc.abstractmethod
     def _restart_impl(self, q:ProcessQuery) -> ProcessInstanceList:

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -100,7 +100,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 name = 'terminate',
                 data_type = ['process_manager_pb2.ProcessQuery'],
                 help = 'Kill all processes in session.',
-                return_type = 'process_manager_pb2.ProcessInstance'
+                return_type = 'process_manager_pb2.ProcessInstanceList'
             ),
 
             CommandDescription(
@@ -130,16 +130,16 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
             btype = BroadcastType.SERVER_READY
         )
 
-    def terminate(self):
-        self.broadcast(
-            message='over_and_out',
-            btype=BroadcastType.SERVER_SHUTDOWN
-        )
-        self._terminate()
+    # def terminate(self):
+    #     self.broadcast(
+    #         message='over_and_out',
+    #         btype=BroadcastType.SERVER_SHUTDOWN
+    #     )
+    #     self._terminate()
 
-    @abc.abstractmethod
-    def _terminate(self):
-        pass
+    # @abc.abstractmethod
+    # def _terminate(self):
+    #     pass
 
     '''
     A couple of simple pass-through functions to the broadcasting service

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -178,7 +178,7 @@ class ProcessManagerDriver(GRPCDriver):
                 outformat = ProcessInstance,
             )
 
-    async def terminate(self, query:ProcessQuery) -> ProcessInstance:
+    async def terminate(self, query:ProcessQuery) -> ProcessInstanceList:
         return await self.send_command_aio(
             'terminate',
             data = query,

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -178,6 +178,13 @@ class ProcessManagerDriver(GRPCDriver):
                 outformat = ProcessInstance,
             )
 
+    async def terminate(self, query:ProcessQuery) -> ProcessInstance:
+        return await self.send_command_aio(
+            'terminate',
+            data = query,
+            outformat = ProcessInstanceList,
+        )
+
     async def kill(self, query:ProcessQuery) -> ProcessInstance:
         return await self.send_command_aio(
             'kill',

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -85,9 +85,9 @@ class SSHProcessManager(ProcessManager):
             if process.is_alive():
                 import signal
                 sequence = [
-                    signal.SIGINT,
-                    signal.SIGKILL,
-                    signal.SIGQUIT,
+                    # signal.SIGINT, # In appfwk/daq_application, SIGQUIT makes the run marker false and quits the loop, killing the application. SIGINT not needed.
+                    signal.SIGQUIT, 
+                    signal.SIGKILL, # Kept as nuclear option
                 ]
                 for sig in sequence:
                     if not process.is_alive():

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -78,19 +78,66 @@ class SSHProcessManager(ProcessManager):
         from sh import Command
         self.ssh = Command('/usr/bin/ssh')
 
-    def _terminate(self):
-        self._log.info('Terminating')
+    def kill_processes(self, uuids:list) -> ProcessInstanceList:
+        ret = []
+        for uuid in uuids:
+            process = self.process_store[uuid]
+            if process.is_alive():
+                import signal
+                sequence = [
+                    signal.SIGINT,
+                    signal.SIGKILL,
+                    signal.SIGQUIT,
+                ]
+                for sig in sequence:
+                    if not process.is_alive():
+                        break
+                    self.log.info(f'Sending signal \'{str(sig)}\' to \'{uuid}\'')
+                    process.signal_group(sig) # TODO grab this from the inputs
+                    if not process.is_alive():
+                        break
+                    from time import sleep
+                    sleep(self.configuration.data.kill_timeout)
+            pd = ProcessDescription()
+            pd.CopyFrom(self.boot_request[uuid].process_description)
+            pr = ProcessRestriction()
+            pr.CopyFrom(self.boot_request[uuid].process_restriction)
+            pu = ProcessUUID(uuid= uuid)
 
+            return_code = None
+            if not self.process_store[uuid].is_alive():
+                try:
+                    return_code = self.process_store[uuid].exit_code
+                except Exception as e:
+                    pass
+
+            ret += [
+                ProcessInstance(
+                    process_description = pd,
+                    process_restriction = pr,
+                    status_code = ProcessInstance.StatusCode.DEAD,
+                    return_code = return_code,
+                    uuid = pu
+                )
+            ]
+            del self.process_store[uuid]
+
+        pil = ProcessInstanceList(
+            values=ret
+        )
+        return pil
+
+
+    def _terminate_impl(self, query:ProcessQuery) -> ProcessInstanceList:
+        self._log.info('Terminating')
         if self.process_store:
             self._log.warning('Killing all the known processes before exiting')
+            uuids = [uuid for uuid, process in self.process_store.items()]
+            return self.kill_processes(uuids)
         else:
             self._log.info('No known process to kill before exiting')
+            return ProcessInstanceList()
 
-        for uuid, process in self.process_store.items():
-            if not process.is_alive():
-                continue
-            self._log.warning(f'Killing {self.boot_request[uuid].process_description.metadata.name}')
-            process.terminate()
 
 
     async def _logs_impl(self, log_request:LogRequest) -> LogLine:
@@ -366,51 +413,11 @@ class SSHProcessManager(ProcessManager):
         return ret
 
     def _kill_impl(self, query:ProcessQuery) -> ProcessInstanceList:
-        uuids = self._get_process_uid(query)
-        ret = []
-        for uuid in uuids:
-            process = self.process_store[uuid]
-            if process.is_alive():
-                import signal
-                sequence = [
-                    signal.SIGINT,
-                    signal.SIGKILL,
-                    signal.SIGQUIT,
-                ]
-                for sig in sequence:
-                    if not process.is_alive():
-                        break
-                    self.log.info(f'Sending signal \'{str(sig)}\' to \'{uuid}\'')
-                    process.signal_group(sig) # TODO grab this from the inputs
-                    if not process.is_alive():
-                        break
-                    from time import sleep
-                    sleep(self.configuration.data.kill_timeout)
-            pd = ProcessDescription()
-            pd.CopyFrom(self.boot_request[uuid].process_description)
-            pr = ProcessRestriction()
-            pr.CopyFrom(self.boot_request[uuid].process_restriction)
-            pu = ProcessUUID(uuid= uuid)
-
-            return_code = None
-            if not self.process_store[uuid].is_alive():
-                try:
-                    return_code = self.process_store[uuid].exit_code
-                except Exception as e:
-                    pass
-
-            ret += [
-                ProcessInstance(
-                    process_description = pd,
-                    process_restriction = pr,
-                    status_code = ProcessInstance.StatusCode.DEAD,
-                    return_code = return_code,
-                    uuid = pu
-                )
-            ]
-            del self.process_store[uuid]
-
-        pil = ProcessInstanceList(
-            values=ret
-        )
-        return pil
+        self._log.info('Killing')
+        if self.process_store:
+            self._log.warning('Killing all the known processes before exiting')
+            uuids = self._get_process_uid(query)
+            return self.kill_processes(uuids)
+        else:
+            self._log.info('No known process to kill before exiting')
+            return ProcessInstanceList()

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -108,8 +108,9 @@ def unified_shell(ctx, process_manager_configuration:str, log_level:str) -> None
     from drunc.unified_shell.commands import boot
     ctx.command.add_command(boot, 'boot')
 
-    from drunc.process_manager.interface.commands import kill, flush, logs, restart, ps, dummy_boot
+    from drunc.process_manager.interface.commands import kill, terminate, flush, logs, restart, ps, dummy_boot
     ctx.command.add_command(kill, 'kill')
+    ctx.command.add_command(terminate, 'terminate')
     ctx.command.add_command(flush, 'flush')
     ctx.command.add_command(logs, 'logs')
     ctx.command.add_command(restart, 'restart')


### PR DESCRIPTION
`terminate` existed but was poorly formatted and not actually running. Requires `druncschema` PR#[24](https://github.com/DUNE-DAQ/druncschema/pull/24). Notes
 - `terminate` has been implemented as a `process_manager` command. This has been chosen as `controller` does not otherwise have any functions that affect the process.
 - Known issue - as this is a `process_manager` command, no current restriction is placed on what `fsm` stage this can be executed from. This is currently the same as `kill --session <session_name>`. This has been raised as an issue, but wanted to include this command for integration tests
 - Added `terminate` to `unified-shell`
 - With this PR, `terminate` passes around an empty `ProcessQuery`. This does not affect the functionality and will be removed, but as above wanted for int test.