### PR TITLE
Pawel plesniak/terminate no force

### DIFF
--- a/src/drunc/controller/children_interface/grpc_child.py
+++ b/src/drunc/controller/children_interface/grpc_child.py
@@ -94,6 +94,15 @@ class gRPCChildNode(ChildNode):
         return status
 
     def terminate(self):
+        if self.channel:
+            self.channel.close()
+            del self.channel
+        if self.controller:
+            del self.controller
+
+        self.controller = None
+        self.channel = None
+        self.broadcast.stop()
         pass
 
     def propagate_command(self, command, data, token) -> Response:

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -87,10 +87,6 @@ class Controller(ControllerServicer):
             data = self.configuration.data.controller.broadcaster,
         )
 
-        terminate_signals = [signal.SIGHUP, signal.SIGQUIT] # signal.SIGPIPE
-        for sig in terminate_signals:
-            signal.signal(sig, self.shutdown)
-
         self.broadcast_service = BroadcastSender(
             name = name,
             session = session,
@@ -252,21 +248,7 @@ class Controller(ControllerServicer):
             flag = ResponseFlag.NOT_EXECUTED_NODE_IN_ERROR,
             children = [],
         )
-
-    def controller_shutdown(self):
-        console.print('Requested termination')
-        self.terminate()
-
-    def shutdown(self, sig, frame):
-        self.log.warning(f'Received {sig}')
-        try:
-            self.controller_shutdown()
-        except:
-            from drunc.utils.utils import print_traceback
-            print_traceback()
-
     def terminate(self):
-
         if self.can_broadcast():
             self.broadcast(
                 btype = BroadcastType.SERVER_SHUTDOWN,
@@ -277,6 +259,7 @@ class Controller(ControllerServicer):
         for child in self.children_nodes:
             self.logger.debug(f'Stopping {child.name}')
             child.terminate()
+        self.children_nodes = []
 
         from drunc.controller.children_interface.rest_api_child import ResponseListener
 

--- a/src/drunc/controller/interface/controller.py
+++ b/src/drunc/controller/interface/controller.py
@@ -60,27 +60,6 @@ def controller_cli(configuration:str, command_facility:str, name:str, session:st
 
         return server
 
-    def controller_shutdown():
-        console.print('Requested termination')
-        ctrlr.terminate()
-
-    def shutdown(sig, frame):
-        console.print(f'Received {sig}')
-        try:
-            controller_shutdown()
-        except:
-            from drunc.utils.utils import print_traceback
-            print_traceback()
-
-        import os
-        os.kill(os.getpid(), signal.SIGQUIT)
-
-
-    terminate_signals = [signal.SIGHUP, signal.SIGPIPE]
-    # terminate_signals = set(signal.Signals) - set([signal.SIGKILL, signal.SIGSTOP])
-    for sig in terminate_signals:
-        signal.signal(sig, shutdown)
-
     try:
         server = serve(command_facility)
         server.wait_for_termination(timeout=None)

--- a/src/drunc/controller/interface/controller.py
+++ b/src/drunc/controller/interface/controller.py
@@ -60,6 +60,25 @@ def controller_cli(configuration:str, command_facility:str, name:str, session:st
 
         return server
 
+    def controller_shutdown():
+        console.print('Requested termination')
+        ctrlr.terminate()
+
+    def shutdown(sig, frame):
+        console.print(f'Received {sig}')
+        try:
+            controller_shutdown()
+        except:
+            from drunc.utils.utils import print_traceback
+            print_traceback()
+
+        import os
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    terminate_signals = [signal.SIGHUP] # Only SIGHUP - killing the tunnels
+    for sig in terminate_signals:
+        signal.signal(sig, shutdown)
+
     try:
         server = serve(command_facility)
         server.wait_for_termination(timeout=None)


### PR DESCRIPTION
Changes:
 - When exiting controllers, no more SIGPIPE
 - When terminating a gRPC child, the channel is formally closed, both the channel and controller are deleted, and the broadcast is stopped
 - On shutdown the controller now gets SIGKILL not SIGQUIT
 - In the controller, on terminate the killed children get removed from the list of children nodes