### PR TITLE
No stack on failed connectivity service lookup

### DIFF
--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -161,18 +161,18 @@ Two possibilities:
 
 1. The most likely, the controller died. You can check that by looking for error like:
 [yellow]Process \'{top_controller_name}\' (session: \'{session_name}\', user: \'{getpass.getuser()}\') process exited with exit code 1).[/]
-Try running \'ps\' to see if the {top_controller_name} is still running.
+Try running [yellow]ps[/] to see if the {top_controller_name} is still running.
 You may also want to check the logs of the controller, try typing:
-[yellow]logs --name {top_controller_name} --grep grpc[/]
-To get to the reason why the controller died, you can restart this shell with [yellow]--log-level debug[/], and look out for \'STDOUT\' and \'STDERR\'.
+[yellow]logs --name {top_controller_name} --how-far 1000[/]
+If that's not helping, you can restart this shell with [yellow]--log-level debug[/], and look out for \'STDOUT\' and \'STDERR\'.
 
 2. The controller did not die, but is still setting up and has not advertised itself on the connection service.
 You may be able to connect to the {top_controller_name} in a bit. Check the logs of the controller:
 [yellow]logs --name {top_controller_name} --grep grpc[/]
 And look for messages like:
-[yellow]Registering root-controller to the connectivity service at grpc://xx.xx.xxx.xx:xxxxx[/]
-To find the controller address, look up \'{top_controller_name}_control\' on http://{connection_server}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs above. Then just connect this shell with:
-[yellow]connect grpc://<controller address>[/]
+[yellow]Registering root-controller to the connectivity service at grpc://xxx.xxx.xxx.xxx:xxxxx[/]
+To find the controller address, you can look up \'{top_controller_name}_control\' on http://{resolve_localhost_and_127_ip_to_network_ip(connection_server)}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs as above. Then just connect this shell to the controller with:
+[yellow]connect grpc://{{controller_address}}:{{controller_port}}>[/]
 ''', extra={"markup": True})
                     return
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -156,13 +156,17 @@ class ProcessManagerDriver(GRPCDriver):
                     import getpass
                     self._log.error(f'''Could not find \'{top_controller_name}\' on the connectivity service. 2 possibilities:
 1. The most likely, the controller died. You can check that by looking for error like:
-Process \'{top_controller_name}\' (session: \'{session_name}\', user: \'{getpass.getuser()}\') process exited with exit code 1).
+[yellow]Process \'{top_controller_name}\' (session: \'{session_name}\', user: \'{getpass.getuser()}\') process exited with exit code 1).[/]
 Try running \'ps\' to see if the {top_controller_name} is still running.
+To get to the reason why the controller died, you can restart this shell with [yellow]--log-level debug[/], and look out for \'STDOUT\' and \'STDERR\'.
 
 2. The controller did not die, but is still setting up and has not advertised itself on the connection service.
