### PR TITLE
Update to include detector in ps

### DIFF
--- a/src/drunc/process_manager/oks_parser.py
+++ b/src/drunc/process_manager/oks_parser.py
@@ -121,7 +121,16 @@ def collect_apps(db, session, segment, env:Dict[str,str]) -> List[Dict]:
         "log_path": app.log_path,
       }
     )
-
+    if hasattr(app, "contains"):
+      for i in app.contains:
+        fullname_split = i.__fullname__.split("@")
+        detector_name = fullname_split[0]  
+        contains_class = fullname_split[1]
+        if contains_class == "DetectorToDaqConnection":
+          # REQUIRES REVIEW!!!!
+          # Note for local-1x1-session this is conn_apa1, but in ehn1-daqconfigs/segments this is e.g. apa1-connections/crp4-connections. This is not consistent between the schema
+          detector_name = [_ for _ in detector_name.replace("-", "_").split("_") if "conn" not in _][0].upper()
+          apps[-1]["detector_name"] = detector_name
   return apps
 
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -121,7 +121,8 @@ class ProcessManagerDriver(GRPCDriver):
                         session = session_name,
                         name = name,
                         hostname = "",
-                        tree_id = tree_id
+                        tree_id = tree_id,
+                        detector_name = app["detector_name"] if "detector_name" in app else None
                     ),
                     executable_and_arguments = executable_and_arguments,
                     env = env,
@@ -161,9 +162,9 @@ class ProcessManagerDriver(GRPCDriver):
             except Exception as e:
                 log.critical(f'''\nInvalid configuration passed (cannot consolidate your configuration). To debug it, close drunc and run the following command:
 
-[yellow]oks_dump --files-only {oks_conf}[/]
+                [yellow]oks_dump --files-only {oks_conf}[/]
 
-''', extra={'markup': True})
+                ''', extra={'markup': True})
                 return
 
         db = conffwk.Configuration(f"oksconflibs:{oks_conf}")

--- a/src/drunc/process_manager/utils.py
+++ b/src/drunc/process_manager/utils.py
@@ -1,4 +1,4 @@
-
+from druncschema.process_manager_pb2 import ProcessInstanceList, ProcessInstance
 def generate_process_query(f, at_least_one:bool, all_processes_by_default:bool=False):
     import click
 
@@ -44,18 +44,19 @@ def make_tree(values):
             lines.append("    " + m.name)
     return lines
 
-def tabulate_process_instance_list(pil, title, long=False):
+def tabulate_process_instance_list(pil:ProcessInstanceList, title:str, long:bool=False):
     from rich.table import Table
     t = Table(title=title)
-    t.add_column('session')
-    t.add_column('friendly name')
-    t.add_column('user')
-    t.add_column('host')
-    t.add_column('uuid')
-    t.add_column('alive')
-    t.add_column('exit-code')
+    t.add_column('Session')
+    t.add_column('Friendly name')
+    t.add_column('Detector')
+    t.add_column('User')
+    t.add_column('Host')
+    t.add_column('UUID')
+    t.add_column('Alive')
+    t.add_column('Exit-code')
     if long:
-        t.add_column('executable')
+        t.add_column('Executable')
 
     from operator import attrgetter
     sorted_pil = sorted(pil.values, key=attrgetter('process_description.metadata.tree_id'))
@@ -63,9 +64,8 @@ def tabulate_process_instance_list(pil, title, long=False):
     try:
         for process, line in zip(sorted_pil, tree_str):
             m = process.process_description.metadata
-            from druncschema.process_manager_pb2 import ProcessInstance
             alive = 'True' if process.status_code == ProcessInstance.StatusCode.RUNNING else '[danger]False[/danger]'
-            row = [m.session, line, m.user, m.hostname, process.uuid.uuid]
+            row = [m.session, line, m.detector_name, m.user, m.hostname, process.uuid.uuid]
             if long:
                 executables = [e.exec for e in process.process_description.executable_and_arguments]
                 row += ['; '.join(executables)]


### PR DESCRIPTION
`ps` now includes the detector name, derived from the presence of a `DetectorToDaqConnection`. 
Requires https://github.com/DUNE-DAQ/druncschema/pull/32