### PR TITLE
Simpler FSM transition CLI

### DIFF
--- a/src/drunc/controller/interface/shell.py
+++ b/src/drunc/controller/interface/shell.py
@@ -25,10 +25,10 @@ def controller_shell(ctx, controller_address:str, log_level:str) -> None:
     transitions = ctx.obj.get_driver('controller').describe_fsm(key="all-transitions").data
 
     from drunc.controller.interface.commands import (
-        describe, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude, wait
+        list_transitions, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude, wait
     )
 
-    ctx.command.add_command(describe, 'describe')
+    ctx.command.add_command(list_transitions, 'list-transitions')
     ctx.command.add_command(ls, 'ls')
     ctx.command.add_command(status, 'status')
     ctx.command.add_command(connect, 'connect')

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -349,17 +349,14 @@ def generate_fsm_command(ctx, transition:FSMCommandDescription, controller_name:
         else:
             raise Exception(f'Unhandled argument type \'{argument.type}\'')
 
-        if argument.presence == Argument.Presence.MANDATORY:
-            cmd = click.argument(argument.name, type=atype, nargs=1)(cmd)
-
-        else:
-            argument_name = f'--{argument.name.lower().replace("_", "-")}'
-            cmd = click.option(
-                f'{argument_name}',
-                type=atype,
-                default=atype(default_value.value),
-                help=argument.help,
-            )(cmd)
+        argument_name = f'--{argument.name.lower().replace("_", "-")}'
+        cmd = click.option(
+            f'{argument_name}',
+            type=atype,
+            default = atype(default_value.value) if argument.presence != Argument.Presence.MANDATORY else None,
+            required= argument.presence == Argument.Presence.MANDATORY,
+            help=argument.help,
+        )(cmd)
 
     cmd = click.command(
         name = transition.name.replace('_', '-').lower(),

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -184,10 +184,10 @@ def unified_shell(
 
 
     from drunc.controller.interface.commands import (
-        describe, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude, wait
+        list_transitions, ls, status, connect, take_control, surrender_control, who_am_i, who_is_in_charge, fsm, include, exclude, wait
     )
 
-    ctx.command.add_command(describe, 'describe')
+    ctx.command.add_command(list_transitions, 'list-transitions')
     ctx.command.add_command(ls, 'ls')
     ctx.command.add_command(status, 'status')
     ctx.command.add_command(connect, 'connect')


### PR DESCRIPTION
This PR:
 - removes the `describe` command altogether, and replaces it with `list-transitions`, which list available transitions (one can also pass `--all` to list all the transitions).
 - makes all arguments options so now `start 1234` is `start --run-number 1234`.