### PR TITLE
Correcting mislabelled FSM commands

### DIFF
--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -5,8 +5,6 @@ from druncschema.broadcast_pb2 import BroadcastType
 from druncschema.controller_pb2_grpc import ControllerServicer
 from druncschema.controller_pb2 import Status, ChildrenStatus
 
-from drunc.broadcast.server.broadcast_sender import BroadcastSender
-
 from drunc.controller.children_interface.child_node import ChildNode
 from drunc.controller.stateful_node import StatefulNode
 from drunc.broadcast.server.broadcast_sender import BroadcastSender

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -98,7 +98,7 @@ def controller_setup(ctx, controller_address):
 
         if ret.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
             ctx.info('You are in control.')
-            print(f"Current FSM status is [green]initial[/green]. Available transitions are [green]conf terminate[/green]")
+            print(f"Current FSM status is [green]initial[/green]. Available transitions are [green]conf[/green]")
             ctx.took_control = True
         else:
             ctx.warn(f'You are NOT in control.')


### PR DESCRIPTION
The `FSM` model has been reviewed. `terminate` is a `process_manager` command and should not be present in `decribe --command fsm`