### PR TITLE
Trigger rate change and default

### DIFF
--- a/src/drunc/fsm/action_factory.py
+++ b/src/drunc/fsm/action_factory.py
@@ -81,6 +81,9 @@ class FSMActionFactory:
             case "master-send-fl-command":
                 from drunc.fsm.actions.timing.master_send_fl_command import MasterSendFLCommand
                 iface = MasterSendFLCommand(configuration)
+            case "trigger-rate-specifier":
+                from drunc.fsm.actions.trigger_rate_specifier import TriggerRateSpecifier
+                iface = TriggerRateSpecifier(configuration)
             case _:
                 raise fsme.UnknownAction(action_name)
 

--- a/src/drunc/fsm/actions/trigger_rate_specifier.py
+++ b/src/drunc/fsm/actions/trigger_rate_specifier.py
@@ -1,0 +1,19 @@
+from drunc.fsm.core import FSMAction
+
+import json
+import tempfile
+import tarfile
+import os
+import requests
+
+class TriggerRateSpecifier(FSMAction):
+    def __init__(self, configuration):
+        super().__init__(
+            name = "trigger-rate-specifier"
+        )
+
+    def pre_change_rate(self, _input_data:dict, _context, trigger_rate:float,**kwargs):
+        _input_data["trigger_rate"] = trigger_rate
+        return _input_data
+
+

--- a/src/drunc/fsm/actions/user_provided_run_number.py
+++ b/src/drunc/fsm/actions/user_provided_run_number.py
@@ -6,7 +6,7 @@ class UserProvidedRunNumber(FSMAction):
             name = "run-number"
         )
 
-    def pre_start(self, _input_data:dict, _context, run_number:int, disable_data_storage:bool=False, trigger_rate:float=1.0, run_type:str='TEST', **kwargs):
+    def pre_start(self, _input_data:dict, _context, run_number:int, disable_data_storage:bool=False, trigger_rate:float=0., run_type:str='TEST', **kwargs):
         from drunc.fsm.actions.utils import validate_run_type
         run_type = validate_run_type(run_type.upper())
         _input_data['production_vs_test'] = run_type

--- a/src/drunc/fsm/actions/usvc_provided_run_number.py
+++ b/src/drunc/fsm/actions/usvc_provided_run_number.py
@@ -20,7 +20,7 @@ class UsvcProvidedRunNumber(FSMAction):
         import logging
         self._log = logging.getLogger('microservice')
 
-    def pre_start(self, _input_data:dict, _context, run_type:str="TEST", disable_data_storage:bool=False, trigger_rate:float=1.0, **kwargs):
+    def pre_start(self, _input_data:dict, _context, run_type:str="TEST", disable_data_storage:bool=False, trigger_rate:float=0., **kwargs):
         from drunc.fsm.actions.utils import validate_run_type
         run_type = validate_run_type(run_type.upper())
         _input_data['production_vs_test'] = run_type


### PR DESCRIPTION
With this PR, the default trigger rate at `start` is 0, which I was told would make the application use the default trigger rate from the configuration.

This PR also introduces a `TriggerRateSpecifier` action, that allows the user to change the trigger rate when issuing the `change-rate` command. This last feature must be used in conjunction with the FSM defined in `daqsystemtest`: https://github.com/DUNE-DAQ/daqsystemtest/pull/127.