### PR TITLE
I noticed that when the ping failed, the controller went into error

### DIFF
--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -238,7 +238,7 @@ class AppCommander:
             self.log.debug(f'\'{self.app}\' pings')
             return True
         except Exception as e:
-            self.log.debug(f'\'{self.app}\' does not ping, reason: \'{str(e)}\'')
+            self.log.error(f'\'{self.app}\' does not ping, reason: \'{str(e)}\'')
             return False
 
     def send_command(


### PR DESCRIPTION
status and the integration test I was running failed. Tracking down the issue was non-trivial, and would have been a lot easier if this message was not a debug, but an error.