### PR TITLE
JCF: Issue #423: modify Markdown so it works not just with GitHub but…

### DIFF
--- a/docs/Controller-interface.md
+++ b/docs/Controller-interface.md
@@ -47,12 +47,12 @@ message Argument {
 }
 ```
 Where:
- - `name` is the name of the arguments
- - `presence` is encoded in an enum defined in the Argument schema.
- - `type` is the data type. Note that the only supported data types are the ones listed here.
- - `default_value` is the default value that the argument will take (required if presence=optional)
- - `choices` are the eventual choices that the argument can take
- - `help` is some string for help.
+* `name` is the name of the arguments
+* `presence` is encoded in an enum defined in the Argument schema.
+* `type` is the data type. Note that the only supported data types are the ones listed here.
+* `default_value` is the default value that the argument will take (required if presence=optional)
+* `choices` are the eventual choices that the argument can take
+* `help` is some string for help.
 
 ### `FSMCommandDescription`
 have the [form](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/controller.proto#L66):
@@ -66,11 +66,11 @@ message FSMCommandDescription {
 }
 ```
 Where:
- - `name` is the name of the FSM command (such as `conf`, `enable_triggers`, etc.)
- - `data_type` is what is needed to run the command (it's always `FSMCommand` - described later)
- - `help` some explanatory text of the command (never really filled but would be nice to have at some point)
- - `return_type` is what is returned by the command (it's always `FSMCommandResponse` - described later)
- - `arguments` is a list of the arguments in [`Argument` format](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#argument) that are needed to execute the command.
+* `name` is the name of the FSM command (such as `conf`, `enable_triggers`, etc.)
+* `data_type` is what is needed to run the command (it's always `FSMCommand` - described later)
+* `help` some explanatory text of the command (never really filled but would be nice to have at some point)
+* `return_type` is what is returned by the command (it's always `FSMCommandResponse` - described later)
+* `arguments` is a list of the arguments in [`Argument` format](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#argument) that are needed to execute the command.
 
 ### `FSMCommandsDescription`
 Is a list of available FSM commands described above:
@@ -96,14 +96,14 @@ message FSMCommand{
 ```
 
 where:
- - `command_name` is the name of the command one wants to execute (such as `conf`, `enable_triggers`, etc.)
- - `arguments` is a map of argument names to their values. Their value must be one of the 4:
-    - [`int_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L22)
-    - [`float_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L25)
-    - [`string_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L28)
-    - [`bool_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L31)
- - `children_nodes` is used to address the command to one or more children. If one wants to send a command to a specific list of children they can be specified as a list here. If no list is specified, the controller will send the FSM command to all the children.
- - `data` is the internal drunc message that gets derived from the FSMInterfaces. The user should not fill this out manually.
+* `command_name` is the name of the command one wants to execute (such as `conf`, `enable_triggers`, etc.)
+* `arguments` is a map of argument names to their values. Their value must be one of the 4:
+  * [`int_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L22)
+  * [`float_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L25)
+  * [`string_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L28)
+  * [`bool_msg`](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L31)
+* `children_nodes` is used to address the command to one or more children. If one wants to send a command to a specific list of children they can be specified as a list here. If no list is specified, the controller will send the FSM command to all the children.
+* `data` is the internal drunc message that gets derived from the FSMInterfaces. The user should not fill this out manually.
 
 ### `FSMResponseFlag`
 Is a simple enum to understand if the command was successful or not:
@@ -126,9 +126,9 @@ message FSMCommandResponse{
 }
 ```
 where:
- - `flag` is a simple enum describing the FSM command's successful execution or not
- - `command_name` is the command that was executed.
- - `data` is the returned data for the FSM transition (which can be safely ignored for now, since it's not used)
+* `flag` is a simple enum describing the FSM command's successful execution or not
+* `command_name` is the command that was executed.
+* `data` is the returned data for the FSM transition (which can be safely ignored for now, since it's not used)
 
 
 The controller is interfaced through `gRPC` messaging. The `drunc` server should be interfaced through the `drunc`-defined [messages](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Messaging-format). This document refers to the `controller` in particular. Its `proto` can be found [here](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/controller.proto)
@@ -144,64 +144,64 @@ One can ask the controller to specifically describe its FSM. The controller will
 
 ### `execute_fsm_command`
 FSM commands can be sent to the controller by using the RPC endpoint `execute_fsm_command`:
- - input: [FSMCommand](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#fsmcommand)
- - output: [FSMCommandResponse](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#fsmcommandresponse)
- - interruption/exceptions:
-    - The sender is not in control of the controller
-    - The arguments in the input data are not of correct type
-    - The mandatory arguments were not specified
+* input: [FSMCommand](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#fsmcommand)
+* output: [FSMCommandResponse](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#fsmcommandresponse)
+* interruption/exceptions:
+  * The sender is not in control of the controller
+  * The arguments in the input data are not of correct type
+  * The mandatory arguments were not specified
 
 ### `get_status`
- - input: None
- - output: [Status message](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#status)
- - interruption/exceptions:
-    - None hopefully
+* input: None
+* output: [Status message](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#status)
+* interruption/exceptions:
+  * None hopefully
 
 ### `get_children_status`
- - input: None
- - output: [ChildrenStatus message](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#childrenstatus)
- - interruption/exceptions:
-    - One child cannot be reached (I think)
+* input: None
+* output: [ChildrenStatus message](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface#childrenstatus)
+* interruption/exceptions:
+  * One child cannot be reached (I think)
 
 ### `ls`
- - input: None
- - output: [PlainTextVector](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L11) containing all a list of the controller's children
- - interruption/exceptions:
-    - None hopefully
+* input: None
+* output: [PlainTextVector](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L11) containing all a list of the controller's children
+* interruption/exceptions:
+  * None hopefully
 
 ### `exclude`
 Excluded nodes won't be passed FSM commands. This command excludes the controller and all its descendants.
- - input: None (TODO should be a list of children to exclude)
- - output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<controller_name> excluded"
- - interruption/exceptions:
-    - The sender is not in control of the controller
-    - The controller is already excluded
+* input: None (TODO should be a list of children to exclude)
+* output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<controller_name> excluded"
+* interruption/exceptions:
+  * The sender is not in control of the controller
+  * The controller is already excluded
 
 ### `include`
 Excluded nodes won't be passed FSM commands. This command includes the controller and all its descendants.
- - input: None (TODO should be a list of children to include)
- - output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<controller_name> included"
- - interruption/exceptions:
-    - The sender is not in control of the controller
-    - The controller is already included
+* input: None (TODO should be a list of children to include)
+* output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<controller_name> included"
+* interruption/exceptions:
+  * The sender is not in control of the controller
+  * The controller is already included
 
 ### `take_control`
 Takes control of a controller and it's children
- - input: None (TODO should be a list of children to take control of)
- - output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<user_name> took control"
- - interruption/exceptions:
-    - Someone is already in control of the controller (including the same user name)
+* input: None (TODO should be a list of children to take control of)
+* output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<user_name> took control"
+* interruption/exceptions:
+  * Someone is already in control of the controller (including the same user name)
 
 ### `surrender_control`
 Surrenders control of a controller and it's children
- - input: None (TODO should be a list of children to surrender the control of)
- - output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<user_name> surrendered control"
- - interruption/exceptions:
-    - The sender is not in control of the controller
+* input: None (TODO should be a list of children to surrender the control of)
+* output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<user_name> surrendered control"
+* interruption/exceptions:
+  * The sender is not in control of the controller
 
 ### `who_is_in_charge`
 Says who is controlling the controller
- - input: None
- - output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<user_name>"
- - interruption/exceptions:
-    - None hopefully.
+* input: None
+* output: [PlainText](https://github.com/DUNE-DAQ/druncschema/blob/develop/schema/druncschema/generic.proto#L7) of the form: "<user_name>"
+* interruption/exceptions:
+  * None hopefully.

--- a/docs/Controller.md
+++ b/docs/Controller.md
@@ -21,16 +21,15 @@ This interface is very similar to the `drunc-unified-shell`. All the commands on
 
 ### `conf`, `start`, `enable-triggers`, `change-rate`, `disable-triggers`, `drain-dataflow`, `stop-trigger-sources`, `stop` and `scrap`
 More details on the available FSM commands is provided [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/FSM).
-
- - See `conf`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#conf)
- - See `start`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
- - See `enable-triggers`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
- - See `change-rate`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#change-rate)
- - See `disable-triggers`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
- - See `drain-dataflow`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
- - See `stop-trigger-sources`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop-trigger-sources)
- - See `stop`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop)
- - See `scrap`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#scrap)
+* See `conf`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#conf)
+* See `start`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
+* See `enable-triggers`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
+* See `change-rate`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#change-rate)
+* See `disable-triggers`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
+* See `drain-dataflow`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
+* See `stop-trigger-sources`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop-trigger-sources)
+* See `stop`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop)
+* See `scrap`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#scrap)
 
 ### `connect`
 See `connect`'s documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#connect)

--- a/docs/FSM.md
+++ b/docs/FSM.md
@@ -2,7 +2,7 @@
 ## Schematic
 The FSM operates the DAQ infrastructure. The FSM is configurable, so technically this schema is a special case of a configuration... But if you are here, you probably want to use the DAQ.
 
-![FSM](https://github.com/DUNE-DAQ/drunc/blob/develop/docs/FSM.png)
+![FSM](FSM.png)
 
 Each transition (black arrow) is translated to a `drunc-controller-shell` or `drunc-unified-shell` command defined, what they do is describe later. States are in the green boxes, each `drunc-controller` should be in one of these states. Batch of transitions can be run as sequences (yellow dotted lines) which execute a series of transitions (although they are not working anymore...)
 
@@ -10,29 +10,29 @@ Before and after certain transitions, there are actions that are associated with
 
 ## Common configurations
 Three configurations are currently available, they are defined in [in this file](https://github.com/DUNE-DAQ/daqsystemtest/blob/develop/config/daqsystemtest/fsm.data.xml):
-- `fsmConf-test`
-    - This configuration is for test setup _anywhere_. With this configuration, you get:
-        - Asked by the run control for a run number (user-provided-run-number action) when you start: you need to provide `--run-number 1234`. You can also specify to `--disable-data-storage`, the `--trigger-rate` and whether the run is "PROD" or "TEST" with `--run-type`.
-        - A simple thread pinning example running before and after conf, and after start.
-        - A "consolidated" configuration saved in PWD with the run number in its filename.
-        - A logbook.txt that doesn't say much beyond who started the run, the run number and time, and any message you leave at start.
-- `fsmConf-prod`
-    - This configuration is for setup _at EHN1_. You need to have a `~/.drunc.json` that specifies endpoints of ELisA, the run registry and the run number. With this configuration, you get:
-        - The CERN run number service to specify the run number when you start. You can also specify to `--disable-data-storage`, the `--trigger-rate` and whether the run is "PROD" or "TEST" with `--run-type`.
-        - A simple thread pinning example running before and after conf, and after start.
-        - A "consolidated" configuration saved in the run registry.
-        - An entry in the ELisA logbook that doesn't say much beyond who started the run, the run number and time, and any message you leave at start.
-- `FSMConfiguration_noAction`
-    - This configuration is used by subsystem controller only. You don't really need to worry about it, but need to setup your `ru-controller`, `trg-controller`, `hsi-controller` and `df-controller` with this one.
+* `fsmConf-test`
+  * This configuration is for test setup _anywhere_. With this configuration, you get:
+    * Asked by the run control for a run number (user-provided-run-number action) when you start: you need to provide `--run-number 1234`. You can also specify to `--disable-data-storage`, the `--trigger-rate` and whether the run is "PROD" or "TEST" with `--run-type`.
+    * A simple thread pinning example running before and after conf, and after start.
+    * A "consolidated" configuration saved in PWD with the run number in its filename.
+    * A logbook.txt that doesn't say much beyond who started the run, the run number and time, and any message you leave at start.
+* `fsmConf-prod`
+  * This configuration is for setup _at EHN1_. You need to have a `~/.drunc.json` that specifies endpoints of ELisA, the run registry and the run number. With this configuration, you get:
+    * The CERN run number service to specify the run number when you start. You can also specify to `--disable-data-storage`, the `--trigger-rate` and whether the run is "PROD" or "TEST" with `--run-type`.
+    * A simple thread pinning example running before and after conf, and after start.
+    * A "consolidated" configuration saved in the run registry.
+    * An entry in the ELisA logbook that doesn't say much beyond who started the run, the run number and time, and any message you leave at start.
+* `FSMConfiguration_noAction`
+  * This configuration is used by subsystem controller only. You don't really need to worry about it, but need to setup your `ru-controller`, `trg-controller`, `hsi-controller` and `df-controller` with this one.
 
 ## States
- - `none` - apps have not been booted
- - `initial` - app constructors have been ran
- - `configured` - queues and connections have been initialized
- - `ready` - TPs are being generated, but dropped at the DFO
- - `running` - TPs are being generated and stored to disk
- - `dataflow_drained` - TPs are being generated, but not propagated to the TRBs. DFO and DQM aplications stopped. Requests and fragments drained from queues
- - `trigger_sources_stopped` - TPs are no longer being generated. HSI, sources, and readout fully stopped.
+  * `none` - apps have not been booted
+  * `initial` - app constructors have been ran
+  * `configured` - queues and connections have been initialized
+  * `ready` - TPs are being generated, but dropped at the DFO
+  * `running` - TPs are being generated and stored to disk
+  * `dataflow_drained` - TPs are being generated, but not propagated to the TRBs. DFO and DQM aplications stopped. Requests and fragments drained from queues
+  * `trigger_sources_stopped` - TPs are no longer being generated. HSI, sources, and readout fully stopped.
 
 ## Transitions
 
@@ -52,43 +52,43 @@ These are the black arrows defined in the diagram above. They are:
 
 ## Actions
 The actions are defined in drunc (for now), but drunc decides to use them according to the FSM configuration, so they are listed here according the configurations that use them:
-- `fsmConf-test`
-    - `user-provided-run-number` - the user provides the run number.
-    - `file-run-registry` - saves a consolidated configuration in PWD.
-    - `file-logbook` - generates a logbook as a file in the directory from which `drunc` was spawned. Takes the file name as an argument.
-    - `thread-pinning` - has a `pre-conf`, `post-conf`, and `post-start` variable. Contains the file with the thread pinning configuration to attach specific processes to specific threads.
-- `fsmConf-prod`
-    - `usvc-provided-run-number` - microservice (usvc) generates the run number.
-    - `db-run-registry` - saves a consolidated configuration on the run registry.
-    - `usvc-elisa-logbook` - pushes an entry to the ELisA logbook ([instructions](https://github.com/DUNE-DAQ/drunc/wiki/Elisa-microservice))
-    - `thread-pinning` - has a `pre-conf`, `post-conf`, and `post-start` variable. Contains the file with the thread pinning configuration to attach specific processes to specific threads.
-- `FSMConfiguration_noAction`
-    - As expected, contains no action.
+* `fsmConf-test`
+  * `user-provided-run-number` - the user provides the run number.
+  * `file-run-registry` - saves a consolidated configuration in PWD.
+  * `file-logbook` - generates a logbook as a file in the directory from which `drunc` was spawned. Takes the file name as an argument.
+  * `thread-pinning` - has a `pre-conf`, `post-conf`, and `post-start` variable. Contains the file with the thread pinning configuration to attach specific processes to specific threads.
+* `fsmConf-prod`
+  * `usvc-provided-run-number` - microservice (usvc) generates the run number.
+  * `db-run-registry` - saves a consolidated configuration on the run registry.
+  * `usvc-elisa-logbook` - pushes an entry to the ELisA logbook ([instructions](https://github.com/DUNE-DAQ/drunc/wiki/Elisa-microservice))
+  * `thread-pinning` - has a `pre-conf`, `post-conf`, and `post-start` variable. Contains the file with the thread pinning configuration to attach specific processes to specific threads.
+* `FSMConfiguration_noAction`
+  * As expected, contains no action.
 
 
 ## Transitions with `pre-` and `post-` sequences
 The listings provide the actions in the order of execution. Any actions presented with parentheses e.g. (`file-logbook`) are optional.
 ## `start-prod`
- - `pre` - `usvc-provided-run-number` and `db-run-registry`
- - `post` - (`file-logbook`), `thread-pinning`, and `elisa-logbook`
+* `pre` - `usvc-provided-run-number` and `db-run-registry`
+* `post` - (`file-logbook`), `thread-pinning`, and `elisa-logbook`
 
 ## `start-test`
- - `pre` - `usvc-provided-run-number` and `file-run-registry`
- - `post` - (`file-logbook`) and `thread-pinning`
+* `pre` - `usvc-provided-run-number` and `file-run-registry`
+* `post` - (`file-logbook`) and `thread-pinning`
 
 ## `conf`
- - `pre` - `thread-pinning`
- - `post` - `thread-pinning`
+* `pre` - `thread-pinning`
+* `post` - `thread-pinning`
 
 ## `drain_dataflow-prod`
- - `post`- (`db-run-registry`), (`file-logbook`), (`elisa-logbook`)
+* `post`- (`db-run-registry`), (`file-logbook`), (`elisa-logbook`)
 
 ## `drain_dataflow-test`
- - `post`- (`file-logbook`)
+* `post`- (`file-logbook`)
 
 ## Sequences
 Are not supported yet. You can ignore the rest of this document.
 These define a sequence of transitions pregrouped. These are executed in the order that they are presented in. They are currently only defined on the client side. They are executed as normal FSM transitions. The existing sequences are in yellow in the diagram at the top of the screen. The sequences are
- - `start_run` - executes `conf`, `start`, and `enable_triggers`
- - `stop_run` - executes `disable_triggers`, `drain_dataflow`, `stop_trigger_sources`, and `stop`
- - `shutdown` - executes `disable_triggers`, `drain_dataflow`, `stop_trigger_sources`, `stop`, and `scrap`
+* `start_run` - executes `conf`, `start`, and `enable_triggers`
+* `stop_run` - executes `disable_triggers`, `drain_dataflow`, `stop_trigger_sources`, and `stop`
+* `shutdown` - executes `disable_triggers`, `drain_dataflow`, `stop_trigger_sources`, `stop`, and `scrap`

--- a/docs/Messaging-format.md
+++ b/docs/Messaging-format.md
@@ -82,11 +82,11 @@ message Description {
   optional google.protobuf.Any broadcast = 5;
 }
 ```
- - `type` can be `process_manager` or `controller` right now it is a string.
- - `name` is the name of the server.
- - `session` is the (optional) session name.
- - `commands` is a vector of acceptable commands to send to the endpoint.
- - `broadcast` is a description of the broadcast service.
+* `type` can be `process_manager` or `controller` right now it is a string.
+* `name` is the name of the server.
+* `session` is the (optional) session name.
+* `commands` is a vector of acceptable commands to send to the endpoint.
+* `broadcast` is a description of the broadcast service.
 
 `CommandDescription` is used to describe all the commands, it has the following format:
 ```
@@ -97,10 +97,10 @@ message CommandDescription {
   string return_type = 4;
 }
 ```
- - `name` is the name of the RPC
- - `data_type` is the format of the `data` field that is expected inside the `Request`. This data is encoded in an `Any` format and decoded prior to command execution
- - `help` is a string providing help
- - `return_type` is the format of the `data` field that should be expected inside the `Response` if the command execution was successful.
+* `name` is the name of the RPC
+* `data_type` is the format of the `data` field that is expected inside the `Request`. This data is encoded in an `Any` format and decoded prior to command execution
+* `help` is a string providing help
+* `return_type` is the format of the `data` field that should be expected inside the `Response` if the command execution was successful.
 
 For broadcasting, there is right now only one format that the `describe` command can fill, with a description of the Kafka service that is used to broadcast the log messages:
 ```
@@ -109,8 +109,8 @@ message KafkaBroadcastHandlerConfiguration{
   string topic = 2;
 }
 ```
- - `kafka_address` is a bootstrap server
- - `topic` is the Kafka topic on which this service is logging.
+* `kafka_address` is a bootstrap server
+* `topic` is the Kafka topic on which this service is logging.
 
 More formats of broadcasting may be added in the future (potentially using [ERS's python binding](https://github.com/DUNE-DAQ/erskafka/tree/develop/python/erskafka)).
 

--- a/docs/Process-manager-interface.md
+++ b/docs/Process-manager-interface.md
@@ -50,10 +50,10 @@ message ProcessUUID {
 
 ### `ProcessMetadata`
 This message encodes all the metadata used for a process. In theory, this is not strictly needed by the process to be executed, but I realise there is a `user` field here, which does not fall in that category... Oh well.
- - `uuid` is the process unique identifier ([ProcessUUID](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processuuid))
- - `user` is the user who started the process
- - `session` is the DAQ session that is associated with this process. There may be some processes that are not associated with any session (or associated with all the sessions?) hence this is an optional field.
- - `name` is a "friendly name" that can be used to query the process (for example in a [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery))
+* `uuid` is the process unique identifier ([ProcessUUID](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processuuid))
+* `user` is the user who started the process
+* `session` is the DAQ session that is associated with this process. There may be some processes that are not associated with any session (or associated with all the sessions?) hence this is an optional field.
+* `name` is a "friendly name" that can be used to query the process (for example in a [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery))
 
 ```
 message ProcessMetadata {
@@ -66,10 +66,10 @@ message ProcessMetadata {
 
 ### `ProcessQuery`
 This message can be used to query the processes run by the process manager. ProcessQuery can correspond to one or more processes (or even zero). Generally, an `OR` is formed between all the field by the process manager to get the corresponding processes.
- - `uuids` is a vector of [ProcessUUID](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processuuid) to directly get process by UUIDs.
- - `names` is a vector of processes friendly names.
- - `user` is the user
- - `session`: the session associated with the process.
+* `uuids` is a vector of [ProcessUUID](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processuuid) to directly get process by UUIDs.
+* `names` is a vector of processes friendly names.
+* `user` is the user
+* `session`: the session associated with the process.
 
 ```
 message ProcessQuery {
@@ -82,11 +82,11 @@ message ProcessQuery {
 
 ### `ProcessDescription`
 A ProcessDescription carries all the information necessary to start a process on any host. It uses two sub-message types, the StringList and ExecAndArgs. The fields mean:
- - `metadata`: to carry the [ProcessMetadata](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processmetadata) of the process
- - `env`: this is a key: value map (string to string) that stores the environment variables that need to be set for the process to run.
- - `executable_and_arguments` is a vector of executable and argument in the [ExecAndArgs](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#execandargs) format. Multiple executables can be specified and executed sequentially.
- - `process_execution_directory` (new after 27th Sept 2023) is the place where the process should be executed.
- - `process_logs_path` (new after 27th Sept 2023) is the place where the log will be stored.
+* `metadata`: to carry the [ProcessMetadata](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processmetadata) of the process
+* `env`: this is a key: value map (string to string) that stores the environment variables that need to be set for the process to run.
+* `executable_and_arguments` is a vector of executable and argument in the [ExecAndArgs](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#execandargs) format. Multiple executables can be specified and executed sequentially.
+* `process_execution_directory` (new after 27th Sept 2023) is the place where the process should be executed.
+* `process_logs_path` (new after 27th Sept 2023) is the place where the log will be stored.
 
 ```
 message ProcessDescription {
@@ -114,11 +114,11 @@ message ExecAndArgs{
 
 ### `ProcessInstance`
 This message carries the description of a running process, and, eventually, the exit code.
- - `process_description` carries the [ProcessDescription](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processdescription) of the process, hence information like which executable, arguments, environment, etc.
- - `process_restriction` carries information about the host on which the process is running (well, really just the name of the host for now).
- - `status_code` is a very simple enum that show if a process is running or not (0: Running, 1: Dead).
- - `return_code` is the return code of the process.
- - `uuid` is the process unique identifier [ProcessUUID](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processuuid)
+* `process_description` carries the [ProcessDescription](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processdescription) of the process, hence information like which executable, arguments, environment, etc.
+* `process_restriction` carries information about the host on which the process is running (well, really just the name of the host for now).
+* `status_code` is a very simple enum that show if a process is running or not (0: Running, 1: Dead).
+* `return_code` is the return code of the process.
+* `uuid` is the process unique identifier [ProcessUUID](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processuuid)
 
 ```
 message ProcessInstance {
@@ -136,8 +136,8 @@ message ProcessInstance {
 
 ### `BootRequest`
 Describes requests to start a process.
- - `process_description` is used to start the process, it uses the [ProcessDescription](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processdescription) format.
- - `process_restriction` is used to choose the host on which the process will run. This follows the [ProcessRestriction](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processrestriction).
+* `process_description` is used to start the process, it uses the [ProcessDescription](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processdescription) format.
+* `process_restriction` is used to choose the host on which the process will run. This follows the [ProcessRestriction](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processrestriction).
 
 ```
 message BootRequest {
@@ -197,44 +197,44 @@ Each RPC call is described here.
 
 ### `boot`
 Is used to boot processes. No resolution whatsoever is done for the executable arguments, they need to be formatted correctly by the client.
- - input: [BootRequest](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#bootrequest)
- - output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) of all the process started
- - interrupts/exceptions:
-   - `allowed_hosts` is empty
+* input: [BootRequest](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#bootrequest)
+* output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) of all the process started
+* interrupts/exceptions:
+  * `allowed_hosts` is empty
 
 For the SSH process manager, the `allowed_host_types` are not allowed in the [ProcessRestriction](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processrestriction). The process manager will try each host listed in the `allowed_hosts` until it one leads to successful execution of the process (which can itself fail).
 
 ### `restart`
 Restart one (and only one) process. If the process is running, it will be killed and restarted. If the process is already dead, it simply boots it.
- - input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
- - output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the one process that was started (should be `ProcessInstance` instead).
- - interrupts/exceptions:
-   - The input process query leads to more than one processes, or zero process.
+* input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
+* output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the one process that was started (should be `ProcessInstance` instead).
+* interrupts/exceptions:
+  * The input process query leads to more than one processes, or zero process.
 
 ### `kill`
 Kill one or more processes.
- - input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
- - output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the processes that were killed.
- - interrupts/exceptions:
-   - None known.
+* input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
+* output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the processes that were killed.
+* interrupts/exceptions:
+  * None known.
 
 ### `flush`
 Remove the **dead** processes from the process manager. One cannot restart processes that have been flushed, and they will not appear in the [ps](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#ps).
- - input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
- - output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the processes that were flushed.
- - interrupts/exceptions:
-   - None known.
+* input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
+* output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the processes that were flushed.
+* interrupts/exceptions:
+  * None known.
 
 ### `ps`
 List the processes
- - input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
- - output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the processes queried.
- - interrupts/exceptions:
-   - None known.
+* input: [ProcessQuery](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processquery)
+* output: [ProcessInstanceList](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#processinstancelist) containing the processes queried.
+* interrupts/exceptions:
+  * None known.
 
 ### `logs`
 Stream the logs from a specific process
- - input: [LogRequest](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#logrequest)
- - output (streamed): [LogLine](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#logline)
- - interrupt/exceptions:
-   - The input process query leads to more than one processes, or zero process.
+* input: [LogRequest](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#logrequest)
+* output (streamed): [LogLine](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface#logline)
+* interrupt/exceptions:
+  * The input process query leads to more than one processes, or zero process.

--- a/docs/Process-manager.md
+++ b/docs/Process-manager.md
@@ -5,11 +5,11 @@ For a standalone `process_manager` you will need two shells - one shell to run t
 
 ## Configurations
 To boot a `process_manager`, you will need to choose the most appropriate configuration that applies to the use case. The configurations that are packaged with `drunc` are defined in `drunc/src/data/process_manager/`, which are
- - `ssh-standalone.json`: `ssh` based standalone implementation without a `kafka` feed.
- - `ssh-pocket-kafka.json`: `ssh` based implementation with `pocket`'s `kafka` for message broadcasting.
- - `ssh-CERN-kafka.json`: `ssh` based implementation with `kafka` service running at ENH1.
- - `ssh-CERN-kafka-OpMon.json`: `ssh` based implementation with `kafka` service running at ENH1, and with Opmon.
- - `k8s.json`: `kubernetes` implementation (not recommended nor working, so don't use this unless you are an working on getting it to work).
+* `ssh-standalone.json`: `ssh` based standalone implementation without a `kafka` feed.
+* `ssh-pocket-kafka.json`: `ssh` based implementation with `pocket`'s `kafka` for message broadcasting.
+* `ssh-CERN-kafka.json`: `ssh` based implementation with `kafka` service running at ENH1.
+* `ssh-CERN-kafka-OpMon.json`: `ssh` based implementation with `kafka` service running at ENH1, and with Opmon.
+* `k8s.json`: `kubernetes` implementation (not recommended nor working, so don't use this unless you are an working on getting it to work).
 
 ## Starting
 Note that this runs the process manager service, _you will not be able to do anything else with it other than starting it and ctrl-c it_.
@@ -55,16 +55,16 @@ This command spawns the processes that are used by the DAQ. In most cases, it SS
 The `boot` command will check if there are processes running in the process manager with the same session name and ask for confirmation if it detects other process running under the same session name.
 
 Command arguments (in this order):
- - `configuration_file`: path to the system configuration file (xml `OKS` file).
- - `configuration_session_id`: name of the session defined in the system configuration file.
- - `session_name`: name of the session.
+* `configuration_file`: path to the system configuration file (xml `OKS` file).
+* `configuration_session_id`: name of the session defined in the system configuration file.
+* `session_name`: name of the session.
 
 Command options:
- - `--override-logs/--no-override-logs` (optional), this flags adds a timestamp to the log files of the application, effectively making them non-overriding. Note this happens only in the case where the `log_path` is _not_ set in your configuration's `Session` or `Application` objects. If the configuration's `log_path` is not `./` in either of these, the run control will use that, and the log will not be overriding (in this case, _this flag is ignored_).
- - `-u/--user` (optional), assigns an owner to the spawned processes, default is `$USER`.
+* `--override-logs/--no-override-logs` (optional), this flags adds a timestamp to the log files of the application, effectively making them non-overriding. Note this happens only in the case where the `log_path` is _not_ set in your configuration's `Session` or `Application` objects. If the configuration's `log_path` is not `./` in either of these, the run control will use that, and the log will not be overriding (in this case, _this flag is ignored_).
+* `-u/--user` (optional), assigns an owner to the spawned processes, default is `$USER`.
 
 Caveats:
- - It is most likely impossible to specify a `user` different from the one that is running the `process_manager`, simply because that user will likely not have the ssh keys necessary to ssh on a different host as a different user.
+* It is most likely impossible to specify a `user` different from the one that is running the `process_manager`, simply because that user will likely not have the ssh keys necessary to ssh on a different host as a different user.
 
 #### Example
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
+# DUNE Run Control (drunc)
+
 [![Lint](https://github.com/DUNE-DAQ/drunc/actions/workflows/lint.yml/badge.svg)](https://github.com/DUNE-DAQ/drunc/actions/workflows/lint.yml)
 [![pytest](https://github.com/DUNE-DAQ/drunc/actions/workflows/run_pytest.yml/badge.svg)](https://github.com/DUNE-DAQ/drunc/actions/workflows/run_pytest.yml)
-
-# DUNE Run Control (drunc)
 
 This software defines a flexible run control infrastructure for a distributed DAQ system defined in a set of configuration files used at run time for DUNE. Operation of the experiment is defined through a finite state machine (FSM) which describes the operational state of the DAQ.
 
 The project is still under development, and as such will still have bugs or features that users may not want. If you encounter any of these please raise an issue and describe it clearly so that we can resolve it easily.
 
-![drunc_overview](https://github.com/DUNE-DAQ/drunc/blob/develop/docs/drunc_overview.png)
+![drunc_overview](drunc_overview.png)
 
 # Setting up
 If you are trying to run `drunc` you **must** have a DUNE-DAQ environment, with `cvmfs` available. See setup instructions [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-buildtools/) to setup an nightly or a static release.
@@ -16,20 +16,20 @@ If you are trying to run `drunc` you **must** have a DUNE-DAQ environment, with 
 Once you have drunc, you can look at the [quick start instructions](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Running-drunc).
 
 If you need more details:
- - [Process manager](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-manager)
- - [Controller](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller)
- - [Unified shell](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell) (merges the controller and process manager shells)
+* [Process manager](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-manager)
+* [Controller](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller)
+* [Unified shell](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell) (merges the controller and process manager shells)
 
 There are more in depth descriptions of part of the system here:
- - [FSM](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/FSM)
+* [FSM](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/FSM)
 
 Finally, we have a [FAQ](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/FAQ), have a look there if you have a problem!
 
 # Developing
 If are developing a user interface for `drunc`, you can get help here:
- - [Messaging format](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Messaging-format) (valid for all the `drunc` endpoints)
- - [Process manager endpoint description](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface)
- - [Controller endpoint description](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface)
+* [Messaging format](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Messaging-format) (valid for all the `drunc` endpoints)
+* [Process manager endpoint description](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-Manager-interface)
+* [Controller endpoint description](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Controller-interface)
 
 There is more developer information in the [drunc wiki](https://github.com/DUNE-DAQ/drunc/wiki).
 

--- a/docs/Release-notes.md
+++ b/docs/Release-notes.md
@@ -1,3 +1,5 @@
+# Release Notes 
+
 # v0.10.1
 Adds a hierarchy to the processes when they're spawned, so the trees with `ps` get correctly constructed
 
@@ -82,9 +84,9 @@ Most of the server side exceptions should now be propagated back to the shell
 
 ## Thread pinning
 If you are using `fsm.data.xml` from `appdal`, [here](https://github.com/DUNE-DAQ/appdal/blob/develop/config/appdal/fsm.data.xml), you will now get an example of thread pinning. These happen:
- - just before `conf`
- - just after `conf`
- - just after `start`
+* just before `conf`
+* just after `conf`
+* just after `start`
 
 Right now the file is the same for all the three transition, but hopefully it's not too complicated for you to understand what you'd need to modify to get different ones.
 

--- a/docs/Running-drunc.md
+++ b/docs/Running-drunc.md
@@ -15,10 +15,10 @@ In your terminal window, run `drunc-unified-shell`:
 drunc-unified-shell process_manager_configuration config-file.data.xml configuration_session_id session_name
 ```
 For which:
- - `process_manager_configuration` is the name of a configuration file defined in `drunc/src/drunc/data/process_manager/` (see them [here](https://github.com/DUNE-DAQ/drunc/tree/develop/src/drunc/data/process_manager)). There is a description of them in [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-manager#Configurations). Alternatively, this can be the path to name of a custom configuration file, relative or absolute.
- - `config-file.data.xml` is the name of the DAQ system configuration file, typically defined in [`daqsystemtest/config/example-configs.data.xml`](https://github.com/DUNE-DAQ/daqsystemtest/blob/develop/config/daqsystemtest/example-configs.data.xml).
- - `configuration_session_id` is the name of the session defined in `config-file.data.xml`.
- - `session_name` is a name you choose.
+* `process_manager_configuration` is the name of a configuration file defined in `drunc/src/drunc/data/process_manager/` (see them [here](https://github.com/DUNE-DAQ/drunc/tree/develop/src/drunc/data/process_manager)). There is a description of them in [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Process-manager#Configurations). Alternatively, this can be the path to name of a custom configuration file, relative or absolute.
+* `config-file.data.xml` is the name of the DAQ system configuration file, typically defined in [`daqsystemtest/config/example-configs.data.xml`](https://github.com/DUNE-DAQ/daqsystemtest/blob/develop/config/daqsystemtest/example-configs.data.xml).
+* `configuration_session_id` is the name of the session defined in `config-file.data.xml`.
+* `session_name` is a name you choose.
 
 ### Interacting with `process_manager`
 At this point the `process_manager` has been spawned, and you can interface it directly through the current shell. You can now start the DAQ processes as
@@ -47,38 +47,38 @@ drunc-unified-shell > ps
 ```
 
 We have started a couple of processes - the standard DAQ applications organized into segments each with a controller, and a `root-controller` that will control all the segments. From here you can use the `process_manger` commands
- - `ps`: list all the processes
- - `kill`: kill specific processes
- - `flush`: remove dead processes
- - `restart`: restart processes (DO NOT USE)
- - `logs`: show the logs of specific processes
- - `terminate`: kill all the processes
+* `ps`: list all the processes
+* `kill`: kill specific processes
+* `flush`: remove dead processes
+* `restart`: restart processes (DO NOT USE)
+* `logs`: show the logs of specific processes
+* `terminate`: kill all the processes
 
 ### Interacting with `root-controller`
 Next, let's send commands to the `root-controller`. These commands will be propagated by it to other applications using `gRPC`. To see which segments a controller controls, you can use `ls`:
 
 The set of commands that you can send to the `root-controller` are
- - `status`: lists the FSM state, substate, error status, and included parameters of the segments.
- - `recompute-status`: calculates the status of the controllers from their children, and reset their status.
- - `connect`: connects to another controller,
- - `disconnect`: disconnects from a controller,
- - `take-control`: updates the user in charge of the controller (DO NOT USE)
- - `surrender-control`: releases the current user (DO NOT USE)
- - `whoami`: prints your username (DO NOT USE)
- - `who-is-in-charge`: prints who is in charge of the root controller (DO NOT USE)
- - `include`: includes a children in the current session
- - `exclude`: excludes a children from the current session
- - `expert-command`: send abritrary json to an application
+* `status`: lists the FSM state, substate, error status, and included parameters of the segments.
+* `recompute-status`: calculates the status of the controllers from their children, and reset their status.
+* `connect`: connects to another controller,
+* `disconnect`: disconnects from a controller,
+* `take-control`: updates the user in charge of the controller (DO NOT USE)
+* `surrender-control`: releases the current user (DO NOT USE)
+* `whoami`: prints your username (DO NOT USE)
+* `who-is-in-charge`: prints who is in charge of the root controller (DO NOT USE)
+* `include`: includes a children in the current session
+* `exclude`: excludes a children from the current session
+* `expert-command`: send abritrary json to an application
 
 [FSM](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/FSM) transitions can be executed directly from the shell with the commands:
- - `conf`: configure the applications by ingesting the parameters from the configuration file to the applications
- - `start`: start a run, allocating a run number. Initializes queues and connections
- - `enable-triggers`: start generating TPs, TDs are not propagated to the DFO
- - `disable-triggers`: stop collecting generated TPs to file
- - `drain-dataflow`: stop propagating TDs to the TRBs.
- - `stop-trigger-sources`: stop generating TPs
- - `stop`: stop app communication
- - `scrap`: remove all the configuration parameters from the applications
+* `conf`: configure the applications by ingesting the parameters from the configuration file to the applications
+* `start`: start a run, allocating a run number. Initializes queues and connections
+* `enable-triggers`: start generating TPs, TDs are not propagated to the DFO
+* `disable-triggers`: stop collecting generated TPs to file
+* `drain-dataflow`: stop propagating TDs to the TRBs.
+* `stop-trigger-sources`: stop generating TPs
+* `stop`: stop app communication
+* `scrap`: remove all the configuration parameters from the applications
 
 ### Typical operation of the DAQ
 Let's take the DAQ for a spin.

--- a/docs/Unified-shell-reference.md
+++ b/docs/Unified-shell-reference.md
@@ -30,7 +30,7 @@ This command spawns the processes that are used by the DAQ. In most cases, it SS
 The `boot` command will check if there are processes running in the process manager with the same session name and ask for confirmation if it detects other process running under the same session name.
 
 The `boot` command can take the following option:
- - `--override-logs/--no-override-logs` (optional), this flags adds a timestamp to the log files of the application, effectively making them non-overriding. Note this happens only in the case where the `log_path` is _not_ set in your configuration's `Session` or `Application` objects. If the configuration's `log_path` is not `./` in either of these, the run control will use that, and the log will not be overriding (in this case, _this flag is ignored_).
+* `--override-logs/--no-override-logs` (optional), this flags adds a timestamp to the log files of the application, effectively making them non-overriding. Note this happens only in the case where the `log_path` is _not_ set in your configuration's `Session` or `Application` objects. If the configuration's `log_path` is not `./` in either of these, the run control will use that, and the log will not be overriding (in this case, _this flag is ignored_).
 
 ### Example
 ```bash
@@ -38,8 +38,8 @@ boot --override-logs
 ```
 
 ### Related commands
- - [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
- - [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
+* [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
+* [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
 
 ## change-rate
 ### Description
@@ -50,8 +50,8 @@ boot --override-logs
 This command allows you to change the trigger rate of the system, when it is `running` or `ready`, this command does not change the state of the system.
 
 The `change-rate` command can take the following options:
- - `--trigger-rate` (mandatory), is a float to specify the trigger rate in Hz you want the system to be running at.
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--trigger-rate` (mandatory), is a float to specify the trigger rate in Hz you want the system to be running at.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To send `change-rate` to the whole of the DAQ:
@@ -68,10 +68,10 @@ change-rate --trigger-rate 0.01 --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
- - [`enable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
- - [`disable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
- - [`drain-dataflow`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
+* [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
+* [`enable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
+* [`disable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
+* [`drain-dataflow`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
 
 ## conf
 ### Description
@@ -82,7 +82,7 @@ change-rate --trigger-rate 0.01 --target root-controller/trg-controller/mlt
 This command allows you to configure the system, when it is `initialised`, and thus to reach the `configured` state.
 
 The `conf` command can take the following option:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To send `conf` to the whole of the DAQ:
@@ -99,8 +99,8 @@ conf --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`scrap`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#scrap)
- - [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
+* [`scrap`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#scrap)
+* [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
 
 ## connect
 ### Description
@@ -111,7 +111,7 @@ The `connect` command takes the control address of the controller as argument
 If you are already connected to a controller, you will be asked to confirm that you want to connect to another controller.
 
 The `connect` command take the following options:
- - `-f/--force`, which can be used to skip the confirmation step in case you are already connected to another controller.
+* `-f/--force`, which can be used to skip the confirmation step in case you are already connected to another controller.
 
 ### Example
 ```bash
@@ -119,7 +119,7 @@ connect grpc://np04-srv-019:56582
 ```
 
 ### Related command
- - [`disconnect`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disconnect)
+* [`disconnect`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disconnect)
 
 ## disable-triggers
 ### Description
@@ -130,7 +130,7 @@ connect grpc://np04-srv-019:56582
 This command allows you to disable the triggers of the system, when it is `running`, and thus to reach the `ready` state.
 
 The `disable-triggers` command can take the following option:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To send `disable-triggers` to the whole of the DAQ:
@@ -147,8 +147,8 @@ disable-triggers --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`enable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
- - [`change-rate`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#change-rate)
+* [`enable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
+* [`change-rate`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#change-rate)
 
 ## disconnect
 ### Description
@@ -159,7 +159,7 @@ The `disconnect` command takes the control address of the controller as argument
 If you are connected to a controller, you will be asked to confirm that you want to disconnect.
 
 The `disconnect` command take the following options:
- - `-f/--force`, which can be used to skip the confirmation step in case you are already connected to another controller.
+* `-f/--force`, which can be used to skip the confirmation step in case you are already connected to another controller.
 
 ### Example
 ```bash
@@ -167,7 +167,7 @@ disconnect
 ```
 
 ### Related command
- - [`connect`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#connect)
+* [`connect`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#connect)
 
 ## drain-dataflow
 ### Description
@@ -178,9 +178,9 @@ disconnect
 This command allows you to drain the dataflow of the system, when it is `ready`, and thus to reach the `dataflow-drained` state.
 
 The `drain-dataflow` command can take the following options, depending on your FSM configuration:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
- - `--elisa-post` (optional), allows you to add a message on the ELisA logbook post that gets created when the run finishes.
- - `--file-logbook-post` (optional), allows you to add a message on the file logbook post that gets create when the run finishes.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--elisa-post` (optional), allows you to add a message on the ELisA logbook post that gets created when the run finishes.
+* `--file-logbook-post` (optional), allows you to add a message on the file logbook post that gets create when the run finishes.
 ### Examples
 To send `drain-dataflow` to the whole of the DAQ:
 ```bash
@@ -196,9 +196,9 @@ drain-dataflow --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
- - [`disable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
- - [`stop-trigger-sources`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop-trigger-sources)
+* [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
+* [`disable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
+* [`stop-trigger-sources`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop-trigger-sources)
 
 ## enable-triggers
 ### Description
@@ -209,7 +209,7 @@ drain-dataflow --target root-controller/trg-controller/mlt
 This command allows you to enable the trigger of the system, when it is `ready`, and thus to reach the `running` state.
 
 The `enable-triggers` command can take the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To send `enable-triggers` to the whole of the DAQ:
@@ -226,8 +226,8 @@ enable-triggers --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
- - [`disable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
+* [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
+* [`disable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#disable-triggers)
 
 ## exclude
 ### Description
@@ -236,7 +236,7 @@ enable-triggers --target root-controller/trg-controller/mlt
 Allows you to exclude a segment or an application from the DAQ system. All commands to the excluded part of the system are then ignored, and the next time `recompute-status` is issued, excluded nodes states are ignored.
 
 The `exclude` command can take the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To `exclude` to the whole trigger segment:
@@ -249,9 +249,9 @@ exclude --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`include`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#include)
- - [`status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#status)
- - [`recompute-status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#recompute-status)
+* [`include`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#include)
+* [`status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#status)
+* [`recompute-status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#recompute-status)
 
 ## expert-command
 ### Description
@@ -278,17 +278,17 @@ The format of the JSON is:
 }
 ```
 Where:
- - `entry_state` and `exit_state` need to be set to _the same state in the FSM_, written in capital.
- - `id` is the command name the application will respond to (`register_command` in your module).
- - `data.modules[:].data` is the data you are sending to the modules.
- - `data.modules[:].match` is the name of the module, if left blank (""), the command will be propagated to all the module that have registered the command `id`.
+* `entry_state` and `exit_state` need to be set to _the same state in the FSM_, written in capital.
+* `id` is the command name the application will respond to (`register_command` in your module).
+* `data.modules[:].data` is the data you are sending to the modules.
+* `data.modules[:].match` is the name of the module, if left blank (""), the command will be propagated to all the module that have registered the command `id`.
 
 `expert-command` command take the following mandatory argument:
- - `command`, which is either the path to a json file that will be sent to the application(s) or, an actual json string (wrapped in `"`). An example of the file can be found in [here](https://github.com/DUNE-DAQ/drunc/blob/develop/src/drunc/data/expert-command/record.json).
+* `command`, which is either the path to a json file that will be sent to the application(s) or, an actual json string (wrapped in `"`). An example of the file can be found in [here](https://github.com/DUNE-DAQ/drunc/blob/develop/src/drunc/data/expert-command/record.json).
 
 The `expert-command` command can take the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment if you specify it. By default, the target is the top segment for the whole session.
- - `-s/--string` (optional), a flag to signify that you are sending raw json, rather than a json file.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment if you specify it. By default, the target is the top segment for the whole session.
+* `-s/--string` (optional), a flag to signify that you are sending raw json, rather than a json file.
 
 ### Examples
 To send an expert command to the whole readout segment application:
@@ -302,10 +302,10 @@ expert-command --target root-controller/ru-controller data/record.json
 This command removes the dead processes from the `ps` list, after issuing `flush`, you will not be able to send `restart` to that process.
 
 The `flush` command can take the following options:
- - `--uuid`, to select a process to flush based on its UUID.
- - `-u/--user`, to select the processes to flush based on its user.
- - `-n/--name`, to select a process to flush based on its "friendly name".
- - `-s/--session`, to select the processes to flush based on a session name.
+* `--uuid`, to select a process to flush based on its UUID.
+* `-u/--user`, to select the processes to flush based on its user.
+* `-n/--name`, to select a process to flush based on its "friendly name".
+* `-s/--session`, to select the processes to flush based on a session name.
 
 By default, `flush` will flush all the dead processes from all sessions, users and names.
 
@@ -326,8 +326,8 @@ flush -s your-session-name
 ```
 
 ### Related commands
- - [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
- - [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
+* [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
+* [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
 
 ## include
 ### Description
@@ -336,7 +336,7 @@ flush -s your-session-name
 Allows you to include a segment or an application (that was previously excluded) from the DAQ system.
 
 The `include` command can take the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To `include` to the whole trigger segment:
@@ -349,19 +349,19 @@ include --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`exclude`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#exclude)
- - [`status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#status)
- - [`recompute-status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#recompute-status)
+* [`exclude`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#exclude)
+* [`status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#status)
+* [`recompute-status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#recompute-status)
 
 ## kill
 ### Description
 This command kills running processes.
 
 The `kill` command must take at least one the following options:
- - `--uuid`, to select a process to flush based on its UUID.
- - `-u/--user`, to select the processes to flush based on its user.
- - `-n/--name`, to select a process to flush based on its "friendly name".
- - `-s/--session`, to select the processes to flush based on a session name.
+* `--uuid`, to select a process to flush based on its UUID.
+* `-u/--user`, to select the processes to flush based on its user.
+* `-n/--name`, to select a process to flush based on its "friendly name".
+* `-s/--session`, to select the processes to flush based on a session name.
 
 By default, `kill` does nothing, you need to supply one of the options.
 
@@ -384,10 +384,10 @@ kill -s your-session-name
 ```
 
 ### Related commands
- - [`terminate`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#terminate)
- - [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
- - [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
- - [`restart`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#restart)
+* [`terminate`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#terminate)
+* [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
+* [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
+* [`restart`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#restart)
 
 
 ## logs
@@ -395,12 +395,12 @@ kill -s your-session-name
 This command prints the log of a processes.
 
 The `logs` command must take at least one the following options:
- - `--uuid`, to select a process to flush based on its UUID.
- - `-u/--user`, to select the processes to flush based on its user.
- - `-n/--name`, to select a process to flush based on its "friendly name".
- - `-s/--session`, to select the processes to flush based on a session name.
- - `--how-far`, how many lines to print, by default it `logs` print the last 100 lines of log.
- - `--grep`, to select a particular string in the logs. Works with regex too.
+* `--uuid`, to select a process to flush based on its UUID.
+* `-u/--user`, to select the processes to flush based on its user.
+* `-n/--name`, to select a process to flush based on its "friendly name".
+* `-s/--session`, to select the processes to flush based on a session name.
+* `--how-far`, how many lines to print, by default it `logs` print the last 100 lines of log.
+* `--grep`, to select a particular string in the logs. Works with regex too.
 
 By default, `logs` does nothing, you need to supply one or more of the options `--uuid`, `-u/--user`, `-n/--name`, `-s/-session`, and the logical _AND_ of this options must correspond to exactly one process.
 
@@ -424,7 +424,7 @@ logs --name mlt --grep ERROR
 ```
 
 ### Related command
- - [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
+* [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
 
 
 ## ps
@@ -432,11 +432,11 @@ logs --name mlt --grep ERROR
 This command list running processes.
 
 The `ps` command must take at least one the following options:
- - `--uuid`, to select a process to flush based on its UUID.
- - `-u/--user`, to select the processes to flush based on its user.
- - `-n/--name`, to select a process to flush based on its "friendly name".
- - `-s/--session`, to select the processes to flush based on a session name.
- - `--long-format/-l`, to get a long listing format.
+* `--uuid`, to select a process to flush based on its UUID.
+* `-u/--user`, to select the processes to flush based on its user.
+* `-n/--name`, to select a process to flush based on its "friendly name".
+* `-s/--session`, to select the processes to flush based on a session name.
+* `--long-format/-l`, to get a long listing format.
 
 By default, `ps` list all the processes.
 
@@ -475,10 +475,10 @@ ps
 ```
 
 ### Related commands
- - [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
- - [`logs`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#logs)
- - [`restart`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#restart)
- - [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
+* [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
+* [`logs`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#logs)
+* [`restart`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#restart)
+* [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
 
 ## recompute-status
 ### Description
@@ -487,9 +487,9 @@ ps
 Figure out the status the status of the controller, from the state of its _included_ children.
 
 The `recompute-status` command takes the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
- - `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
- - `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
+* `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
 
 By default, the `recompute-status` recomputes the status of all the system.
 
@@ -508,9 +508,9 @@ recompute-status --target root-controller/trg-controller --dont-execute-along-pa
 ```
 
 ### Related commands
- - [`status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#status)
- - [`exclude`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#exclude)
- - [`include`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#include)
+* [`status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#status)
+* [`exclude`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#exclude)
+* [`include`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#include)
 
 
 ## restart
@@ -520,10 +520,10 @@ recompute-status --target root-controller/trg-controller --dont-execute-along-pa
 Restart a process that was booted.
 
 The `restart` command must take at least one the following options:
- - `--uuid`, to select a process to flush based on its UUID.
- - `-u/--user`, to select the processes to flush based on its user.
- - `-n/--name`, to select a process to flush based on its "friendly name".
- - `-s/--session`, to select the processes to flush based on a session name.
+* `--uuid`, to select a process to flush based on its UUID.
+* `-u/--user`, to select the processes to flush based on its user.
+* `-n/--name`, to select a process to flush based on its "friendly name".
+* `-s/--session`, to select the processes to flush based on a session name.
 
 By default, `restart` does nothing, you need to supply one or more of the options `--uuid`, `-u/--user`, `-n/--name`, `-s/-session`, and the logical _AND_ of this options must correspond to exactly one process.
 
@@ -534,9 +534,9 @@ restart --name mlt
 ```
 
 ### Related commands
- - [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
- - [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
- - [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
+* [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
+* [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
+* [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
 
 
 ## scrap
@@ -548,7 +548,7 @@ restart --name mlt
 This command allows you to "unconfigure" the system, when it is `configured`, and thus to reach the `initial` state.
 
 The `scrap` command can take the following option:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To send `scrap` to the whole of the DAQ:
@@ -565,8 +565,8 @@ scrap --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`conf`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#conf)
- - [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
+* [`conf`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#conf)
+* [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
 
 ## start
 ### Description
@@ -577,13 +577,13 @@ scrap --target root-controller/trg-controller/mlt
 This command allows you to "start" the run on system, when it is `configured`, and thus to reach the `ready` state.
 
 The `start` command can take the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
- - `--elisa-post` (optional), allows you to add a message on the ELisA logbook post that gets created when the run ends. By default, nothing is added on the post.
- - `--file-logbook-post` (optional), allows you to add a message on the file logbook post that gets create when the run ends. By default, nothing is added on the post.
- - `--run-type` (optional), either _PROD_ or _TEST_, depending on how you think the data will be used. By default, _TEST_ is used.
- - `--trigger-rate` (optional), the trigger rate you want to set. By default it's 0 Hz, but the system will use the trigger rate from the configuration.
- - `--disable-data-storage` (optional), wether to disable the writing of the data and have a "dry run" of the DAQ. By default, write data.
- - `--run-number` (required, in some cases), which run number to use.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--elisa-post` (optional), allows you to add a message on the ELisA logbook post that gets created when the run ends. By default, nothing is added on the post.
+* `--file-logbook-post` (optional), allows you to add a message on the file logbook post that gets create when the run ends. By default, nothing is added on the post.
+* `--run-type` (optional), either _PROD_ or _TEST_, depending on how you think the data will be used. By default, _TEST_ is used.
+* `--trigger-rate` (optional), the trigger rate you want to set. By default it's 0 Hz, but the system will use the trigger rate from the configuration.
+* `--disable-data-storage` (optional), wether to disable the writing of the data and have a "dry run" of the DAQ. By default, write data.
+* `--run-number` (required, in some cases), which run number to use.
 
 ### Examples
 To send `start`:
@@ -596,9 +596,9 @@ start --elisa-post "A run with the TDE and PDS" --run-type PROD
 ```
 
 ### Related commands
- - [`conf`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#conf)
- - [`enable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
- - [`drain-dataflow`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
+* [`conf`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#conf)
+* [`enable-triggers`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#enable-triggers)
+* [`drain-dataflow`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
 
 ## status
 ### Description
@@ -607,9 +607,9 @@ start --elisa-post "A run with the TDE and PDS" --run-type PROD
 Prints the status the status of the controller.
 
 The `status` command takes the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
- - `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
- - `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
+* `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
 
 By default, the `status` prints the status of all the system.
 
@@ -628,9 +628,9 @@ status --target root-controller/trg-controller --dont-execute-along-path
 ```
 
 ### Related commands
- - [`recompute-status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#recompute-status)
- - [`exclude`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#exclude)
- - [`include`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#include)
+* [`recompute-status`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#recompute-status)
+* [`exclude`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#exclude)
+* [`include`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#include)
 
 ## stop
 ### Description
@@ -641,7 +641,7 @@ status --target root-controller/trg-controller --dont-execute-along-path
 This command allows you to stop the system, when it is in the `trigger-sources-stopped` state, and thus to reach the `configured` state.
 
 The `stop` command can take the following option:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To send `stop` to the whole of the DAQ:
@@ -658,9 +658,9 @@ stop --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`scrap`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#scrap)
- - [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
- - [`stop-trigger-sources`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop-trigger-sources)
+* [`scrap`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#scrap)
+* [`start`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#start)
+* [`stop-trigger-sources`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop-trigger-sources)
 
 ## stop-trigger-sources
 ### Description
@@ -671,7 +671,7 @@ stop --target root-controller/trg-controller/mlt
 This command allows you to stop the trigger sources of the system, when it is in the `dataflow-drained` state, and thus to reach the `trigger-sources-stopped` state.
 
 The `stop-trigger-sources` command can take the following option:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
 
 ### Examples
 To send `stop-trigger-sources` to the whole of the DAQ:
@@ -688,8 +688,8 @@ stop-trigger-sources --target root-controller/trg-controller/mlt
 ```
 
 ### Related commands
- - [`stop`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop)
- - [`drain-dataflow`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
+* [`stop`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#stop)
+* [`drain-dataflow`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#drain-dataflow)
 
 ## surrender-control
 ### Description
@@ -700,9 +700,9 @@ stop-trigger-sources --target root-controller/trg-controller/mlt
 This commands allows you to give up the control of a controller and its children. Note the user must be in control to be able to send commands to the controller
 
 The `surrender-control` command takes the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
- - `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
- - `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
+* `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
 
 By default, `surrender-control` surrenders the control on the whole system.
 
@@ -717,9 +717,9 @@ surrender-control --target root-controller/trg-controller
 ```
 
 ### Related commands
- - [`take-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#take-control)
- - [`who-is-in-charge`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#who-is-in-charge)
- - [`whoami`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#whoami)
+* [`take-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#take-control)
+* [`who-is-in-charge`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#who-is-in-charge)
+* [`whoami`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#whoami)
 
 ## take-control
 ### Description
@@ -730,9 +730,9 @@ surrender-control --target root-controller/trg-controller
 This commands allows you to take the control of a controller and its children. Note the user must be in control to be able to send commands to the controller
 
 The `take-control` command takes the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
- - `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
- - `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
+* `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
 
 By default, `take-control` surrenders the control on the whole system.
 
@@ -747,9 +747,9 @@ take-control --target root-controller/trg-controller
 ```
 
 ### Related commands
- - [`surrender-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#surrender-control)
- - [`who-is-in-charge`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#who-is-in-charge)
- - [`whoami`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#whoami)
+* [`surrender-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#surrender-control)
+* [`who-is-in-charge`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#who-is-in-charge)
+* [`whoami`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#whoami)
 
 ## terminate
 ### Description
@@ -782,10 +782,10 @@ terminate
 ```
 
 ### Related commands
- - [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
- - [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
- - [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
- - [`restart`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#restart)
+* [`kill`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#kill)
+* [`ps`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#ps)
+* [`boot`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#boot)
+* [`restart`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#restart)
 
 ## wait
 ### Description
@@ -810,9 +810,9 @@ wait 10
 This commands displays who is has the control of a controller and its children. Note the user must be in control to be able to send commands to the controller
 
 The `who-is-in-charge` command takes the following options:
- - `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
- - `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
- - `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
+* `--target` (optional), allows you to specify a target application/segment for the command. The command will only be run on that application or segment and children if you specify it. By default, the target is the top segment for the whole session.
+* `--execute-along-path/--dont-execute-along-path` (optional), the command gets executed along the path of the target, starting with the top controller, etc. By default, execute along path is true.
+* `--execute-on-all-subsequent-children-in-path/--dont-execute-on-all-subsequent-children-in-path` (optional), the command gets executed on all the children (applications and controllers) that are controlled by target (similar to `-r/--recursive` for `rm` or `grep`). By default, execute on all subsequent children in path.
 
 By default, `who-is-in-charge` surrenders the control on the whole system.
 
@@ -827,9 +827,9 @@ who-is-in-charge --target root-controller/trg-controller
 ```
 
 ### Related commands
- - [`take-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#take-control)
- - [`surrender-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#surrender-control)
- - [`whoami`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#whoami)
+* [`take-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#take-control)
+* [`surrender-control`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#surrender-control)
+* [`whoami`](https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/Unified-shell-reference#whoami)
 
 ## whoami### Description
 **NOTE**: This command isn't typically used right now.


### PR DESCRIPTION
… also with ReadTheDocs' MkDocs

To test, compare https://dune-daq-sw.readthedocs.io/en/johnfreeman-test_drunc_issue423/packages/drunc/ with https://dune-daq-sw.readthedocs.io/en/latest/packages/drunc/, in particular noticing that with the new changes the diagrams show up on the main page and the FSM page, and that the tables format correctly. 


Details in the commit comment, reproduced here:

Changes I've made here include:

* To create bullet points, used asterices instead of dashes; MkDocs isn't good with dashes

* For links to *.png files, just use the name of the file and leave out the full path to it, otherwise it doesn't display

* On the release notes page, provide a header saying "Release Notes" so in the drop down menu for drunc in the ReadTheDocs sidebar it's "Release Notes" rather than "v0.10.1" which shows up

* Somewhat similarly, put the header "DUNE Run Control" above the linting and pytest links so that the docs' repo's script "the_final_markdown.md" doesn't unnecessarily add a second header called "drunc README"