### PR TITLE
Adding wait command

### DIFF
--- a/src/drunc/controller/interface/commands.py
+++ b/src/drunc/controller/interface/commands.py
@@ -82,6 +82,17 @@ def ls(obj:ControllerContext) -> None:
     obj.print(children.text)
 
 
+
+@click.command('wait')
+@click.argument("sleep_time", type=int, default=1)
+@click.pass_obj
+def wait(obj:ControllerContext, sleep_time:int) -> None:
+    # Requested to "allow processing of commands to pause for a specified number of seconds"
+    from time import sleep
+    sleep(sleep_time)
+    obj.print(f"Command [green]wait[/green] ran for {sleep_time} seconds.")
+
+
 @click.command('status')
 @click.pass_obj
 def status(obj:ControllerContext) -> None:

--- a/src/drunc/controller/interface/shell.py
+++ b/src/drunc/controller/interface/shell.py
@@ -24,7 +24,7 @@ def controller_shell(ctx, controller_address:str, log_level:str) -> None:
     controller_setup(ctx.obj, controller_address)
 
     from drunc.controller.interface.commands import (
-        describe, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude
+        describe, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude, wait
     )
     ctx.command.add_command(describe, 'describe')
     ctx.command.add_command(ls, 'ls')
@@ -37,3 +37,4 @@ def controller_shell(ctx, controller_address:str, log_level:str) -> None:
     ctx.command.add_command(fsm, 'fsm')
     ctx.command.add_command(include, 'include')
     ctx.command.add_command(exclude, 'exclude')
+    ctx.command.add_command(wait, 'wait')

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -118,7 +118,7 @@ def unified_shell(ctx, process_manager_configuration:str, log_level:str) -> None
     ctx.command.add_command(dummy_boot, 'dummy_boot')
 
     from drunc.controller.interface.commands import (
-        describe, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude
+        describe, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude, wait
     )
     ctx.command.add_command(describe, 'describe')
     ctx.command.add_command(ls, 'ls')
@@ -131,3 +131,4 @@ def unified_shell(ctx, process_manager_configuration:str, log_level:str) -> None
     ctx.command.add_command(fsm, 'fsm')
     ctx.command.add_command(include, 'include')
     ctx.command.add_command(exclude, 'exclude')
+    ctx.command.add_command(wait, 'wait')


### PR DESCRIPTION
I have temporarily defined `wait` as a `controller` command, not a FSM command as per Kurt's request. 
We should discuss the future of the `fsm` prefix before executing FSM commands, as while `wait` is not currently defined as an FSM command, using it in a batch of commands would look like
```
fsm <start_of_batch>
wait
fsm <rest_of_batch>
```
This would also apply to the other commands, so I think this needs to be discussed sooner than later