### PR TITLE
Missing exception type in connectivity_service client publish function.

### DIFF
--- a/src/drunc/connectivity_service/client.py
+++ b/src/drunc/connectivity_service/client.py
@@ -130,7 +130,7 @@ class ConnectivityServiceClient:
                     ignore_errors = True
                 ).raise_for_status()
                 break
-            except (HTTPError, ConnectionError) as e:
+            except (HTTPError, ConnectionError, ReadTimeout) as e:
                 from time import sleep
                 sleep(0.2)
                 continue


### PR DESCRIPTION
While debugging the occasional slow startup of DAQ applications and `drunc` controller applications on Fermilab development computer `daq.fnal.gov`, I noticed that a particular exception type was not being caught in the `publish` function of the `drunc` ConnSvc client code.  This PR has a code change that adds that exception type.

The following steps can be used to demonstrate the behavior of this code change:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest_v5
dbt-create -n NFD_DEV_241216_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
cd daqsystemtest; git checkout fc40036a8c; cd ..
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

git clone https://github.com/DUNE-DAQ/connectivityserver.git -b kbiery/artificial_get_connection_delay
cd connectivityserver; pip install -U .; cd ..

git clone https://github.com/DUNE-DAQ/drunc.git -b develop
cd drunc
sed -i s/self.logger.debug\(f\'Publishing/self.logger.info\(f\'Publishing/ src/drunc/connectivity_service/client.py
pip install -U .; cd ..

daqsystemtest_integtest_bundle.sh -l 0

echo ""
echo "================================================================================"
echo ""
grep attempt /tmp/pytest-of-${USER}/pytest-current/runcurrent/log*.txt
echo ""
echo "================================================================================"
echo ""

cd $DBT_AREA_ROOT/drunc
git stash
git checkout kbiery/addl_excpt_catch_connsvc_client
git stash pop
pip install -U . ; cd ..

daqsystemtest_integtest_bundle.sh -l 0

echo ""
echo "================================================================================"
echo ""
grep attempt /tmp/pytest-of-${USER}/pytest-current/runcurrent/log*.txt
echo ""
echo "================================================================================"
echo ""
```

In the results of the first running of the `minimal_system_quick_test` in these sample instructions, one often sees `ReadTimeoutErrors` in the console output from the test, and one **_never_** sees publish attempt numbers great than one.

In the results of the second running of the `minimal_system_quick_test` (i.e. with the changes from this PR), one does **_not_** see `ReadTimeoutErrors` in the test output, and one **_does_** see publish attempt numbers greater than one.

I believe that this demonstrates the value of this code change.