### PR TITLE
Fix message format and acquire a lock to read the actor token

### DIFF
--- a/src/drunc/connectivity_service/client.py
+++ b/src/drunc/connectivity_service/client.py
@@ -1,4 +1,4 @@
-from requests.exceptions import HTTPError, ConnectionError
+from requests.exceptions import HTTPError, ConnectionError, ReadTimeout
 from drunc.exceptions import DruncException
 
 class ApplicationRegistryNotPresent(DruncException):
@@ -91,7 +91,7 @@ class ConnectivityServiceClient:
                 else:
                     self.logger.debug(f'Could not find the address of \'{uid_regex}\' on the application registry')
 
-            except (HTTPError, ConnectionError) as e:
+            except (HTTPError, ConnectionError, ReadTimeout) as e:
                 self.logger.debug(e)
                 from time import sleep
                 sleep(0.2)

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -49,7 +49,10 @@ class ControllerActor:
         self._lock.release()
 
     def compare_token(self, token1, token2):
-        return token1.user_name == token2.user_name and token1.token == token2.token #!! come on protobuf, you can compare messages
+        self._lock.acquire()
+        result = token1.user_name == token2.user_name and token1.token == token2.token #!! come on protobuf, you can compare messages
+        self._lock.release()
+        return result
 
     def token_is_current_actor(self, token):
         return self.compare_token(token, self._token)

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -617,7 +617,7 @@ if nothing (None) is provided, return the transitions accessible from the curren
             return self.construct_error_node_response(
                 fsm_command.command_name,
                 token,
-                cause = FSMResponseFlag.FSM_NODE_IN_ERROR
+                cause = FSMResponseFlag.FSM_NOT_EXECUTED_IN_ERROR
             )
 
         if not self.stateful_node.node_is_included():

--- a/src/drunc/controller/decorators.py
+++ b/src/drunc/controller/decorators.py
@@ -8,11 +8,15 @@ def in_control(cmd):
         if not obj.actor.token_is_current_actor(request.token):
             from druncschema.request_response_pb2 import Response, ResponseFlag
             from druncschema.generic_pb2 import PlainText
+            from drunc.utils.grpc_utils import pack_to_any
+
             return Response(
                 name = obj.name,
                 token = request.token,
-                data = PlainText(
-                    text = f"User {request.token.user_name} is not in control of {obj.__class__.__name__}",
+                data = pack_to_any(
+                    PlainText(
+                        text = f"User {request.token.user_name} is not in control of {obj.__class__.__name__}",
+                    )
                 ),
                 flag = ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
                 children = []

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -175,6 +175,9 @@ def resolve_localhost_and_127_ip_to_network_ip(address):
     )
     # https://stackoverflow.com/a/25969006
 
+    if not ip_match:
+        return address
+
     if ip_match.group(0).startswith('127.'):
         address = address.replace(ip_match.group(0), this_ip)
 


### PR DESCRIPTION
Attempt to fix https://github.com/DUNE-DAQ/drunc/issues/268
There are 2 problem in that issue:
1. Why is the ControllerActor not the one in charge of the controller?
2. The stack itself which is clearly a bug

For 2., its quite simple.
For 1. this PR made the assumption that the read of the actor happens while the actor is being changed (take_control), therefore leading to this weird, transient error.