### PR TITLE
Fix imports of non-standard tooling

### DIFF
--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -21,7 +21,6 @@ from druncschema.request_response_pb2 import (
     ResponseFlag,
 )
 from druncschema.token_pb2 import Token
-from kafkaopmon.OpMonPublisher import OpMonPublisher
 
 from drunc.authoriser.configuration import DummyAuthoriserConfHandler
 from drunc.authoriser.decorators import authentified_and_authorised
@@ -96,6 +95,8 @@ class Controller(ControllerServicer):
     children_nodes = []  # type: List[ChildNode]
 
     def __init__(self, configuration, name: str, session: str, token: Token):
+        from kafkaopmon.OpMonPublisher import OpMonPublisher
+
         super().__init__()
 
         self.name = name

--- a/src/drunc/controller/stateful_node.py
+++ b/src/drunc/controller/stateful_node.py
@@ -1,7 +1,7 @@
-import abc
-from typing import Optional
+from __future__ import annotations
 
-from kafkaopmon.OpMonPublisher import OpMonPublisher
+import abc
+from typing import TYPE_CHECKING, Optional
 
 from drunc.exceptions import DruncCommandException
 from drunc.fsm.core import FSM
@@ -9,7 +9,8 @@ from drunc.fsm.exceptions import InvalidTransition
 from drunc.fsm.utils import decode_fsm_arguments
 from drunc.utils.utils import get_logger
 
-from druncschema.opmon_pb2 import Status  # isort: skip
+if TYPE_CHECKING:
+    from kafkaopmon.OpMonPublisher import OpMonPublisher
 
 
 class Observed:
@@ -89,7 +90,7 @@ class StatefulNode(abc.ABC):
     def __init__(
         self,
         fsm_configuration,
-        publisher: Optional[OpMonPublisher] = None,
+        publisher: Optional["OpMonPublisher"] = None,
         session: str = "",
         name: str = "",
     ):
@@ -109,6 +110,8 @@ class StatefulNode(abc.ABC):
         self.__in_error = ErrorState(stateful_node=self, initial_value=False)
 
     def publish_state(self):
+        from druncschema.opmon_pb2 import Status
+
         if self.publisher is not None:
             self.publisher.publish(
                 session=self.session,

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -4,7 +4,6 @@ import os
 import signal
 import tempfile
 
-from daqconf.consolidate import consolidate_db
 from druncschema.process_manager_pb2 import (
     BootRequest,
     LogLine,
@@ -23,11 +22,6 @@ from drunc.connectivity_service.client import ConnectivityServiceClient
 from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
 from drunc.controller.utils import get_segment_lookup_timeout
 from drunc.exceptions import DruncSetupException, DruncShellException
-from drunc.process_manager.oks_parser import (
-    collect_apps,
-    collect_infra_apps,
-    collect_variables,
-)
 from drunc.process_manager.utils import get_log_path, get_rte_script
 from drunc.utils.shell_utils import GRPCDriver
 from drunc.utils.utils import (
@@ -59,6 +53,8 @@ class ProcessManagerDriver(GRPCDriver):
         session_name: str,
         override_logs: bool,
     ) -> BootRequest:
+        from drunc.process_manager.oks_parser import collect_apps, collect_infra_apps
+
         env = {
             "DUNEDAQ_SESSION": session_name,
         }
@@ -163,6 +159,8 @@ class ProcessManagerDriver(GRPCDriver):
         override_logs: bool = True,
         **kwargs,
     ) -> ProcessInstance:
+        from daqconf.consolidate import consolidate_db
+
         self.log.info(f"Booting session [green]{session_name}[/green]")
 
         with tempfile.NamedTemporaryFile(suffix=".data.xml", delete=True) as f:
@@ -205,6 +203,8 @@ To debug it, close drunc and run the following command:
         top_controller_name = session_dal.segment.controller.id
 
         def get_controller_address(session_dal, session_name):
+            from drunc.process_manager.oks_parser import collect_variables
+
             env = {}
             collect_variables(session_dal.environment, env)
             if session_dal.connectivity_service:


### PR DESCRIPTION
This PR tweaks the imports of some tooling required by `drunc` such that they are imported within the methods/functions that really required them. This is necessary so that `drunc_ui`, which does not need any of that functionality within `drunc`, can import the relevant modules without failure.

The changes made in this PR allow the `drunc_ui` to run, but I don't know if it will cause a problem somewhere else.