### PR TITLE
Format the available commands

### DIFF
--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -306,7 +306,7 @@ class ShellContext:
         if status.in_error:
             self.print(f"[red] FSM is in error ({status})[/red], not currently accepting new commands.")
         else:
-            available_actions = [command.name for command in self.get_driver('controller').describe_fsm().data.commands]
+            available_actions = [command.name.replace('_', '-') for command in self.get_driver('controller').describe_fsm().data.commands]
             self.print(f"Current FSM status is [green]{status.state}[/green]. Available transitions are [green]{'[/green], [green]'.join(available_actions)}[/green].")
 
 


### PR DESCRIPTION
Replaces
```
Current FSM status is running. Available transitions are disable_triggers, change_rate.
```
with
```
Current FSM status is running. Available transitions are disable-triggers, change-rate.
```
after a command is ran, i.e. add a `replace("_", "-")` to the command name.