### PR TITLE
Better error when NP04 proxy is enabled

### DIFF
--- a/src/drunc/controller/interface/shell.py
+++ b/src/drunc/controller/interface/shell.py
@@ -19,8 +19,12 @@ def controller_shell(ctx, controller_address:str, log_level:str) -> None:
         address = controller_address,
     )
     from drunc.controller.interface.shell_utils import controller_setup, controller_cleanup_wrapper, generate_fsm_command
+    try:
+        controller_desc = controller_setup(ctx.obj, controller_address, timeout=0)
+    except Exception as e:
+        exit(1)
+
     ctx.call_on_close(controller_cleanup_wrapper(ctx.obj))
-    controller_desc = controller_setup(ctx.obj, controller_address)
 
     transitions = ctx.obj.get_driver('controller').describe_fsm(key="all-transitions").data
 

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -38,7 +38,7 @@ def controller_cleanup_wrapper(ctx):
     return controller_cleanup
 
 
-def controller_setup(ctx, controller_address):
+def controller_setup(ctx, controller_address, timeout=60):
     if not hasattr(ctx, 'took_control'):
         from drunc.exceptions import DruncSetupException
         raise DruncSetupException('This context is not compatible with a controller, you need to add a \'took_control\' bool member')
@@ -47,42 +47,51 @@ def controller_setup(ctx, controller_address):
     from druncschema.request_response_pb2 import Description
     desc = Description()
 
-    timeout = 60
-
     from drunc.utils.grpc_utils import ServerUnreachable
-    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeRemainingColumn, TimeElapsedColumn
+    stored_exception = None
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        TimeRemainingColumn(),
-        TimeElapsedColumn(),
-        console=ctx._console,
-    ) as progress:
+    if timeout == 0: # we break directly
+        try:
+            desc = ctx.get_driver('controller').describe().data
+        except Exception as e:
+            ctx.critical(f'Could not connect to the process manager, use --log-level DEBUG for more information')
+            ctx.debug(f'Error: {e}')
+            ctx.print(f'\nIf you are sure that the controller exists, on the NP04 cluster, this error usually happens when you have the web proxy enabled. Try to disable it by doing:\n\n[yellow]source ~np04daq/bin/web_proxy.sh -u[/]\n')
+            raise e
 
-        waiting = progress.add_task("[yellow]Trying to talk to the top controller...", total=timeout)
+    else:
+        from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeRemainingColumn, TimeElapsedColumn
 
-        stored_exception = None
-        import time
-        start_time = time.time()
-        while time.time()-start_time < timeout:
-            progress.update(waiting, completed=time.time()-start_time)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TimeRemainingColumn(),
+            TimeElapsedColumn(),
+            console=ctx._console,
+        ) as progress:
 
-            try:
-                desc = ctx.get_driver('controller').describe().data
-                stored_exception = None
-                break
-            except ServerUnreachable as e:
-                stored_exception = e
-                time.sleep(1)
+            waiting = progress.add_task("[yellow]Trying to talk to the top controller...", total=timeout)
 
-            except Exception as e:
-                ctx.critical('Could not get the controller\'s status')
-                ctx.critical(e)
-                ctx.critical('Exiting.')
-                ctx.terminate()
-                raise e
+            import time
+            start_time = time.time()
+            while time.time()-start_time < timeout:
+                progress.update(waiting, completed=time.time()-start_time)
+
+                try:
+                    desc = ctx.get_driver('controller').describe().data
+                    stored_exception = None
+                    break
+                except ServerUnreachable as e:
+                    stored_exception = e
+                    time.sleep(1)
+
+                except Exception as e:
+                    ctx.critical('Could not get the controller\'s status')
+                    ctx.critical(e)
+                    ctx.critical('Exiting.')
+                    ctx.terminate()
+                    raise e
 
     if stored_exception is not None:
         raise stored_exception

--- a/src/drunc/process_manager/interface/shell.py
+++ b/src/drunc/process_manager/interface/shell.py
@@ -16,16 +16,16 @@ def process_manager_shell(ctx, process_manager_address:str, log_level:str) -> No
         address = process_manager_address,
     )
 
-    from drunc.utils.grpc_utils import ServerUnreachable
-
     try:
         import asyncio
         desc = asyncio.get_event_loop().run_until_complete(
             ctx.obj.get_driver('process_manager').describe()
         )
-    except ServerUnreachable as e:
-        ctx.obj.critical(f'Could not connect to the process manager')
-        raise e
+    except Exception as e:
+        ctx.obj.critical(f'Could not connect to the process manager, use --log-level DEBUG for more information')
+        ctx.obj.debug(f'Error: {e}')
+        ctx.obj.print(f'\nIf you are sure that the process manager exists, on the NP04 cluster, this error usually happens when you have the web proxy enabled. Try to disable it by doing:\n\n[yellow]source ~np04daq/bin/web_proxy.sh -u[/]\n')
+        exit(1)
 
     ctx.obj.info(f'{process_manager_address} is \'{desc.data.name}.{desc.data.session}\' (name.session), starting listening...')
     if desc.data.HasField('broadcast'):

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -100,10 +100,14 @@ def unified_shell(
         desc = desc.data
 
     except Exception as e:
-        ctx.obj.critical(f'Could not connect to the process manager')
+        ctx.obj.critical(f'Could not connect to the process manager, use --log-level DEBUG for more information')
+        ctx.obj.debug(f'Error: {e}')
         if not ctx.obj.pm_process.is_alive():
             ctx.obj.critical(f'The process manager is dead, exit code {ctx.obj.pm_process.exitcode}')
-        raise e
+        else:
+            ctx.obj.print(f'\nOn the NP04 cluster, this usually happens when you have the web proxy enabled. Try to disable it by doing:\n\n[yellow]source ~np04daq/bin/web_proxy.sh -u[/]\n')
+            ctx.obj.pm_process.terminate()
+        exit(1)
 
     ctx.obj.info(f'{process_manager_address} is \'{desc.name}.{desc.session}\' (name.session), starting listening...')
     if desc.HasField('broadcast'):


### PR DESCRIPTION
Change the error from a massive stacktrace to a simpler error message when the server side is up, but we cannot connect to it. This is generally caused by having the web proxy on.