### PR TITLE
Die quicker, controller

### DIFF
--- a/src/drunc/connectivity_service/client.py
+++ b/src/drunc/connectivity_service/client.py
@@ -26,14 +26,14 @@ class ConnectivityServiceClient:
             # assume the simplest case here
             self.address = f'http://{address}'
 
-    def retract(self, uid):
+    def retract(self, uid, data_type:str, break_on_unreachable:bool=False):
         from drunc.utils.utils import http_post
         data = {
             'partition': self.session,
             'connections': [
                 {
                     'connection_id': uid,
-                    'data_type': 'run-control-messages',
+                    'data_type': data_type,
                 }
             ]
         }
@@ -59,9 +59,14 @@ class ConnectivityServiceClient:
                 r.raise_for_status()
                 break
             except (HTTPError, ConnectionError) as e:
+
+                if break_on_unreachable and isinstance(e, ConnectionError):
+                    self.logger.warning('Connectivity service seems unreachable, assuming it\'s already been killed')
+                    break
+
                 from time import sleep
                 sleep(0.5)
-                continue
+
 
 
 

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -313,7 +313,7 @@ if nothing (None) is provided, return the transitions accessible from the curren
             if self.connectivity_service_thread:
                 self.connectivity_service_thread.join()
             self.logger.info('Unregistering from the connectivity service')
-            self.connectivity_service.retract(self.name+"_control")
+            self.connectivity_service.retract(self.name+"_control", 'RunControlMessage', break_on_unreachable=True)
 
         if self.can_broadcast():
             self.broadcast(
@@ -331,6 +331,10 @@ if nothing (None) is provided, return the transitions accessible from the curren
 
         if ResponseListener.exists():
             ResponseListener.get().terminate()
+
+        import logging
+        if self.logger.level != logging.DEBUG:
+            return
 
         import threading
         self.logger.debug("Threading threads")


### PR DESCRIPTION
This PR corrects a typo in the `data_type` for the `RunControlMessage`.
More importantly, it changes the behaviour if we can't reach the connectivity server on `retract`: if that's the case (meaning the connectivity server has probably been killed before the controller), we abort.

Fixes https://github.com/DUNE-DAQ/drunc/issues/204, again