### PR TITLE
Send errors executing the ssh command to the Error log stream (successes are always silent)

### DIFF
--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -279,7 +279,7 @@ class SSHProcessManager(ProcessManager):
                 self.process_store[uuid] = self.ssh (
                     *arguments,
                     # _out=partial(self._process_children_logs, uuid),
-                    _out=self.log.error,
+                    _err=self.log.error,
                     _bg=True,
                     _bg_exc=False,
                     _new_session=True,

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -279,6 +279,7 @@ class SSHProcessManager(ProcessManager):
                 self.process_store[uuid] = self.ssh (
                     *arguments,
                     # _out=partial(self._process_children_logs, uuid),
+                    _out=self.log.error,
                     _bg=True,
                     _bg_exc=False,
                     _new_session=True,

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -279,6 +279,7 @@ class SSHProcessManager(ProcessManager):
                 self.process_store[uuid] = self.ssh (
                     *arguments,
                     # _out=partial(self._process_children_logs, uuid),
+                    _out=self.log.debug,
                     _err=self.log.error,
                     _bg=True,
                     _bg_exc=False,


### PR DESCRIPTION
I was trying to debug why some of my processes were failing to boot, and I was getting a message:
```
[2025/02/27 09:40:02] INFO       ssh_process_manager.py:209     drunc.process_manager.SSH_process_manager:    Process 'hsi-fake-01' (session: 'local-1x1-config', user: 'eflumerf') process exited with exit code 255
```
But there were no log files, and on more investigation, we never `exit(-1)` in our code.

After making this change in ssh_process_manager.py, I get more helpful output:
```
⠋ Looking for root-controller on the connectivity service... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ -:--:-- 0:00:00[2025/02/27 09:40:02] INFO       ssh_process_manager.py:209     drunc.process_manager.SSH_process_manager:    Process 'hsi-fake-controller' (session: 'local-1x1-config', user: 'eflumerf') process exited with exit code 255
[2025/02/27 09:40:02] INFO       ssh_process_manager.py:209     drunc.process_manager.SSH_process_manager:    Process 'hsi-fake-01' (session: 'local-1x1-config', user: 'eflumerf') process exited with exit code 255
⠹ Looking for root-controller on the connectivity service... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ -:--:-- 0:00:00[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:    X Error of failed request:  BadWindow (invalid Window parameter)

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Major opcode of failed request:  20 (X_GetProperty)

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Resource id in failed request:  0x1000001

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:    X Error of failed request:  BadWindow (invalid Window parameter)

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Serial number of failed request:  12

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Major opcode of failed request:  20 (X_GetProperty)

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Current serial number in output stream:  12

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Resource id in failed request:  0xc00001

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Serial number of failed request:  12

[2025/02/27 09:40:02] ERROR      sh.py:1717                     drunc.process_manager.SSH_process_manager:      Current serial number in output stream:  12
```

Aha! Something is wrong with my X config!