### PR TITLE
Pawel plesniak/batch mode

### DIFF
--- a/src/drunc/controller/decorators.py
+++ b/src/drunc/controller/decorators.py
@@ -7,8 +7,9 @@ def in_control(cmd):
     def wrap(obj, request):
         if not obj.actor.token_is_current_actor(request.token):
             from druncschema.request_response_pb2 import Response
+            from druncschema.generic_pb2 import PlainText
             return Response(
-                name = self.obj.name,
+                name = obj.name,
                 token = request.token,
                 data = PlainText(
                     text = f"User {request.token.user_name} is not in control of {obj.__class__.__name__}",

--- a/src/drunc/controller/exceptions.py
+++ b/src/drunc/controller/exceptions.py
@@ -14,3 +14,9 @@ class OtherUserAlreadyInControl(ControllerException):
 
 class MalformedMessage(ControllerException):
     pass
+
+class MalformedCommand(ControllerException):
+    pass
+
+class MalformedCommandArgument(ControllerException):
+    pass

--- a/src/drunc/controller/interface/commands.py
+++ b/src/drunc/controller/interface/commands.py
@@ -176,29 +176,29 @@ def fsm(obj:ControllerContext, fsm_command:str) -> None:
 
     def split_FSM_args(obj:ControllerContext, passed_commands:tuple):
         # Note this is a placeholder - want to get this from OKS.
-        available_commands = ["conf", "start", "enable_triggers", "disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "start_run", "stop_run", "shutdown"]
-        available_command_mandatory_args = [[], ["run_number"], [], [], [], [], []]
+        available_commands = ["conf", "start", "enable_triggers", "disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "scrap", "start_run", "stop_run", "shutdown"]
+        available_command_mandatory_args = [[], ["run_number"], [], [], [], [], [], [], ["run_number"], [], []]
+        available_sequences = ["start_run", "stop_run", "shutdown"]
+        available_sequence_commands = [["conf", "start", "enable_triggers"], ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop"], ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "scrap"]]
         available_command_opt_args = []
         available_args = ["run_number"]
 
         # Get the index of all the commands in the command str
         command_list = [command for command in passed_commands if command in available_commands]
         if len(command_list) == 0:
-                if len(passed_commands) == 1:
-                    obj.print(f"The passed command [red]{passed_commands}[/red] was not understood.")    
-                else:
-                    obj.print(f"None of the passed arguments were correctly identified.")
-                raise SystemExit(1)
-
-        command_index = [passed_commands.index(command) for command in command_list]
+            if len(passed_commands) == 1:
+                obj.print(f"The passed command [red]{' '.join(passed_commands)}[/red] was not understood.")    
+            else:
+                obj.print(f"None of the passed arguments were correctly identified.")
+            raise SystemExit(1)
 
         # Get the arguments for each command
-        command_index.append(-1)
+        command_index = [passed_commands.index(command) for command in command_list]
         command_argument_list = []
-        for i in range(len(command_index)-2):
+        for i in range(len(command_index)-1):
             command_argument_list.append(list(passed_commands[command_index[i]+1:command_index[i + 1]]))
-        command_argument_list.append(list(passed_commands[command_index[-2]+1:]))
-        print(f"{command_argument_list=}")
+        command_argument_list.append(list(passed_commands[command_index[-1]+1:]))
+
         # Not elegant, would be better to check at the command level first but it does work
         for argument_list in command_argument_list:
             argument_names = argument_list[::2]
@@ -212,26 +212,6 @@ def fsm(obj:ControllerContext, fsm_command:str) -> None:
                     from drunc.controller.exceptions import MalformedCommand
                     raise MalformedCommand(f"Argument '{argument}' has been repeated.")
 
-
-        # Extract commands from sequences
-        for command in command_list:
-            if command not in ["start_run", "stop_run", "shutdown"]:
-                continue
-            sequence_command_index = command_list.index(command)
-            sequence_command_args = command_argument_list[sequence_command_index]
-            match command:
-                case "start_run":
-                    sequence_commands = ["conf", "start", "enable_triggers"]
-                case "stop_run":
-                    sequence_commands = ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop"]
-                case "shutdown":
-                    sequence_commands = ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "scrap"]
-            del command_list[sequence_command_index]
-            command_list[sequence_command_index:sequence_command_index] = sequence_commands
-
-            for _ in range(len(sequence_commands)-1):
-                command_argument_list.insert(sequence_command_index, list(sequence_command_args))
-
         # Check the mandatory arguments
         for command in command_list:
             mandatory_command_arguments = available_command_mandatory_args[available_commands.index(command)]
@@ -241,8 +221,24 @@ def fsm(obj:ControllerContext, fsm_command:str) -> None:
             for argument in mandatory_command_arguments:
                 if argument not in provided_command_arguments:
                     missing_command_arguments = list(set(mandatory_command_arguments) - set(provided_command_arguments))
-                    obj.print(f"There are missing arguments for command [green]{command}[/green]. Missing arguments: [red]{' '.join(missing_command_arguments)}[/red].")
+                    obj.print(f"There are missing arguments for command [green]{command}[/green]. Missing mandatory argument(s): [red]{' '.join(missing_command_arguments)}[/red].")
                     raise SystemExit(1)
+
+        # Extract commands from sequences
+        for command in command_list:
+            if command not in available_sequences:
+                continue
+            # Define the sequence command parameters
+            passed_sequence_command_index = command_list.index(command)
+            passed_sequence_command_args = list(command_argument_list[passed_sequence_command_index])
+            sequence_commands = available_sequence_commands[available_sequences.index(command)]
+            # Replace the sequence command with the correct fsm commands
+            del command_list[passed_sequence_command_index]
+            command_list[passed_sequence_command_index:passed_sequence_command_index] = sequence_commands
+            # Replace the sequence command arguments. Duplicates the sequence arguments for all FSM commands
+            del command_argument_list[passed_sequence_command_index]
+            for _ in range(len(sequence_commands)):
+                command_argument_list.insert(passed_sequence_command_index, passed_sequence_command_args)
 
         return command_list, command_argument_list
 
@@ -286,7 +282,13 @@ def fsm(obj:ControllerContext, fsm_command:str) -> None:
     def print_status_summary(obj:ControllerContext) -> None:
         status = obj.get_driver('controller').get_status().data.state
         available_actions = [command.name for command in obj.get_driver('controller').describe_fsm().data.commands]
-        obj.print(f"Current FSM status is [green]{status}[/green]. Available transitions are [green]{' '.join(available_actions)}[/green]")
+        if len(available_actions) == 1:
+            obj.print(f"Current FSM status is [green]{status}[/green]. The available FSM transitions is [green]{' '.join(available_actions)}[/green]")
+        elif len(available_actions) > 1:
+            obj.print(f"Current FSM status is [green]{status}[/green]. The available FSM transitions are [green]{' '.join(available_actions)}[/green]")
+        else:
+            from drunc.exceptions import DruncSetupException
+            raise DruncSetupException(f"There are no commands available from the current state: {status}.")
         return
 
     def filter_arguments(arguments:dict, fsm_command:FSMCommandDescription) -> dict:
@@ -302,7 +304,6 @@ def fsm(obj:ControllerContext, fsm_command:str) -> None:
 
     def construct_FSM_command(obj:ControllerContext, command:tuple[str, list]) -> FSMCommand:
         command_name = command[0]
-        print(f"{command[1]=}")
         command_args = dict_arguments(command[1])
         command_desc = search_fsm_command(command_name, obj.get_driver('controller').describe_fsm().data.commands) # FSMCommandDescription
         if command_desc == None:
@@ -330,9 +331,10 @@ def fsm(obj:ControllerContext, fsm_command:str) -> None:
         # if not result: return
         return result
 
+
     # Split command into a list of commands and a list of arguments
     command_list, argument_list = split_FSM_args(obj, fsm_command)
-    print(f"{argument_list=}")
+
     # Execute the FSM commands
     result = None
     for command in zip(command_list, argument_list):
@@ -343,7 +345,7 @@ def fsm(obj:ControllerContext, fsm_command:str) -> None:
         obj.print(f"Sending [green]{command[0]}[/green].")
         result = send_FSM_command(obj, grpc_command)
         if (result == None):
-            obj.print(f"Transition {FSMtransition} did not execute")
+            obj.print(f"Transition {FSMtransition} did not execute. Check logs for more info.")
             break
 
     print_status_summary(obj)

--- a/src/drunc/controller/interface/commands.py
+++ b/src/drunc/controller/interface/commands.py
@@ -165,15 +165,95 @@ def who_is_in_charge(obj:ControllerContext) -> None:
 
 
 @click.command('fsm')
-@click.argument('command', type=str)
-@click.argument('arguments', type=str, nargs=-1)
+@click.argument('fsm_command', type=str, nargs=-1)
 @click.pass_obj
-def fsm(obj:ControllerContext, command:str, arguments:str) -> None:
+def fsm(obj:ControllerContext, fsm_command:str) -> None:
     from drunc.controller.interface.shell_utils import format_bool, tree_prefix, search_fsm_command, validate_and_format_fsm_arguments, ArgumentException
     from drunc.utils.grpc_utils import unpack_any
     from druncschema.controller_pb2 import FSMResponseFlag, FSMCommandResponse, FSMCommand, FSMCommandDescription
     from druncschema.request_response_pb2 import ResponseFlag
     from rich.table import Table
+
+    def split_FSM_args(obj:ControllerContext, passed_commands:tuple):
+        # Note this is a placeholder - want to get this from OKS.
+        available_commands = ["conf", "start", "enable_triggers", "disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "start_run", "stop_run", "shutdown"]
+        available_command_mandatory_args = [[], ["run_number"], [], [], [], [], []]
+        available_command_opt_args = []
+        available_args = ["run_number"]
+
+        # Get the index of all the commands in the command str
+        command_list = [command for command in passed_commands if command in available_commands]
+        if len(command_list) == 0:
+                if len(passed_commands) == 1:
+                    obj.print(f"The passed command [red]{passed_commands}[/red] was not understood.")    
+                else:
+                    obj.print(f"None of the passed arguments were correctly identified.")
+                raise SystemExit(1)
+
+        command_index = [passed_commands.index(command) for command in command_list]
+
+        # Get the arguments for each command
+        command_index.append(-1)
+        command_argument_list = []
+        for i in range(len(command_index)-2):
+            command_argument_list.append(list(passed_commands[command_index[i]+1:command_index[i + 1]]))
+        command_argument_list.append(list(passed_commands[command_index[-2]+1:]))
+        print(f"{command_argument_list=}")
+        # Not elegant, would be better to check at the command level first but it does work
+        for argument_list in command_argument_list:
+            argument_names = argument_list[::2]
+            for argument in argument_names:
+                # Check if the argument is legal
+                if argument not in available_args:
+                    from drunc.controller.exceptions import MalformedCommandArgument
+                    raise MalformedCommandArgument(f"Argument '{argument}' not recognised as a valid argument.")
+                # Check for duplicates
+                if argument_names.count(argument) != 1:
+                    from drunc.controller.exceptions import MalformedCommand
+                    raise MalformedCommand(f"Argument '{argument}' has been repeated.")
+
+
+        # Extract commands from sequences
+        for command in command_list:
+            if command not in ["start_run", "stop_run", "shutdown"]:
+                continue
+            sequence_command_index = command_list.index(command)
+            sequence_command_args = command_argument_list[sequence_command_index]
+            match command:
+                case "start_run":
+                    sequence_commands = ["conf", "start", "enable_triggers"]
+                case "stop_run":
+                    sequence_commands = ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop"]
+                case "shutdown":
+                    sequence_commands = ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "scrap"]
+            del command_list[sequence_command_index]
+            command_list[sequence_command_index:sequence_command_index] = sequence_commands
+
+            for _ in range(len(sequence_commands)-1):
+                command_argument_list.insert(sequence_command_index, list(sequence_command_args))
+
+        # Check the mandatory arguments
+        for command in command_list:
+            mandatory_command_arguments = available_command_mandatory_args[available_commands.index(command)]
+            provided_command_arguments = command_argument_list[command_list.index(command)]
+            if mandatory_command_arguments == []:
+                continue
+            for argument in mandatory_command_arguments:
+                if argument not in provided_command_arguments:
+                    missing_command_arguments = list(set(mandatory_command_arguments) - set(provided_command_arguments))
+                    obj.print(f"There are missing arguments for command [green]{command}[/green]. Missing arguments: [red]{' '.join(missing_command_arguments)}[/red].")
+                    raise SystemExit(1)
+
+        return command_list, command_argument_list
+
+
+    def dict_arguments(arguments:str) -> dict:
+        if len(arguments) % 2 != 0:
+            raise click.BadParameter('Arguments are pairs of key-value!')
+        keys = arguments[::2]
+        values = arguments[1::2]
+        arguments_dict = {keys[i]:values[i] for i in range(len(keys))}
+        return arguments_dict
 
     def bool_to_success(flag_message, FSM):
         flag = False
@@ -209,45 +289,34 @@ def fsm(obj:ControllerContext, command:str, arguments:str) -> None:
         obj.print(f"Current FSM status is [green]{status}[/green]. Available transitions are [green]{' '.join(available_actions)}[/green]")
         return
 
-    def filter_sequence_commands(arguments:dict, command_desc:FSMCommandDescription) -> tuple[dict, dict]:
+    def filter_arguments(arguments:dict, fsm_command:FSMCommandDescription) -> dict:
         if not arguments:
-            return arguments, None
-        argument_desc = command_desc.arguments
-        cmd_argument_names = [argument.name for argument in argument_desc]
+            return None
         cmd_arguments = {}
+        command_arguments = fsm_command.arguments
+        cmd_argument_names = [argument.name for argument in command_arguments]
         for argument in list(arguments):
             if argument in cmd_argument_names:
                 cmd_arguments[argument] = arguments[argument]
-                del arguments[argument]
-        return arguments, cmd_arguments
+        return cmd_arguments
 
-    def dict_arguments(arguments:str) -> dict:
-        if len(arguments) % 2 != 0:
-            raise click.BadParameter('Arguments are pairs of key-value!')
-        keys = arguments[::2]
-        values = arguments[1::2]
-        arguments_dict = {keys[i]:values[i] for i in range(len(keys))}
-        return arguments_dict
-
-    def construct_FSM_command(obj:ControllerContext, command:str, arguments:dict, is_sequence:bool) -> tuple[FSMCommand, dict]:
-        desc = obj.get_driver('controller').describe_fsm().data # FSMCommandsDescription
-        command_desc = search_fsm_command(obj, command, desc.commands, is_sequence) # FSMCommandDescription
+    def construct_FSM_command(obj:ControllerContext, command:tuple[str, list]) -> FSMCommand:
+        command_name = command[0]
+        print(f"{command[1]=}")
+        command_args = dict_arguments(command[1])
+        command_desc = search_fsm_command(command_name, obj.get_driver('controller').describe_fsm().data.commands) # FSMCommandDescription
         if command_desc == None:
-            return None, arguments
+            return None
 
+        # Apply the appropriate arguments for this command
+        arguments = filter_arguments(command_args, command_desc)
         # Construct the FSMCommand
         from druncschema.controller_pb2 import FSMCommand
-
-        # Allocate the arguments to the correct commands
-        if is_sequence:
-            arguments, cmd_arguments = filter_sequence_commands(arguments, command_desc)
-        else:
-            cmd_arguments = arguments
         cmd = FSMCommand( 
-            command_name = command, 
-            arguments = validate_and_format_fsm_arguments(cmd_arguments, command_desc.arguments)
+            command_name = command_name, 
+            arguments = validate_and_format_fsm_arguments(arguments, command_desc.arguments)
         )
-        return cmd, arguments
+        return cmd
 
     def send_FSM_command(obj:ControllerContext, command:FSMCommand) -> FSMCommandResponse:
         result = None
@@ -258,43 +327,24 @@ def fsm(obj:ControllerContext, command:str, arguments:str) -> None:
             raise e
         print_execution_report(command.command_name, result)
         obj.print(f"[green]{command.command_name}[/green] executed successfully.")
-        if not result: return
+        # if not result: return
         return result
 
-    # Create a new list for all the FSM commands
-    arguments = dict_arguments(arguments)
-    if command in ["start_run", "stop_run", "shutdown"]: # FSMsequence is provided
-        is_sequence = True
-        match command:
-            case "start_run":
-                commands = ["conf", "start", "enable_triggers"]
-            case "stop_run":
-                commands = ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop"]
-            case "shutdown":
-                commands = ["disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "scrap"]
-    elif command in ["conf", "start", "enable_triggers", "disable_triggers", "drain_dataflow", "stop_trigger_sources", "stop", "scrap"]: # FSMtransition is provided
-        is_sequence = False
-        commands = [command]
-    else:
-        raise click.BadParameter('Unrecognised FSMcommand.')
-
+    # Split command into a list of commands and a list of arguments
+    command_list, argument_list = split_FSM_args(obj, fsm_command)
+    print(f"{argument_list=}")
     # Execute the FSM commands
     result = None
-    for command_name in commands:
-        grpc_command, arguments = construct_FSM_command(obj, command_name, arguments, is_sequence)
-        if grpc_command == None and is_sequence:
-            obj.print(f"[red]{command_name}[/red] is not possible in current state, attempting to construct next transition in sequence [green]{command}[/green]: [green]{command_name}[/green].")
+    for command in zip(command_list, argument_list):
+        grpc_command = construct_FSM_command(obj, command)
+        if grpc_command == None:
+            obj.print(f"[red]{command[0]}[/red] is not possible in current state, not executing.")
             continue
-        obj.print(f"Sending [green]{command_name}[/green].")
+        obj.print(f"Sending [green]{command[0]}[/green].")
         result = send_FSM_command(obj, grpc_command)
-
         if (result == None):
             obj.print(f"Transition {FSMtransition} did not execute")
             break
-
-    # If the last command failed and a sequence was used, don't print the summary table
-    if result != None and len(commands) > 1:
-        print_execution_report(command, result)
 
     print_status_summary(obj)
     return

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -98,7 +98,7 @@ def controller_setup(ctx, controller_address):
 
         if ret.flag == ResponseFlag.EXECUTED_SUCCESSFULLY:
             ctx.info('You are in control.')
-            print(f"Current FSM status is [green]initial[/green]. Available transitions are [green]conf[/green]")
+            print(f"Current FSM status is [green]initial[/green]. Available FSM transitions are [green]conf[/green]")
             ctx.took_control = True
         else:
             ctx.warn(f'You are NOT in control.')

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -114,16 +114,11 @@ def controller_setup(ctx, controller_address):
 
 from drunc.controller.interface.context import ControllerContext
 from druncschema.controller_pb2 import FSMCommand
-def search_fsm_command(obj:ControllerContext, command_name:str, command_list:list[FSMCommand], is_sequence:bool=False):
+def search_fsm_command(command_name:str, command_list:list[FSMCommand]):
     for command in command_list:
         if command_name == command.name:
             return command
-    if is_sequence:
-        return None
-    else:
-        from drunc.fsm.exceptions import InvalidTransition
-        raise InvalidTransition(command_name, obj.get_driver('controller').get_status().data.state)
-
+    return None
 
 from drunc.exceptions import DruncShellException
 class ArgumentException(DruncShellException):
@@ -163,7 +158,7 @@ def validate_and_format_fsm_arguments(arguments:dict, command_arguments:list[Arg
     arguments_left = arguments
     # If the argument dict is empty, don't bother trying to read it
     if not arguments:
-        return
+        return out_dict
 
     for argument_desc in command_arguments:
         aname = argument_desc.name


### PR DESCRIPTION
FSM commands can now be sent in batch mode without requiring additional changes - all the commands and arguments get parsed. This still requires work to use all the arguments, but this should be pulled from OKS rather than being hard coded as it is at the moment. 
Features
 - can send commands and sequences in batch mode as `fsm <command> <arguments>`. The sequence arguments get duplicated to all of the FSM commands.
 - one decorator error resolved.