### PR TITLE
RTE for daq-releases

### DIFF
--- a/src/drunc/fsm/actions/thread_pinning.py
+++ b/src/drunc/fsm/actions/thread_pinning.py
@@ -23,14 +23,16 @@ class ThreadPinning(FSMAction):
 
         apps = collect_apps(db, session_dal, session_dal.segment, environ)
 
-        import os
-        rte=session_dal.rte_script
-        if not rte and os.getenv("DBT_INSTALL_DIR"):
-            rte = os.getenv("DBT_INSTALL_DIR") + "/daq_app_rte.sh"
-        elif not rte:
-            self.log.error(f'RTE was not supplied in the OKS configuration or in the environment, running without it')
-        if not os.path.isabs(rte):
-            rte = os.getcwd() + "/" + rte
+        if session_dal.rte_script:
+            rte = session_dal.rte_script
+
+        else:
+            from drunc.process_manager.utils import get_rte_script
+            rte_script = get_rte_script()
+            if not rte_script:
+                raise DruncSetupException("No RTE script found.")
+
+            rte = rte_script
 
         cmd = f"source {rte}; " if rte else ""
         cmd += f"readout-affinity.py --pinfile {thread_pinning_file}"
@@ -55,11 +57,11 @@ class ThreadPinning(FSMAction):
             except ErrorReturnCode as e:
                 self.log.error(e.stdout.decode('ascii'))
                 self.log.error(e.stderr.decode('ascii'))
-                failed_hosts.add(host)
+                failed_hosts.add(f'{host}: {e.stderr.decode("ascii")}')
                 continue
             except Exception as e:
                 self.log.critical(str(e))
-                failed_hosts.add(host)
+                failed_hosts.add(f'{host}: {e}')
                 continue
             self.log.debug(proc)
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -81,23 +81,15 @@ class ProcessManagerDriver(GRPCDriver):
                     exec='source',
                     args=[session_dal.rte_script]))
 
