### PR TITLE
Sequence commands for patch

### DIFF
--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -42,6 +42,7 @@ from drunc.process_manager.interface.commands import (
 )
 from drunc.process_manager.interface.process_manager import run_pm
 from drunc.unified_shell.commands import boot
+from drunc.unified_shell.shell_utils import generate_fsm_sequence_command
 from drunc.utils.configuration import ConfTypes, OKSKey
 from drunc.utils.grpc_utils import ServerUnreachable
 from drunc.utils.utils import (
@@ -300,6 +301,11 @@ def unified_shell(
     for transition in transitions.commands:
         ctx.command.add_command(
             *generate_fsm_command(ctx.obj, transition, controller_name)
+        )
+
+    for sequence in session_dal.segment.controller.fsm.command_sequences:
+        ctx.command.add_command(
+            *generate_fsm_sequence_command(ctx, sequence, controller_name)
         )
 
     ctx.command.add_command(status, "status")

--- a/src/drunc/unified_shell/shell_utils.py
+++ b/src/drunc/unified_shell/shell_utils.py
@@ -1,0 +1,77 @@
+from functools import partial
+
+import click
+
+from drunc.exceptions import DruncSetupException
+
+
+def run_fsm_sequence(sequence_commands, options_and_args, ctx, **kwargs):
+    print(f"Running sequence: {sequence_commands}")
+    # params = cmd1, x=x, flag=flag
+    for command in sequence_commands:
+        print(f"Running command: {command}")
+        cmd_kwargs = {
+            kwarg_name: kwargs[kwarg_name] for kwarg_name in options_and_args[command]
+        }
+        ctx.command.invoke(ctx.command.commands[command], **cmd_kwargs)
+
+
+def generate_fsm_sequence_command(ctx, sequence, controller_name):
+    print(f"Sequence: {sequence.id}")
+    sequence_commands = []
+    cmd_to_options_and_args = {}
+    name_to_options_and_args = {}
+    sequence_str = ""
+    middle_text = "[optionally], then "
+    command_ids = [command.id for command in sequence.sequence]
+
+    if sequence.id == "start_run":
+        command_ids = ["boot"] + command_ids
+    elif sequence.id == "shutdown":
+        command_ids = command_ids + ["terminate"]
+
+    for command_id in command_ids:
+        sequence_commands.append(command_id)
+        command_name = command_id.replace("_", "-")
+        sequence_str += f"{command_name}{middle_text}"
+        print(f"Considering command: {command_name}")
+        if command_name not in ctx.command.commands.keys():
+            raise DruncSetupException(
+                f"Command {command_name} required by sequence {sequence.id} not found in the command list!"
+            )
+
+        params = ctx.command.commands[command_name].get_params(ctx)
+        cmd_to_options_and_args[command_name] = []
+        for param in params:
+            if param.name == "help":
+                continue
+            cmd_to_options_and_args[command_name].append(param.name)
+            name_to_options_and_args[param.name] = param
+
+    sequence_str = sequence_str[: -len(middle_text)]
+
+    cmd = partial(run_fsm_sequence, sequence_commands, cmd_to_options_and_args)
+    cmd = click.pass_obj(cmd)
+
+    for param_name, param in name_to_options_and_args.items():
+        if param.name == "help":
+            continue
+
+        print(param_name)
+        param_name = param_name.replace("_", "-").lower()
+        cmd = click.option(
+            f"--{param_name}",
+            type=param.type,
+            default=param.default,
+            show_default=param.show_default,
+            required=param.required,
+            help=param.help,
+        )(cmd)
+
+    print(cmd.__dict__)
+    cmd = click.command(
+        name=sequence.id.replace("_", "-"),
+        help=f"Run the sequence {sequence.id}: {sequence_str}",
+    )(cmd)
+    print(cmd.__dict__)
+    return cmd, sequence.id.replace("_", "-")

--- a/src/drunc/unified_shell/shell_utils.py
+++ b/src/drunc/unified_shell/shell_utils.py
@@ -12,13 +12,13 @@ def run_fsm_sequence(sequence_commands, cmd_to_options_and_args, ctx, obj, **kwa
     logger.info(f"Running sequence: {sequence_commands}")
 
     for command in sequence_commands:
-        accepted_command = ["boot"]
+        accepted_command = ["boot", "terminate"]  # Always accept boot and terminate
 
         cd = obj.get_driver("controller", quiet_fail=True)
 
         if cd:
             accepted_command_raw = cd.describe_fsm()
-            accepted_command = [
+            accepted_command += [
                 c.name.lower().replace("_", "-")
                 for c in accepted_command_raw.data.commands
             ]

--- a/src/drunc/unified_shell/shell_utils.py
+++ b/src/drunc/unified_shell/shell_utils.py
@@ -2,22 +2,48 @@ from functools import partial
 
 import click
 
-from drunc.exceptions import DruncSetupException
+from drunc.exceptions import DruncException, DruncSetupException
+from drunc.utils.utils import get_logger
+
+logger = get_logger("unified_shell.shell_utils")
 
 
-def run_fsm_sequence(sequence_commands, options_and_args, ctx, **kwargs):
-    print(f"Running sequence: {sequence_commands}")
-    # params = cmd1, x=x, flag=flag
+def run_fsm_sequence(sequence_commands, cmd_to_options_and_args, ctx, obj, **kwargs):
+    logger.info(f"Running sequence: {sequence_commands}")
+
     for command in sequence_commands:
-        print(f"Running command: {command}")
+        accepted_command = ["boot"]
+
+        cd = obj.get_driver("controller", quiet_fail=True)
+
+        if cd:
+            accepted_command_raw = cd.describe_fsm()
+            accepted_command = [
+                c.name.lower().replace("_", "-")
+                for c in accepted_command_raw.data.commands
+            ]
+        logger.debug(f"Accepted commands: {accepted_command}")
+
+        if command not in accepted_command and command != [sequence_commands[-1]]:
+            logger.info(f"Skipping command '{command}'")
+            continue
+
+        logger.info(f"Running command: '{command}'")
+
         cmd_kwargs = {
-            kwarg_name: kwargs[kwarg_name] for kwarg_name in options_and_args[command]
+            kwarg_name: kwargs[kwarg_name]
+            for kwarg_name in cmd_to_options_and_args[command]
         }
-        ctx.command.invoke(ctx.command.commands[command], **cmd_kwargs)
+
+        try:
+            ctx.invoke(ctx.command.commands[command], **cmd_kwargs)
+        except DruncException as e:
+            logger.error(f"Error running command: '{command}'")
+            logger.exception(e)
+            raise e
 
 
 def generate_fsm_sequence_command(ctx, sequence, controller_name):
-    print(f"Sequence: {sequence.id}")
     sequence_commands = []
     cmd_to_options_and_args = {}
     name_to_options_and_args = {}
@@ -31,10 +57,9 @@ def generate_fsm_sequence_command(ctx, sequence, controller_name):
         command_ids = command_ids + ["terminate"]
 
     for command_id in command_ids:
-        sequence_commands.append(command_id)
         command_name = command_id.replace("_", "-")
+        sequence_commands.append(command_name)
         sequence_str += f"{command_name}{middle_text}"
-        print(f"Considering command: {command_name}")
         if command_name not in ctx.command.commands.keys():
             raise DruncSetupException(
                 f"Command {command_name} required by sequence {sequence.id} not found in the command list!"
@@ -50,14 +75,13 @@ def generate_fsm_sequence_command(ctx, sequence, controller_name):
 
     sequence_str = sequence_str[: -len(middle_text)]
 
-    cmd = partial(run_fsm_sequence, sequence_commands, cmd_to_options_and_args)
+    cmd = partial(run_fsm_sequence, sequence_commands, cmd_to_options_and_args, ctx)
     cmd = click.pass_obj(cmd)
 
     for param_name, param in name_to_options_and_args.items():
         if param.name == "help":
             continue
 
-        print(param_name)
         param_name = param_name.replace("_", "-").lower()
         cmd = click.option(
             f"--{param_name}",
@@ -68,10 +92,9 @@ def generate_fsm_sequence_command(ctx, sequence, controller_name):
             help=param.help,
         )(cmd)
 
-    print(cmd.__dict__)
     cmd = click.command(
         name=sequence.id.replace("_", "-"),
         help=f"Run the sequence {sequence.id}: {sequence_str}",
     )(cmd)
-    print(cmd.__dict__)
+
     return cmd, sequence.id.replace("_", "-")

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -289,7 +289,7 @@ class ShellContext:
             raise DruncShellException(f"Driver {name} already present in this context")
         self._drivers[name] = driver
 
-    def get_driver(self, name: str = None) -> GRPCDriver:
+    def get_driver(self, name: str = None, quiet_fail: bool = False) -> GRPCDriver:
         try:
             if name:
                 return self._drivers[name]
@@ -297,6 +297,8 @@ class ShellContext:
                 raise DruncShellException("More than one driver in this context")
             return list(self._drivers.values())[0]
         except KeyError:
+            if quiet_fail:
+                return None
             log = get_logger("utils.ShellContext")
             log.exception(
                 "Controller-specific commands cannot be sent until the session is booted"


### PR DESCRIPTION
This PR adds the following commands to the unified shell:
- `start-run`, which executes the sequence`boot`, `conf`, `start` and `enable-triggers`
- `stop-run` (`disable-triggers`, `drain-dataflow`, `stop-trigger-sources`, `stop`)
- `shutdown` (same as above with the addition of `scrap` and `terminate`.
Implemented in the unified shell _only_, as this requires configuration. Intended for patch release (v5.3.2).