### PR TITLE
Add ruff configuration + CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint with ruff
+
+on:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v1

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,5 @@
+exclude = ["tests/*"]
+
+[lint]
+ignore = ["ALL"]
+select = ["F821"]

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     ],
     extras_require={"develop": [
         "ipdb",
-        "ipython"
+        "ipython",
+        "ruff",
     ]},
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     ],
     extras_require={"develop": [
         "ipdb",
-        "ipython",
-        "ruff",
+        "ipython"
     ]},
 )

--- a/src/drunc/broadcast/server/grpc_servicer.py
+++ b/src/drunc/broadcast/server/grpc_servicer.py
@@ -4,9 +4,11 @@ from queue import Queue
 from druncschema.broadcast_pb2_grpc import BroadcastSenderServicer
 from druncschema.broadcast_pb2 import BroadcastRequest
 from druncschema.request_response_pb2 import Request, Response
-from druncschema.generic_pb2 import PlainText
+from druncschema.generic_pb2 import PlainText, StringStringMap
 from druncschema.broadcast_pb2 import BroadcastMessage, BroadcastType
 from druncschema.authoriser_pb2 import ActionType
+from drunc.utils.grpc_utils import unpack_any
+from google.protobuf.any_pb2 import Any
 
 class ListenerRepresentation:
 
@@ -242,7 +244,7 @@ def main():
         try:
             server_thread = Thread(target=serve, kwargs={'port':port}, name=f'serve_thread_{port}')
             server_thread.start()
-            receiver_threads.append(serve_thread)
+            receiver_threads.append(server_thread)
         except:
             pass
 

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -1,4 +1,5 @@
 from drunc.controller.children_interface.child_node import ChildNode
+from drunc.exceptions import DruncSetupException
 from drunc.utils.utils import ControlType
 from druncschema.request_response_pb2 import Response
 from druncschema.token_pb2 import Token

--- a/src/drunc/fsm/actions/thread_pinning.py
+++ b/src/drunc/fsm/actions/thread_pinning.py
@@ -1,6 +1,7 @@
 from drunc.fsm.core import FSMAction
 from drunc.utils.configuration import find_configuration
 from drunc.fsm.exceptions import ThreadPinningFailed
+from drunc.exceptions import DruncSetupException
 
 
 class ThreadPinning(FSMAction):

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -1,4 +1,5 @@
 from drunc.utils.configuration import ConfHandler
+from rich import print as rprint
 
 from enum import Enum
 

--- a/src/drunc/utils/flask_manager.py
+++ b/src/drunc/utils/flask_manager.py
@@ -198,7 +198,7 @@ class FlaskManager(threading.Thread):
 
 def main():
     from drunc.utils.utils import get_new_port
-    from flask import Flask, make_response, jsonify
+    from flask import Flask, make_response, jsonify, request
     from flask_restful import Api, Resource
 
     class DummyEndpoint(Resource):

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -1,5 +1,6 @@
 from drunc.exceptions import DruncCommandException,DruncException
-from druncschema.request_response_pb2 import Response
+from druncschema.request_response_pb2 import Response, ResponseFlag
+from druncschema.generic_pb2 import PlainText
 
 class UnpackingError(DruncCommandException):
     def __init__(self, data, format):


### PR DESCRIPTION
This PR setups up the repository to use ruff and adds a CI workflow that runs for pull requests.

Currently only one rule is enabled [F821](https://docs.astral.sh/ruff/rules/undefined-name/). This finds undefined names in the code base mostly missing imports but also the odd typo. I've fixed all of the violations that were trivial but there remain a few that need a more expert eye. Plesae feel free to amend this PR with the fixes.

It's worth noting that the full set of [F rules](https://docs.astral.sh/ruff/rules/#pyflakes-f) catches 182 violations but 162 of these can be automatically fixed by ruff. Besides the outstanding F821 violations the remaining things to fix would all be unused imports or unused variables. Both pretty easy to take care of. Worth considering I think to reasonable rule coverage with fairly low effort.