-            elif os.getenv("DBT_INSTALL_DIR") is not None:
-                env['DBT_INSTALL_DIR'] = os.getenv("DBT_INSTALL_DIR")
-                self._log.info(f'RTE script was not supplied in the OKS configuration, using the one from local enviroment instead')
-                rte = os.getenv("DBT_INSTALL_DIR") + "/daq_app_rte.sh"
+            else:
+                from drunc.process_manager.utils import get_rte_script
+                rte_script = get_rte_script(session_dal)
+                if not rte_script:
+                    raise DruncSetupException("No RTE script found.")
 
                 executable_and_arguments.append(ProcessDescription.ExecAndArgs(
                     exec='source',
-                    args=[rte]))
-            else:
-                self._log.warning(f'RTE was not supplied in the OKS configuration or in the environment, running without it')
-
-            # executable_and_arguments.append(
-            #     ProcessDescription.ExecAndArgs(
-            #         exec = "env",
-            #         args = []
-            #     )
-            # )
+                    args=[rte_script]))
 
             executable_and_arguments.append(ProcessDescription.ExecAndArgs(
                 exec=exe,

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -71,6 +71,7 @@ class ProcessManagerDriver(GRPCDriver):
             args = app['args']
             env = app['env']
             env['DUNE_DAQ_BASE_RELEASE'] = os.getenv("DUNE_DAQ_BASE_RELEASE")
+            env['SPACK_RELEASES_DIR'] = os.getenv("SPACK_RELEASES_DIR")
             tree_id = app['tree_id']
 
             self._log.debug(f"{name}:\n{json.dumps(app, indent=4)}")
@@ -83,7 +84,7 @@ class ProcessManagerDriver(GRPCDriver):
 
             else:
                 from drunc.process_manager.utils import get_rte_script
-                rte_script = get_rte_script(session_dal)
+                rte_script = get_rte_script()
                 if not rte_script:
                     raise DruncSetupException("No RTE script found.")
 

--- a/src/drunc/process_manager/utils.py
+++ b/src/drunc/process_manager/utils.py
@@ -92,14 +92,14 @@ def get_version():
     from os import getenv
     version = getenv("DUNE_DAQ_BASE_RELEASE")
     if not version:
-        raise RuntimeError('Utils: dunedaq version not in the variable env DUNE_DAQ_BASE_RELEASE! Exit nanorc and\nexport DUNE_DAQ_BASE_RELEASE=dunedaq-vX.XX.XX\n')
+        raise RuntimeError('Utils: dunedaq version not in the variable env DUNE_DAQ_BASE_RELEASE! Exit drunc and\nexport DUNE_DAQ_BASE_RELEASE=dunedaq-vX.XX.XX\n')
     return version
 
 def get_releases_dir():
     from os import getenv
     releases_dir = getenv("SPACK_RELEASES_DIR")
     if not releases_dir:
-        raise RuntimeError('Utils: cannot get env SPACK_RELEASES_DIR! Exit nanorc and\nrun dbt-workarea-env or dbt-setup-release.')
+        raise RuntimeError('Utils: cannot get env SPACK_RELEASES_DIR! Exit drunc and\nrun dbt-workarea-env or dbt-setup-release.')
     return releases_dir
 
 def release_or_dev():

--- a/src/drunc/process_manager/utils.py
+++ b/src/drunc/process_manager/utils.py
@@ -56,7 +56,7 @@ def tabulate_process_instance_list(pil, title, long=False):
     t.add_column('exit-code')
     if long:
         t.add_column('executable')
-    
+
     from operator import attrgetter
     sorted_pil = sorted(pil.values, key=attrgetter('process_description.metadata.tree_id'))
     tree_str = make_tree(sorted_pil)
@@ -75,3 +75,56 @@ def tabulate_process_instance_list(pil, title, long=False):
         from drunc.exceptions import DruncCommandException
         raise DruncCommandException("Unable to extract the parameters for tabulate_process_instance_list, exiting.")
     return t
+
+
+def strip_env_for_rte(env):
+    import copy as cp
+    import re
+    env_stripped = cp.deepcopy(env)
+    for key in env.keys():
+        if key in ["PATH","CET_PLUGIN_PATH","DUNEDAQ_SHARE_PATH","LD_LIBRARY_PATH","LIBRARY_PATH","PYTHONPATH"]:
+            del env_stripped[key]
+        if re.search(".*_SHARE", key) and key in env_stripped:
+            del env_stripped[key]
+    return env_stripped
+
+def get_version():
+    from os import getenv
+    version = getenv("DUNE_DAQ_BASE_RELEASE")
+    if not version:
+        raise RuntimeError('Utils: dunedaq version not in the variable env DUNE_DAQ_BASE_RELEASE! Exit nanorc and\nexport DUNE_DAQ_BASE_RELEASE=dunedaq-vX.XX.XX\n')
+    return version
+
+def get_releases_dir():
+    from os import getenv
+    releases_dir = getenv("SPACK_RELEASES_DIR")
+    if not releases_dir:
+        raise RuntimeError('Utils: cannot get env SPACK_RELEASES_DIR! Exit nanorc and\nrun dbt-workarea-env or dbt-setup-release.')
+    return releases_dir
+
+def release_or_dev():
+    from os import getenv
+    is_release = getenv("DBT_SETUP_RELEASE_SCRIPT_SOURCED")
+    if is_release:
+        return 'rel'
+    is_devenv = getenv("DBT_WORKAREA_ENV_SCRIPT_SOURCED")
+    if is_devenv:
+        return 'dev'
+    return 'rel'
+
+def get_rte_script():
+    from os import path,getenv
+    script = ''
+    if release_or_dev() == 'rel':
+        ver = get_version()
+        releases_dir = get_releases_dir()
+        script = path.join(releases_dir, ver, 'daq_app_rte.sh')
+
+    else:
+        dbt_install_dir = getenv('DBT_INSTALL_DIR')
+        script = path.join(dbt_install_dir, 'daq_app_rte.sh')
+
+    if not path.exists(script):
+        from drunc.exceptions import DruncSetupException
+        raise DruncSetupException(f'Couldn\'t understand where to find the rte script tentative: {script}')
+    return script


### PR DESCRIPTION
This PR makes drunc work when using `dbt-setup-release` by correctly looking for the RTE script.