### PR TITLE
No stack on failed connectivity service lookup  (redo)

### DIFF
--- a/src/drunc/connectivity_service/client.py
+++ b/src/drunc/connectivity_service/client.py
@@ -26,14 +26,14 @@ class ConnectivityServiceClient:
             # assume the simplest case here
             self.address = f'http://{address}'
 
-    def retract(self, uid, data_type:str, break_on_unreachable:bool=False):
+    def retract(self, uid):
         from drunc.utils.utils import http_post
         data = {
             'partition': self.session,
             'connections': [
                 {
                     'connection_id': uid,
-                    'data_type': data_type,
+                    'data_type': 'run-control-messages',
                 }
             ]
         }
@@ -59,14 +59,9 @@ class ConnectivityServiceClient:
                 r.raise_for_status()
                 break
             except (HTTPError, ConnectionError) as e:
-
-                if break_on_unreachable and isinstance(e, ConnectionError):
-                    self.logger.warning('Connectivity service seems unreachable, assuming it\'s already been killed')
-                    break
-
                 from time import sleep
                 sleep(0.5)
-
+                continue
 
 
 

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -313,7 +313,7 @@ if nothing (None) is provided, return the transitions accessible from the curren
             if self.connectivity_service_thread:
                 self.connectivity_service_thread.join()
             self.logger.info('Unregistering from the connectivity service')
-            self.connectivity_service.retract(self.name+"_control", 'RunControlMessage', break_on_unreachable=True)
+            self.connectivity_service.retract(self.name+"_control")
 
         if self.can_broadcast():
             self.broadcast(
@@ -331,10 +331,6 @@ if nothing (None) is provided, return the transitions accessible from the curren
 
         if ResponseListener.exists():
             ResponseListener.get().terminate()
-
-        import logging
-        if self.logger.level != logging.DEBUG:
-            return
 
         import threading
         self.logger.debug("Threading threads")

--- a/src/drunc/controller/interface/shell.py
+++ b/src/drunc/controller/interface/shell.py
@@ -19,12 +19,8 @@ def controller_shell(ctx, controller_address:str, log_level:str) -> None:
         address = controller_address,
     )
     from drunc.controller.interface.shell_utils import controller_setup, controller_cleanup_wrapper, generate_fsm_command
-    try:
-        controller_desc = controller_setup(ctx.obj, controller_address, timeout=0)
-    except Exception as e:
-        exit(1)
-
     ctx.call_on_close(controller_cleanup_wrapper(ctx.obj))
+    controller_desc = controller_setup(ctx.obj, controller_address)
 
     transitions = ctx.obj.get_driver('controller').describe_fsm(key="all-transitions").data
 

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -38,7 +38,7 @@ def controller_cleanup_wrapper(ctx):
     return controller_cleanup
 
 
-def controller_setup(ctx, controller_address, timeout=60):
+def controller_setup(ctx, controller_address):
     if not hasattr(ctx, 'took_control'):
         from drunc.exceptions import DruncSetupException
         raise DruncSetupException('This context is not compatible with a controller, you need to add a \'took_control\' bool member')
@@ -47,51 +47,42 @@ def controller_setup(ctx, controller_address, timeout=60):
     from druncschema.request_response_pb2 import Description
     desc = Description()
 
+    timeout = 60
+
     from drunc.utils.grpc_utils import ServerUnreachable
-    stored_exception = None
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeRemainingColumn, TimeElapsedColumn
 
-    if timeout == 0: # we break directly
-        try:
-            desc = ctx.get_driver('controller').describe().data
-        except Exception as e:
-            ctx.critical(f'Could not connect to the process manager, use --log-level DEBUG for more information')
-            ctx.debug(f'Error: {e}')
-            ctx.print(f'\nIf you are sure that the controller exists, on the NP04 cluster, this error usually happens when you have the web proxy enabled. Try to disable it by doing:\n\n[yellow]source ~np04daq/bin/web_proxy.sh -u[/]\n')
-            raise e
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TimeRemainingColumn(),
+        TimeElapsedColumn(),
+        console=ctx._console,
+    ) as progress:
 
-    else:
-        from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeRemainingColumn, TimeElapsedColumn
+        waiting = progress.add_task("[yellow]Trying to talk to the top controller...", total=timeout)
 
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TimeRemainingColumn(),
-            TimeElapsedColumn(),
-            console=ctx._console,
-        ) as progress:
+        stored_exception = None
+        import time
+        start_time = time.time()
+        while time.time()-start_time < timeout:
+            progress.update(waiting, completed=time.time()-start_time)
 
