### PR TITLE
Catch controller commands before boot

### DIFF
--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -265,11 +265,15 @@ class ShellContext:
         self._drivers[name] = driver
 
     def get_driver(self, name:str=None) -> GRPCDriver:
-        if name:
-            return self._drivers[name]
-        elif len(self._drivers)>1:
-            raise DruncShellException(f'More than one driver in this context')
-        return list(self._drivers.values())[0]
+        try:
+            if name:
+                return self._drivers[name]
+            elif len(self._drivers)>1:
+                raise DruncShellException(f'More than one driver in this context')
+            return list(self._drivers.values())[0]
+        except KeyError:
+            self._log.error(f'FSM Commands cannot be sent until the Session is booted')
+            raise SystemExit(1)
 
     def get_token(self) -> Token:
         return self._token

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -273,7 +273,7 @@ class ShellContext:
             return list(self._drivers.values())[0]
         except KeyError:
             self._log.error(f'FSM Commands cannot be sent until the Session is booted')
-            raise SystemExit(1)
+            raise SystemExit(1) # used to avoid having to catch multiple Attribute errors when this function gets called 
 
     def get_token(self) -> Token:
         return self._token


### PR DESCRIPTION
#175 
Caught a key error that craetes a stacktrace when trying to run an FSM command before the session is booted.

Catches KeyError, raises an error that informs user that FSM Commands cannot be sent until the Session is booted and finally stops running completely