### PR TITLE
Pawel plesniak/terminate kill fixes

### DIFF
--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -76,13 +76,10 @@ async def dummy_boot(obj:ProcessManagerContext, user:str, n_processes:int, sleep
 
 
 @click.command('terminate')
-@add_query_options(at_least_one=False)
 @click.pass_obj
 @run_coroutine
-async def terminate(obj:ProcessManagerContext, query:ProcessQuery) -> None:
-    result = await obj.get_driver('process_manager').terminate(
-        query = query,
-    )
+async def terminate(obj:ProcessManagerContext) -> None:
+    result = await obj.get_driver('process_manager').terminate()
     if not result: return
 
     from drunc.process_manager.utils import tabulate_process_instance_list

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -86,7 +86,7 @@ async def terminate(obj:ProcessManagerContext) -> None:
     obj.print(tabulate_process_instance_list(result.data, 'Terminated process', False))
 
 @click.command('kill')
-@add_query_options(at_least_one=False)
+@add_query_options(at_least_one=True)
 @click.pass_obj
 @run_coroutine
 async def kill(obj:ProcessManagerContext, query:ProcessQuery) -> None:

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -192,7 +192,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
 
 
     @abc.abstractmethod
-    def _terminate_impl(self, q:ProcessQuery) -> ProcessInstanceList:
+    def _terminate_impl(self) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -201,10 +201,10 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         action=ActionType.DELETE,
         system=SystemType.PROCESS_MANAGER
     ) # 2nd step
-    @unpack_request_data_to(ProcessQuery) # 3rd step
-    def terminate(self, q:ProcessQuery) -> Response:
+    @unpack_request_data_to(None) # 3rd step
+    def terminate(self) -> Response:
         try:
-            resp = self._terminate_impl(q)
+            resp = self._terminate_impl()
             return Response(
                 name = self.name,
                 token = None,

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -281,11 +281,10 @@ To find the controller address, you can look up \'{top_controller_name}_control\
                 outformat = ProcessInstance,
             )
 
-    async def terminate(self, query:ProcessQuery) -> ProcessInstanceList:
+    async def terminate(self, ) -> ProcessInstanceList:
         return await self.send_command_aio(
             'terminate',
-            data = query,
-            outformat = ProcessInstanceList,
+            outformat = ProcessInstanceList
         )
 
     async def kill(self, query:ProcessQuery) -> ProcessInstance:

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -128,7 +128,7 @@ class SSHProcessManager(ProcessManager):
         return pil
 
 
-    def _terminate_impl(self, query:ProcessQuery) -> ProcessInstanceList:
+    def _terminate_impl(self) -> ProcessInstanceList:
         self._log.info('Terminating')
         if self.process_store:
             self._log.warning('Killing all the known processes before exiting')

--- a/src/drunc/process_manager/utils.py
+++ b/src/drunc/process_manager/utils.py
@@ -7,7 +7,7 @@ def generate_process_query(f, at_least_one:bool, all_processes_by_default:bool=F
         is_trivial_query = bool((len(uuid) == 0) and (session is None) and (len(name) == 0) and (user is None))
 
         if is_trivial_query and at_least_one:
-            raise click.BadParameter('You need to provide at least a \'--uuid\', \'--session\', \'--user\' or \'--name\'!\nAll these values are presented with \'ps\'.\nIf you want to kill everything, use \'terminate\'.')
+            raise click.BadParameter('You need to provide at least a \'--uuid\', \'--session\', \'--user\' or \'--name\'!\nAll these values are presented with \'ps\'.\nIf you want to kill everything, use \'ps\' and \'kill\'.')
 
         if all_processes_by_default and is_trivial_query:
             name = ['.*']

--- a/src/drunc/process_manager/utils.py
+++ b/src/drunc/process_manager/utils.py
@@ -5,10 +5,9 @@ def generate_process_query(f, at_least_one:bool, all_processes_by_default:bool=F
     @click.pass_context
     def new_func(ctx, session, name, user, uuid, **kwargs):
         is_trivial_query = bool((len(uuid) == 0) and (session is None) and (len(name) == 0) and (user is None))
-        # print(f'is_trivial_query={is_trivial_query} ({type(is_trivial_query)}): uuid={uuid} ({type(uuid)}), session={session} ({type(session)}), name={name} ({type(name)}), user={user} ({type(user)})')
 
         if is_trivial_query and at_least_one:
-            raise click.BadParameter('You need to provide at least a \'--uuid\', \'--session\', \'--user\' or \'--name\'!')
+            raise click.BadParameter('You need to provide at least a \'--uuid\', \'--session\', \'--user\' or \'--name\'!\nAll these values are presented with \'ps\'.\nIf you want to kill everything, use \'terminate\'.')
 
         if all_processes_by_default and is_trivial_query:
             name = ['.*']


### PR DESCRIPTION
Fixes Issue#[185](https://github.com/DUNE-DAQ/drunc/issues/185)
Removes the use of a `ProcessQuery` object from `terminate`