-            waiting = progress.add_task("[yellow]Trying to talk to the top controller...", total=timeout)
+            try:
+                desc = ctx.get_driver('controller').describe().data
+                stored_exception = None
+                break
+            except ServerUnreachable as e:
+                stored_exception = e
+                time.sleep(1)
 
-            import time
-            start_time = time.time()
-            while time.time()-start_time < timeout:
-                progress.update(waiting, completed=time.time()-start_time)
-
-                try:
-                    desc = ctx.get_driver('controller').describe().data
-                    stored_exception = None
-                    break
-                except ServerUnreachable as e:
-                    stored_exception = e
-                    time.sleep(1)
-
-                except Exception as e:
-                    ctx.critical('Could not get the controller\'s status')
-                    ctx.critical(e)
-                    ctx.critical('Exiting.')
-                    ctx.terminate()
-                    raise e
+            except Exception as e:
+                ctx.critical('Could not get the controller\'s status')
+                ctx.critical(e)
+                ctx.critical('Exiting.')
+                ctx.terminate()
+                raise e
 
     if stored_exception is not None:
         raise stored_exception

--- a/src/drunc/process_manager/interface/shell.py
+++ b/src/drunc/process_manager/interface/shell.py
@@ -16,16 +16,16 @@ def process_manager_shell(ctx, process_manager_address:str, log_level:str) -> No
         address = process_manager_address,
     )
 
+    from drunc.utils.grpc_utils import ServerUnreachable
+
     try:
         import asyncio
         desc = asyncio.get_event_loop().run_until_complete(
             ctx.obj.get_driver('process_manager').describe()
         )
-    except Exception as e:
-        ctx.obj.critical(f'Could not connect to the process manager, use --log-level DEBUG for more information')
-        ctx.obj.debug(f'Error: {e}')
-        ctx.obj.print(f'\nIf you are sure that the process manager exists, on the NP04 cluster, this error usually happens when you have the web proxy enabled. Try to disable it by doing:\n\n[yellow]source ~np04daq/bin/web_proxy.sh -u[/]\n')
-        exit(1)
+    except ServerUnreachable as e:
+        ctx.obj.critical(f'Could not connect to the process manager')
+        raise e
 
     ctx.obj.info(f'{process_manager_address} is \'{desc.data.name}.{desc.data.session}\' (name.session), starting listening...')
     if desc.data.HasField('broadcast'):

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -8,7 +8,7 @@ from druncschema.process_manager_pb2 import BootRequest, ProcessUUID, ProcessQue
 
 from drunc.utils.grpc_utils import unpack_any
 from drunc.utils.shell_utils import GRPCDriver
-from drunc.utils.utils import resolve_localhost_and_127_ip_to_network_ip
+from drunc.utils.utils import resolve_localhost_and_127_ip_to_network_ip, resolve_localhost_to_hostname
 
 from drunc.exceptions import DruncSetupException, DruncShellException
 
@@ -179,7 +179,7 @@ You may be able to connect to the {top_controller_name} in a bit. Check the logs
 [yellow]logs --name {top_controller_name} --grep grpc[/]
 And look for messages like:
 [yellow]Registering root-controller to the connectivity service at grpc://xxx.xxx.xxx.xxx:xxxxx[/]
