### PR TITLE
Use the log_path from the confguration

### DIFF
--- a/src/drunc/process_manager/oks_parser.py
+++ b/src/drunc/process_manager/oks_parser.py
@@ -75,7 +75,8 @@ def collect_apps(db, session, segment, env:Dict[str,str]) -> List[Dict]:
       "restriction": host,
       "host": host,
       "env": rc_env,
-      "tree_id": pmch.create_id(controller, segment)
+      "tree_id": pmch.create_id(controller, segment),
+      "log_path": controller.log_path,
     }
   )
 
@@ -116,7 +117,8 @@ def collect_apps(db, session, segment, env:Dict[str,str]) -> List[Dict]:
         "restriction": host,
         "host": host,
         "env": app_env,
-        "tree_id": pmch.create_id(app)
+        "tree_id": pmch.create_id(app),
+        "log_path": app.log_path,
       }
     )
 
@@ -168,7 +170,8 @@ def collect_infra_apps(session, env:Dict[str, str]) -> List[Dict]:
         "restriction": host,
         "host": host,
         "env": app_env,
-        "tree_id": pmch.create_id(app)
+        "tree_id": pmch.create_id(app),
+        "log_path": app.log_path,
       }
     )
 

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -183,6 +183,18 @@ def resolve_localhost_and_127_ip_to_network_ip(address):
 
     return address
 
+def host_is_local(host):
+    from socket import gethostname, gethostbyname
+
+    if host in ['localhost', '0.0.0.0', gethostname(), gethostbyname(gethostname())]:
+        return True
+
+    if host.startswith('127.'):
+        return True
+
+    return False
+
+
 def pid_info_str():
     import os
     return f'Parent\'s PID: {os.getppid()} | This PID: {os.getpid()}'


### PR DESCRIPTION
Requires https://github.com/DUNE-DAQ/confmodel/pull/51

This use the following logic:
1. Applications will log to their log_path (defined in the Application schema).
2. If above is not set, the applications will log to their Session's log_path.
3. If above are not set, the applications will log to PWD.

In cases 1. and 2., the log will be non overwriting (i.e. they will have a timestamp assigned to them). In the case 3. overwriting logs is controlled by the `boot`'s `--override-logs/--no-override-logs` switch.

Note that there is logic to check that the path exists _if you are running on `localhost`_:
Say you configured your `log_path` to `/bananas/cucumbers/potatoes` drunc will only be able to say whether this path exists (and therefore thrown a reasonable exception) if you are running on `localhost`.

There is no check if that path is writable, or if the disk has space.