### PR TITLE
Fix decorators clobbering gRPC context.

### DIFF
--- a/src/drunc/authoriser/decorators.py
+++ b/src/drunc/authoriser/decorators.py
@@ -11,7 +11,7 @@ def authentified_and_authorised(action, system):
         @functools.wraps(
             cmd
         )  # this nifty decorator of decorator (!) is nicely preserving the cmd.__name__ (i.e. signature)
-        def check_token(obj, request):
+        def check_token(obj, request, context):
             log = get_logger("utils.authentified_and_authorised_decorator")
             log.debug("Entering")
             if not obj.authoriser.is_authorised(
@@ -34,7 +34,7 @@ def authentified_and_authorised(action, system):
                 #     drunc_system = obj.name,
                 # )
             log.debug("Executing wrapped function")
-            ret = cmd(obj, request)
+            ret = cmd(obj, request, context)
             log.debug("Exiting")
             return ret
 
@@ -48,7 +48,7 @@ def async_authentified_and_authorised(action, system):
         @functools.wraps(
             cmd
         )  # this nifty decorator of decorator (!) is nicely preserving the cmd.__name__ (i.e. signature)
-        async def check_token(obj, request):
+        async def check_token(obj, request, context):
             log = get_logger("utils.authentified_and_authorised_decorator")
             log.debug("Entering")
             if not obj.authoriser.is_authorised(
@@ -64,7 +64,7 @@ def async_authentified_and_authorised(action, system):
                     children=[],
                 )
             log.debug("Executing wrapped function")
-            async for a in cmd(obj, request):
+            async for a in cmd(obj, request, context):
                 yield a
             log.debug("Exiting")
 

--- a/src/drunc/broadcast/server/decorators.py
+++ b/src/drunc/broadcast/server/decorators.py
@@ -36,9 +36,7 @@ def broadcasted(cmd):
         cmd_start_time = time.time()
         try:
             log.debug("Executing wrapped function")
-            ret = cmd(
-                obj, request
-            )  # we strip the context here, no need for that anymore
+            ret = cmd(obj, request, context)
 
         except Exception as e:
             log.exception(e)
@@ -116,7 +114,7 @@ def async_broadcasted(cmd):
 
         try:
             log.debug("Executing wrapped function")
-            async for a in cmd(obj, request):
+            async for a in cmd(obj, request, context):
                 yield a
 
         except Exception as e:

--- a/src/drunc/controller/decorators.py
+++ b/src/drunc/controller/decorators.py
@@ -12,7 +12,7 @@ from drunc.utils.utils import get_logger
 
 def in_control(cmd):
     @wraps(cmd)
-    def wrap(obj, request):
+    def wrap(obj, request, context):
         if not obj.actor.token_is_current_actor(request.token):
             return Response(
                 name=obj.name,
@@ -25,7 +25,7 @@ def in_control(cmd):
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
                 children=[],
             )
-        return cmd(obj, request)
+        return cmd(obj, request, context)
 
     return wrap
 
@@ -36,7 +36,7 @@ def unpack_addressed_command_to(data_type=None):
         logger = get_logger(f"controller.upack_add'ed_cmd.{command_name}")
 
         @wraps(cmd)
-        def wrap(obj, request):
+        def wrap(obj, request, context):
             try:
                 if request.HasField("data"):
                     command = unpack_any(request.data, AddressedCommand)

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -1,7 +1,6 @@
 """The session manager service."""
 
 import abc
-import logging
 
 from druncschema.request_response_pb2 import (
     CommandDescription,
@@ -15,14 +14,14 @@ from druncschema.token_pb2 import Token
 
 from drunc.session_manager.configuration import SessionManagerConfHandler
 from drunc.utils.grpc_utils import pack_to_any, unpack_request_data_to
-from drunc.utils.utils import pid_info_str
+from drunc.utils.utils import get_logger, pid_info_str
 
 
 class SessionManager(abc.ABC, SessionManagerServicer):
     def __init__(self, name: str, configuration: SessionManagerConfHandler):
         super().__init__()
 
-        self.log = logging.getLogger("drunc.session_manager")
+        self.log = get_logger("session_manager")
         self.log.debug(pid_info_str())
         self.log.debug("Initialized SessionManager")
 

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -40,7 +40,7 @@ def unpack_any(data, format):
 def unpack_request_data_to(data_type=None, pass_token=False):
     def decor(cmd):
         @functools.wraps(cmd)
-        def unpack_request(obj, request):
+        def unpack_request(obj, request, context):
             log = get_logger("utils.unpack_request_data_to_decorator")
             log.debug("Entering")
 
@@ -81,7 +81,7 @@ def unpack_request_data_to(data_type=None, pass_token=False):
 def async_unpack_request_data_to(data_type=None, pass_token=False):
     def decor(cmd):
         @functools.wraps(cmd)
-        async def unpack_request(obj, request):
+        async def unpack_request(obj, request, context):
             log = get_logger("utils.async_unpack_request_data_to_decorator")
             log.debug("Executing wrapped function")
             kwargs = {}


### PR DESCRIPTION
Simple ish fix after a lot of hunting.

Some of the decorators (e.g. broadcast) silently strip the context var of gRPC commands, which causes problems for commands that don't use the broadcast decorator. Not ideal with layered decorators, but this fix changes it so that the final 'unpack' decorator is the one that strips the context. This should hopefully be a bit more consistent. 

Also fixed session manager's broken logging -- woo! Remote backtraces!

Fixes https://github.com/ImperialCollegeLondon/drunc_ui/issues/417
Fixes https://github.com/ImperialCollegeLondon/drunc_ui/issues/439