-To find the controller address, you can look up \'{top_controller_name}_control\' on http://{resolve_localhost_and_127_ip_to_network_ip(connection_server)}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs as above. Then just connect this shell to the controller with:
+To find the controller address, you can look up \'{top_controller_name}_control\' on http://{resolve_localhost_to_hostname(connection_server)}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs as above. Then just connect this shell to the controller with:
 [yellow]connect grpc://{{controller_address}}:{{controller_port}}>[/]
 ''', extra={"markup": True})
                     return

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -139,18 +139,42 @@ class ProcessManagerDriver(GRPCDriver):
                 connection_server = session_dal.connectivity_service.host
                 connection_port = session_dal.connectivity_service.service.port
 
-                from drunc.connectivity_service.client import ConnectivityServiceClient
+                from drunc.connectivity_service.client import ConnectivityServiceClient, ApplicationLookupUnsuccessful
                 csc = ConnectivityServiceClient(session_name, f'{connection_server}:{connection_port}')
 
                 from drunc.utils.utils import get_control_type_and_uri_from_connectivity_service
-                _, uri = get_control_type_and_uri_from_connectivity_service(
-                    csc,
-                    name = top_controller_name,
-                    timeout = 60,
-                    retry_wait = 1,
-                    progress_bar = True,
-                    title = f'Looking for \'{top_controller_name}\' on the connectivity service...',
-                )
+                try:
+                    _, uri = get_control_type_and_uri_from_connectivity_service(
+                        csc,
+                        name = top_controller_name,
+                        timeout = 60,
+                        retry_wait = 1,
+                        progress_bar = True,
+                        title = f'Looking for \'{top_controller_name}\' on the connectivity service...',
+                    )
+                except ApplicationLookupUnsuccessful as e:
+                    import getpass
+                    self._log.error(f'''
+Could not find \'{top_controller_name}\' on the connectivity service.
+
+Two possibilities:
+
+1. The most likely, the controller died. You can check that by looking for error like:
+[yellow]Process \'{top_controller_name}\' (session: \'{session_name}\', user: \'{getpass.getuser()}\') process exited with exit code 1).[/]
+Try running [yellow]ps[/] to see if the {top_controller_name} is still running.
+You may also want to check the logs of the controller, try typing:
+[yellow]logs --name {top_controller_name} --how-far 1000[/]
+If that's not helping, you can restart this shell with [yellow]--log-level debug[/], and look out for \'STDOUT\' and \'STDERR\'.
+
+2. The controller did not die, but is still setting up and has not advertised itself on the connection service.
+You may be able to connect to the {top_controller_name} in a bit. Check the logs of the controller:
+[yellow]logs --name {top_controller_name} --grep grpc[/]
+And look for messages like:
+[yellow]Registering root-controller to the connectivity service at grpc://xxx.xxx.xxx.xxx:xxxxx[/]
+To find the controller address, you can look up \'{top_controller_name}_control\' on http://{resolve_localhost_and_127_ip_to_network_ip(connection_server)}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs as above. Then just connect this shell to the controller with:
+[yellow]connect grpc://{{controller_address}}:{{controller_port}}>[/]
+''', extra={"markup": True})
+                    return
 
                 return uri.replace('grpc://', '')
 

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -100,14 +100,10 @@ def unified_shell(
         desc = desc.data
 
     except Exception as e:
-        ctx.obj.critical(f'Could not connect to the process manager, use --log-level DEBUG for more information')
-        ctx.obj.debug(f'Error: {e}')
+        ctx.obj.critical(f'Could not connect to the process manager')
         if not ctx.obj.pm_process.is_alive():
             ctx.obj.critical(f'The process manager is dead, exit code {ctx.obj.pm_process.exitcode}')
-        else:
-            ctx.obj.print(f'\nOn the NP04 cluster, this usually happens when you have the web proxy enabled. Try to disable it by doing:\n\n[yellow]source ~np04daq/bin/web_proxy.sh -u[/]\n')
-            ctx.obj.pm_process.terminate()
-        exit(1)
+        raise e
 
     ctx.obj.info(f'{process_manager_address} is \'{desc.name}.{desc.session}\' (name.session), starting listening...')
     if desc.HasField('broadcast'):

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -161,6 +161,30 @@ def validate_command_facility(ctx, param, value):
         case _:
             raise BadParameter(message=f'Command factory for drunc-controller only allows \'grpc\'', ctx=ctx, param=param)
 
+def resolve_localhost_to_hostname(address):
+    from socket import gethostbyname, gethostname
+    hostname = gethostname()
+    if 'localhost' in address:
+        address = address.replace('localhost', hostname)
+
+    import re
+    ip_match = re.search(
+        "((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)",
+        address
+    )
+    # https://stackoverflow.com/a/25969006
+
+    if not ip_match:
+        return address
+
+    if ip_match.group(0).startswith('127.'):
+        address = address.replace(ip_match.group(0), hostname)
+
+    if ip_match.group(0).startswith('0.'):
+        address = address.replace(ip_match.group(0), hostname)
+
+    return address
+
 
 def resolve_localhost_and_127_ip_to_network_ip(address):
     from socket import gethostbyname, gethostname
@@ -179,6 +203,9 @@ def resolve_localhost_and_127_ip_to_network_ip(address):
         return address
 
     if ip_match.group(0).startswith('127.'):
+        address = address.replace(ip_match.group(0), this_ip)
+
+    if ip_match.group(0).startswith('0.'):
         address = address.replace(ip_match.group(0), this_ip)
 
     return address


### PR DESCRIPTION
This is a PR for a feature branch which perfectly recreates the plasorak/no-stack-on-failed-lookup branch, commit e5d88ede0b752fcada738c6544eee93004d9172a

PR #272 was accidentally merged into `develop` a little while ago. While I've reverted the change to the head of `develop` so that as of this writing it's as if PR #272 hadn't been merged into it, `git`'s conception of the merge history is such that we can't simply re-do the PR with the original feature branch, `plasorak/no-stack-on-failed-lookup`. So what I've done here is create a new feature branch _which is an exact copy of_ `plasorak/no-stack-on-failed-lookup`, enabling a "do-over". 