### PR TITLE
:wrench: Use dynamic repo URL in actions.

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -35,8 +35,8 @@ jobs:
           cd nightly/NFD_DEV* || true
           source env.sh
           python -m pip install --upgrade pip
-          git clone https://github.com/${{ github.repository_owner }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
-          git clone https://github.com/${{ github.repository_owner }}/drunc.git -b ${{ github.head_ref }}
+          git clone https://github.com/${{ github.event.pull_request.head.headRepositoryOwner }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
+          git clone https://github.com/${{ github.event.pull_request.head.headRepositoryOwner }}/drunc.git -b ${{ github.head_ref }}
           cd druncschema
           pip install .
           cd -

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - name: Check URLs
         run: |
-          echo https://github.com/${{ github.event.pull_request.head.repo.owner }}/druncschema.git
-          echo https://github.com/${{ github.event.pull_request.head.repo.owner }}/drunc.git
-          
+          echo https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/druncschema.git
+          echo https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/drunc.git
+
       - name: Set up dev nightly
         if: ${{ !cancelled() }}
         run: |
@@ -40,8 +40,8 @@ jobs:
           cd nightly/NFD_DEV* || true
           source env.sh
           python -m pip install --upgrade pip
-          git clone https://github.com/${{ github.event.pull_request.head.repo.owner }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
-          git clone https://github.com/${{ github.event.pull_request.head.repo.owner }}/drunc.git -b ${{ github.head_ref }}
+          git clone https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
+          git clone https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/drunc.git -b ${{ github.head_ref }}
           cd druncschema
           pip install .
           cd -

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -16,6 +16,11 @@ jobs:
       image: ghcr.io/dune-daq/nightly-release-alma9:development_v5
 
     steps:
+      - name: Check URLs
+        run: |
+          echo https://github.com/${{ github.event.pull_request.head.repo.owner }}/druncschema.git
+          echo https://github.com/${{ github.event.pull_request.head.repo.owner }}/drunc.git
+          
       - name: Set up dev nightly
         if: ${{ !cancelled() }}
         run: |
@@ -35,8 +40,8 @@ jobs:
           cd nightly/NFD_DEV* || true
           source env.sh
           python -m pip install --upgrade pip
-          git clone https://github.com/${{ github.event.pull_request.head.headRepositoryOwner }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
-          git clone https://github.com/${{ github.event.pull_request.head.headRepositoryOwner }}/drunc.git -b ${{ github.head_ref }}
+          git clone https://github.com/${{ github.event.pull_request.head.repo.owner }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
+          git clone https://github.com/${{ github.event.pull_request.head.repo.owner }}/drunc.git -b ${{ github.head_ref }}
           cd druncschema
           pip install .
           cd -

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -35,8 +35,8 @@ jobs:
           cd nightly/NFD_DEV* || true
           source env.sh
           python -m pip install --upgrade pip
-          git clone https://github.com/DUNE-DAQ/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
-          git clone https://github.com/DUNE-DAQ/drunc.git -b ${{ github.head_ref }}
+          git clone https://github.com/${{ github.repository_owner }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
+          git clone https://github.com/${{ github.repository_owner }}/drunc.git -b ${{ github.head_ref }}
           cd druncschema
           pip install .
           cd -


### PR DESCRIPTION
For the testing, the actions install `drunc` and `druncschema` and update the environment. However, when running them from a fork, this process fail since the working branch that this installation is trying to use does not exist in the base repository.

This PR dynamically construct the URL to clone `drunc` and `druncschema` from based on the forked repository owner. When opening a PR directly from the base repository, the URLs will be:

```
https://github.com/DRUNC-DAQ/druncschema.git 
https://github.com/DRUNC-DAQ/drunc.git
```

But when the PR is open from a fork, these become:

```
https://github.com/FORK_OWNER/druncschema.git 
https://github.com/FORK_OWNER/drunc.git
```

Of course, the `druncschema` repo might not exist for that owner, or exist but not a branch with the same name, in which case it defaults to `https://github.com/DRUNC-DAQ/druncschema.git`

Close https://github.com/ImperialCollegeLondon/drunc/issues/12