### PR TITLE
Verbose output for thread pinning

### DIFF
--- a/src/drunc/fsm/actions/thread_pinning.py
+++ b/src/drunc/fsm/actions/thread_pinning.py
@@ -71,7 +71,7 @@ class ThreadPinning(FSMAction):
                     *arguments,
                     _err_to_out=True,
                 )
-                self.log.info(proc.stdout.decode("ascii"))
+                self.log.info(proc)
             except ErrorReturnCode as e:
                 self.log.error(e.stdout.decode("ascii"))
                 self.log.error(e.stderr.decode("ascii"))

--- a/src/drunc/fsm/actions/thread_pinning.py
+++ b/src/drunc/fsm/actions/thread_pinning.py
@@ -67,7 +67,11 @@ class ThreadPinning(FSMAction):
                 self.log.info(
                     f"Applying thread pinning {cmd} file {thread_pinning_file} on {host}"
                 )
-                proc = my_ssh(*arguments)
+                proc = my_ssh(
+                    *arguments,
+                    _err_to_out=True,
+                )
+                self.log.info(proc.stdout.decode("ascii"))
             except ErrorReturnCode as e:
                 self.log.error(e.stdout.decode("ascii"))
                 self.log.error(e.stderr.decode("ascii"))


### PR DESCRIPTION
Add the stdout from the ThreadPinning FSM action to the log files in order to catch errors that do not result in a non-zero exit code (as originally designed in `readout-affinity.py`).