### PR TITLE
Suppress ssh warnings and hostkey errorns when connecting to localhost

### DIFF
--- a/src/drunc/data/process_manager/ssh-standalone.json
+++ b/src/drunc/data/process_manager/ssh-standalone.json
@@ -2,6 +2,11 @@
     "type": "ssh",
     "name": "SSHProcessManager",
 
+    "settings" : {
+        "disable_localhost_host_key_check": true,
+        "disable_host_key_check": true
+    },
+
     "authoriser": {
         "type": "dummy"
     },

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -25,6 +25,7 @@ class ProcessManagerConfData:
         self.type = ProcessManagerTypes.Unknown
         self.command_address = ""
         self.environment = {}
+        self.settings = {}
         self.opmon_uri = None
         self.opmon_publisher = None
 
@@ -45,6 +46,7 @@ class ProcessManagerConfHandler(ConfHandler):
             new_data.broadcaster = None
         new_data.authoriser = None
         new_data.environment = data.get("environment", {})
+        new_data.settings = data.get("settings", {})
 
         match data["type"].lower():
             case "ssh":

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -52,6 +52,13 @@ class SSHProcessManager(ProcessManager):
 
         super().__init__(configuration=configuration, session=self.session, **kwargs)
 
+        self.disable_localhost_host_key_check = False
+        self.disable_host_key_check = False
+
+        if self.configuration.data.settings:
+            self.disable_localhost_host_key_check = self.configuration.data.settings.get('disable_localhost_host_key_check', False)
+            self.disable_host_key_check = self.configuration.data.settings.get('disable_host_key_check', False)
+
         # self.children_logs_depth = 1000
         # self.children_logs = {}
         self.watchers = []
@@ -126,12 +133,15 @@ class SSHProcessManager(ProcessManager):
         user = self.boot_request[uid].process_description.metadata.user
         host = self.boot_request[uid].process_description.metadata.hostname
         user_host = f"{user}@{host}"
+        disable_host_key_check = self.disable_host_key_check or (self.disable_localhost_host_key_check and host in ('localhost', '127.0.0.1', '::1'))
+
         # https://stackoverflow.com/questions/7167008/efficiently-finding-the-last-line-in-a-text-file
         # "Not the straight forward way"...
         f = tempfile.NamedTemporaryFile(delete=False)
         nlines = log_request.how_far
         if not nlines:
             nlines = 100
+
 
         try:
             cmd = [
@@ -141,7 +151,7 @@ class SSHProcessManager(ProcessManager):
             ]
             self.log.debug(f"cmd: {cmd}")
             arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no"]
-            arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"] if host in ('localhost', '127.0.0.1', '::1') else []
+            arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"] if disable_host_key_check else []
             arguments += cmd
 
             self.ssh(
@@ -222,6 +232,8 @@ class SSHProcessManager(ProcessManager):
 
                 log_file = boot_request.process_description.process_logs_path
                 env_var = boot_request.process_description.env
+                disable_host_key_check = self.disable_host_key_check or (self.disable_localhost_host_key_check and host in ('localhost', '127.0.0.1', '::1'))
+
 
                 # Add EXIT trap and use it kill child processes on the ssh client side when the ssh connection is closed
                 cmd = (
@@ -251,7 +263,7 @@ class SSHProcessManager(ProcessManager):
                     "-tt",
                     "-o StrictHostKeyChecking=no"
                 ]
-                arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"]  if host in ('localhost', '127.0.0.1', '::1') else []
+                arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"]  if disable_host_key_check else []
                 arguments += [
                     f"{{ {cmd} ; }} &> {log_file}",
                 ]

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -140,7 +140,10 @@ class SSHProcessManager(ProcessManager):
                 logfile,
             ]
             self.log.debug(f"cmd: {cmd}")
-            arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no"] + cmd
+            arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no"]
+            arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"] if host in ('localhost', '127.0.0.1', '::1') else []
+            arguments += cmd
+
             self.ssh(
                 *arguments,
                 _out=f.name,
@@ -246,10 +249,12 @@ class SSHProcessManager(ProcessManager):
                 arguments = [
                     user_host,
                     "-tt",
-                    "-o StrictHostKeyChecking=no",
+                    "-o StrictHostKeyChecking=no"
+                ]
+                arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"]  if host in ('localhost', '127.0.0.1', '::1') else []
+                arguments += [
                     f"{{ {cmd} ; }} &> {log_file}",
                 ]
-                self.log.debug(f"{arguments}")
                 # arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no", f'{{ {cmd} ; }} > >(tee -a {log_file}) 2> >(tee -a {log_file} >&2)']
                 # I'm gonna bail now and read that log file, anyway, it's probably better that heavy logger applications don't clog up the process manager CPU.
                 self.process_store[uuid] = self.ssh(


### PR DESCRIPTION
In computer clusters with shared file system, ssh-ing to localhost can result in ssh host-key mismatch errors.
The cause of this errors is the combination of the ssh `known_hosts` file being located on a shared file system and shared across multiple  servers, but containing the 'localhost' key of the host when `ssh localhost` was executed first.
This little patch tweaks the ssh argument in the ssh process manager to completely bypass host-key checks when the target is localhost.