### PR TITLE
Reintroducing changes made in branch plasorak/prettier-cli

### DIFF
--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -358,17 +358,14 @@ def generate_fsm_command(ctx, transition:FSMCommandDescription, controller_name:
         else:
             raise Exception(f'Unhandled argument type \'{argument.type}\'')
 
-        if argument.presence == Argument.Presence.MANDATORY:
-            cmd = click.argument(argument.name, type=atype, nargs=1)(cmd)
-
-        else:
-            argument_name = f'--{argument.name.lower().replace("_", "-")}'
-            cmd = click.option(
-                f'{argument_name}',
-                type=atype,
-                default=atype(default_value.value),
-                help=argument.help,
-            )(cmd)
+        argument_name = f'--{argument.name.lower().replace("_", "-")}'
+        cmd = click.option(
+            f'{argument_name}',
+            type=atype,
+            default = atype(default_value.value) if argument.presence != Argument.Presence.MANDATORY else None,
+            required= argument.presence == Argument.Presence.MANDATORY,
+            help=argument.help,
+        )(cmd)
 
     cmd = click.command(
         name = transition.name.replace('_', '-').lower(),


### PR DESCRIPTION
Resolving confusion from PR#[241](https://github.com/DUNE-DAQ/drunc/pull/241)
PR#[71](https://github.com/DUNE-DAQ/drunc/pull/71) was merged, and had the equivalent of one of the commits included, but it was missing this commit
 - Mandatory argument structure for `generate_fsm_command` [here](https://github.com/DUNE-DAQ/drunc/pull/241/commits/90e98409c9be43626d3728e02ea827eb5b912e68)

[Other commit](https://github.com/DUNE-DAQ/drunc/pull/241/commits/9b51587d008ccab15e57627f2abf1613ddb815ff) validated to already have been merged with PR#[]().