### PR TITLE
Consolidating the db so no faulty configurations get started

### DIFF
--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -1,5 +1,5 @@
 import asyncio
-import tempfile 
+import tempfile
 
 from typing import Dict
 
@@ -53,8 +53,12 @@ class ProcessManagerDriver(GRPCDriver):
             try:
                 consolidate_db(oks_conf, f"{fname}")
             except Exception as e:
-                log.error("Invalid configuration passed")
-                raise e
+                log.critical(f'''\nInvalid configuration passed (cannot consolidate your configuration). To debug it, close drunc and run the following command:
+
+[yellow]oks_dump --files-only {oks_conf}[/]
+
+''', extra={'markup': True})
+                return
 
         db = conffwk.Configuration(f"oksconflibs:{oks_conf}")
         session_dal = db.get_dal(class_name="Session", uid=session)

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -50,7 +50,11 @@ class ProcessManagerDriver(GRPCDriver):
             f.flush()
             f.seek(0)
             fname = f.name
-            consolidate_db(oks_conf, f"{fname}")
+            try:
+                consolidate_db(oks_conf, f"{fname}")
+            except Exception as e:
+                log.error("Invalid configuration passed")
+                raise e
 
         db = conffwk.Configuration(f"oksconflibs:{oks_conf}")
         session_dal = db.get_dal(class_name="Session", uid=session)

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -1,4 +1,5 @@
 import asyncio
+import tempfile 
 
 from typing import Dict
 
@@ -11,6 +12,7 @@ from drunc.utils.utils import resolve_localhost_and_127_ip_to_network_ip
 
 from drunc.exceptions import DruncSetupException, DruncShellException
 
+from daqconf.consolidate import consolidate_db
 class ProcessManagerDriver(GRPCDriver):
     controller_address = ''
 
@@ -44,6 +46,11 @@ class ProcessManagerDriver(GRPCDriver):
         log = getLogger('_convert_oks_to_boot_request')
         log.info(oks_conf)
 
+        with tempfile.NamedTemporaryFile(suffix='.data.xml', delete=True) as f:
+            f.flush()
+            f.seek(0)
+            fname = f.name
+            consolidate_db(oks_conf, f"{fname}")
 
         db = conffwk.Configuration(f"oksconflibs:{oks_conf}")
         session_dal = db.get_dal(class_name="Session", uid=session)


### PR DESCRIPTION
Addresses issue [#276](https://github.com/DUNE-DAQ/drunc/issues/276)
Consolidating the db before booting
