### PR TITLE
Restart `obj.print` removal

### DIFF
--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -172,10 +172,6 @@ async def restart(obj:ProcessManagerContext, query:ProcessQuery) -> None:
         query = query,
     )
 
-    if not result: return
-
-    obj.print(result.data)
-
 
 @click.command('ps')
 @add_query_options(at_least_one=False, all_processes_by_default=True)


### PR DESCRIPTION
This was annoying. Would print the ProcessInstance of the restarted process, not needed