### PR TITLE
Make the --dfo-name parameter optional

### DIFF
--- a/src/drunc/fsm/actions/enable_dfo.py
+++ b/src/drunc/fsm/actions/enable_dfo.py
@@ -1,36 +1,43 @@
 from drunc.fsm.core import FSMAction
 from drunc.fsm.exceptions import EnableDFOFailed
 from drunc.utils.configuration import find_configuration
+from drunc.utils.utils import get_logger
 
 
 class EnableDFO(FSMAction):
     def __init__(self, configuration):
         super().__init__(name="enable-dfo")
-        import logging
 
-        self.log = logging.getLogger("enable-dfo")
+        self.log = get_logger("controller.enable_dfo_action")
         self.conf_dict = {p.name: p.value for p in configuration.parameters}
 
-    def validate_enable_dfo(self, dfo_name, configuration):
-        if dfo_name == "":
+    def validate_enable_dfo(self, dfo_name, session, configuration):
+        self.log.debug(f"Validating dfo-name {dfo_name} in session {session}")
+        if dfo_name == "DISABLE":
             # Special case, disable DFO
-            return
+            return ""
         # Validate DFO Name
         import conffwk
 
         db = conffwk.Configuration(f"oksconflibs:{configuration}")
         dfos = db.get_dals(class_name="DFOApplication")
-        dfo_found = False
+        sessionobj = db.get_dal("Session", session)
+        disabled = sessionobj.disabled
         for dfo in dfos:
-            if dfo.id == dfo_name:
-                dfo_found = True
-                break
+            if dfo not in disabled:
+                if dfo_name == "":
+                    self.log.info(f"No --dfo-name passed to enable-dfo. Enabling first DFO in session {session}: {dfo.id}")
+                    return dfo.id
+                if dfo.id == dfo_name:
+                    return dfo_name
+            else:
+                self.log.debug(f"Not considering session-disabled DFO {dfo.id}")
 
-        if not dfo_found:
-            raise EnableDFOFailed(dfo_name)
+        raise EnableDFOFailed(dfo_name, session)
 
-    def pre_enable_dfo(self, _input_data, _context, dfo_name: str, **kwargs):
+    def pre_enable_dfo(self, _input_data, _context, dfo_name: str = "", **kwargs):
         run_configuration = find_configuration(_context.configuration.initial_data)
-        self.validate_enable_dfo(dfo_name, run_configuration)
+        dfo_name = self.validate_enable_dfo(dfo_name, _context.session, run_configuration)
+        self.log.debug(f"Enabling DFO {dfo_name}")
         _input_data["dfo"] = dfo_name
         return _input_data

--- a/src/drunc/fsm/exceptions.py
+++ b/src/drunc/fsm/exceptions.py
@@ -148,8 +148,8 @@ class ThreadPinningFailed(FSMException):
 
 
 class EnableDFOFailed(FSMException):
-    def __init__(self, dfo):
-        self.message = f'Could not enable DFO "{dfo}" failed'
+    def __init__(self, dfo, session):
+        self.message = f'Could not enable DFO "{dfo}" in session "{session}"'
         super().__init__(self.message)
 
 


### PR DESCRIPTION
If not set, set to first enabled DFO in session. Validate against Session.disabled, do not try to enable a DFO that is not enabled in the current Session!