### PR TITLE
Correct the endpoint for the flask manager

### DIFF
--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -107,7 +107,7 @@ class ResponseListener:
                     return "ready"
 
                 cls.app.add_url_rule("/response", "index", index, methods=["POST"])
-                cls.app.add_url_rule("/", "get", get, methods=["GET"])
+                cls.app.add_url_rule("/readystatus", "get", get, methods=["GET"])
                 cls.manager = FlaskManager(
                     port = cls.port,
                     app = cls.app,

--- a/src/drunc/utils/flask_manager.py
+++ b/src/drunc/utils/flask_manager.py
@@ -130,10 +130,11 @@ class FlaskManager(threading.Thread):
                 resp = requests.get(f"http://{self.host}:{self.port}/readystatus")
                 if resp.text == "ready":
                     break
-            except Exception:
-                pass
+            except Exception as e:
+                self.log.info(f'Cannot get status from {self.name}: {e}, retrying in 0.5s...')
             time.sleep(0.5)
 
+        self.log.info(f'{self.name} is ready')
         # We don't release that lock before we have received a "ready" from the listener
         with self.ready_lock:
             self.ready = True


### PR DESCRIPTION
This may be related to this issue: https://github.com/DUNE-DAQ/drunc/issues/374
That definitely fixes a bug.

What is a bit more worrying is that I haven't understood how the system works with what is currently on `develop`. Still investigating.