### PR TITLE
Run type issue addressing

### DIFF
--- a/src/drunc/fsm/actions/db_run_registry.py
+++ b/src/drunc/fsm/actions/db_run_registry.py
@@ -34,7 +34,7 @@ class DBRunRegistry(FSMAction):
     def pre_start(self, _input_data:dict, _context, **kwargs):
         self.run_number = _input_data['run'] #Seems like run_number isn't in _input_data in post_drain_dataflow so need to initialise it here
         run_configuration = find_configuration(_context.configuration.initial_data)
-        run_type = _input_data.get("run_type", "TEST")
+        run_type = _input_data.get("production_vs_test", "TEST")
         det_id = _context.configuration.db.get_dal(class_name = "Session", uid = _context.configuration.oks_key.session).detector_configuration.id
         software_version = os.getenv("DUNE_DAQ_BASE_RELEASE")
         if software_version == None:

--- a/src/drunc/fsm/actions/usvc_elisa_logbook.py
+++ b/src/drunc/fsm/actions/usvc_elisa_logbook.py
@@ -30,7 +30,7 @@ class ElisaLogbook(FSMAction):
             self._log.info(f"Adding the message:\n--------\n{elisa_post}\n--------\nto the logbook")
             text += f"\n<p>{elisa_post}</p>"
 
-        self.run_type = _input_data.get('run_type', "TEST")    #This class won't exist in a test run, so we're adding this temporarily so that we can actually run the function
+        self.run_type = _input_data.get('production_vs_test', "TEST")    #This class won't exist in a test run, so we're adding this temporarily so that we can actually run the function
         run_configuration = find_configuration(_context.configuration.initial_data)
         text += f"Configuration: {run_configuration}"
 


### PR DESCRIPTION
Addresses [#328](https://github.com/DUNE-DAQ/drunc/issues/328)

To test
In `ccm.data.xml` from `daqsystemtest`, change `root-controller.fsm` from `fsmConf-test` to `fsmConf-prod`.
Run
```
drunc-unified-shell ssh-standalone config/daqsystemtest/example-configs.data.xml local-2x3-config
boot
conf
start --run-type PROD
drain-dataflow
stop-trigger-sources
stop
start --run-type TEST
drain-dataflow
stop-trigger-sources
stop
start --run-type PROD
drain-dataflow
stop-trigger-sources
stop
start --run-type TEST
drain-dataflow
stop-trigger-sources
stop
terminate
quit
```

Example output
In `logbook.txt`
```
Run 35357 started by pplesnia at 01/24/2025,18:09:19
Current run stopped by pplesnia at 01/24/2025,18:09:29
Run 35358 started by pplesnia at 01/24/2025,18:09:36
Current run stopped by pplesnia at 01/24/2025,18:09:44
Run 35359 started by pplesnia at 01/24/2025,18:09:52
Current run stopped by pplesnia at 01/24/2025,18:09:55
Run 35360 started by pplesnia at 01/24/2025,18:10:05
Current run stopped by pplesnia at 01/24/2025,18:10:12
```
From run registry
```
[["RUN_NUMBER","START_TIME","STOP_TIME","DETECTOR_ID","RUN_TYPE","SOFTWARE_VERSION"],
[[35360,"Fri, 24 Jan 2025 17:10:05 GMT","Fri, 24 Jan 2025 17:10:12 GMT","dummy-detector","PROD","fddaq-v5.2.1-rc2-a9"],
[35359,"Fri, 24 Jan 2025 17:09:52 GMT","Fri, 24 Jan 2025 17:09:55 GMT","dummy-detector","TEST","fddaq-v5.2.1-rc2-a9"],
[35358,"Fri, 24 Jan 2025 17:09:36 GMT","Fri, 24 Jan 2025 17:09:44 GMT","dummy-detector","PROD","fddaq-v5.2.1-rc2-a9"],
[35357,"Fri, 24 Jan 2025 17:09:18 GMT","Fri, 24 Jan 2025 17:09:29 GMT","dummy-detector","TEST","fddaq-v5.2.1-rc2-a9"]]]
```