-You may be able to \'connect grpc://<controller address>\' on in a bit.
-To find the controller address, look up \'{top_controller_name}_control\' on {connection_server}:{connection_port} (you may need a SOCKS proxy from outside CERN).
-''')
+You may be able to \'connect grpc://<controller address>\' in a bit: Check the logs of the controller:
+[yellow]logs --name {top_controller_name} --grep grpc[\]
+And look for messages like:
+[yello]Registering root-controller to the connectivity service at grpc://xx.xx.xxx.xx:xxxxx[\]
+To find the controller address, look up \'{top_controller_name}_control\' on {connection_server}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs above.
+''', extra={"markup": True})
                     return
 
                 return uri.replace('grpc://', '')

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -162,9 +162,9 @@ To get to the reason why the controller died, you can restart this shell with [y
 
 2. The controller did not die, but is still setting up and has not advertised itself on the connection service.
 You may be able to \'connect grpc://<controller address>\' in a bit: Check the logs of the controller:
-[yellow]logs --name {top_controller_name} --grep grpc[\]
+[yellow]logs --name {top_controller_name} --grep grpc[/]
 And look for messages like:
-[yello]Registering root-controller to the connectivity service at grpc://xx.xx.xxx.xx:xxxxx[\]
+[yello]Registering root-controller to the connectivity service at grpc://xx.xx.xxx.xx:xxxxx[/]
 To find the controller address, look up \'{top_controller_name}_control\' on {connection_server}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs above.
 ''', extra={"markup": True})
                     return

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -154,18 +154,25 @@ class ProcessManagerDriver(GRPCDriver):
                     )
                 except ApplicationLookupUnsuccessful as e:
                     import getpass
-                    self._log.error(f'''Could not find \'{top_controller_name}\' on the connectivity service. 2 possibilities:
+                    self._log.error(f'''
+Could not find \'{top_controller_name}\' on the connectivity service.
+
+Two possibilities:
+
 1. The most likely, the controller died. You can check that by looking for error like:
 [yellow]Process \'{top_controller_name}\' (session: \'{session_name}\', user: \'{getpass.getuser()}\') process exited with exit code 1).[/]
 Try running \'ps\' to see if the {top_controller_name} is still running.
+You may also want to check the logs of the controller, try typing:
+[yellow]logs --name {top_controller_name} --grep grpc[/]
 To get to the reason why the controller died, you can restart this shell with [yellow]--log-level debug[/], and look out for \'STDOUT\' and \'STDERR\'.
 
 2. The controller did not die, but is still setting up and has not advertised itself on the connection service.
-You may be able to \'connect grpc://<controller address>\' in a bit: Check the logs of the controller:
+You may be able to connect to the {top_controller_name} in a bit. Check the logs of the controller:
 [yellow]logs --name {top_controller_name} --grep grpc[/]
 And look for messages like:
-[yello]Registering root-controller to the connectivity service at grpc://xx.xx.xxx.xx:xxxxx[/]
-To find the controller address, look up \'{top_controller_name}_control\' on {connection_server}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs above.
+[yellow]Registering root-controller to the connectivity service at grpc://xx.xx.xxx.xx:xxxxx[/]
+To find the controller address, look up \'{top_controller_name}_control\' on http://{connection_server}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs above. Then just connect this shell with:
+[yellow]connect grpc://<controller address>[/]
 ''', extra={"markup": True})
                     return
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -153,7 +153,16 @@ class ProcessManagerDriver(GRPCDriver):
                         title = f'Looking for \'{top_controller_name}\' on the connectivity service...',
                     )
                 except ApplicationLookupUnsuccessful as e:
-                    self._log.error(f'Could not find \'{top_controller_name}\' on the connectivity service, this likely means that the controller died. Try running \'ps\' to see if the controller is still running. You may be able to \'connect grpc://<controller address>\' later on, if the controller took too long to start. To find the controller address, look up \'{top_controller_name}_control\' {connection_server}:{connection_port} (you may need a socks proxy from outside CERN)')
+                    import getpass
+                    self._log.error(f'''Could not find \'{top_controller_name}\' on the connectivity service. 2 possibilities:
+1. The most likely, the controller died. You can check that by looking for error like:
+Process \'{top_controller_name}\' (session: \'{session_name}\', user: \'{getpass.getuser()}\') process exited with exit code 1).
+Try running \'ps\' to see if the {top_controller_name} is still running.
+
+2. The controller did not die, but is still setting up and has not advertised itself on the connection service.
+You may be able to \'connect grpc://<controller address>\' on in a bit.
+To find the controller address, look up \'{top_controller_name}_control\' on {connection_server}:{connection_port} (you may need a SOCKS proxy from outside CERN).
+''')
                     return
 
                 return uri.replace('grpc://', '')


### PR DESCRIPTION
This PR aims to make it simpler to debug what is going on when the unified shell cannot find the root controller on the connectivity service by printing a couple of hints. Fixes https://github.com/DUNE-DAQ/drunc/issues/267