### PR TITLE
Return real configs in list_all_configs

### DIFF
--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -11,7 +11,12 @@ from druncschema.request_response_pb2 import (
     Response,
     ResponseFlag,
 )
-from druncschema.session_manager_pb2 import ActiveSession, AllActiveSessions, ConfigKey
+from druncschema.session_manager_pb2 import (
+    ActiveSession,
+    AllActiveSessions,
+    AllConfigKeys,
+    ConfigKey,
+)
 from druncschema.session_manager_pb2_grpc import SessionManagerServicer
 from druncschema.token_pb2 import Token
 
@@ -75,9 +80,36 @@ class SessionManager(abc.ABC, SessionManagerServicer):
     def list_all_sessions(self, token: Token) -> Response:
         self.log.debug(f"{self.name} running list_all_sessions")
 
+        dummy_config = ConfigKey(
+            file="dummy_config_file",
+            session_id="dummy_config_session_id",
+        )
+
+        dummy_session = ActiveSession(
+            name="dummy_session",
+            user="dummy_user",
+            config_key=dummy_config,
+        )
+
+        all_sessions = AllActiveSessions(
+            active_sessions=[dummy_session],
+        )
+
+        return Response(
+            name=self.name,
+            token=None,
+            data=pack_to_any(all_sessions),
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+            children=[],
+        )
+
+    @unpack_request_data_to(None, pass_token=True)
+    def list_all_configs(self, token: Token) -> Response:
+        self.log.debug(f"{self.name} running list_all_configs")
+
         # Get search paths for available configurations.
-        all_search_paths = getenv("DUNEDAQ_DB_PATH")
-        if all_search_paths is None:
+        search_paths = getenv("DUNEDAQ_DB_PATH")
+        if search_paths is None:
             self.log.error("DUNEDAQ_DB_PATH not set")
             return Response(
                 name=self.name,
@@ -89,14 +121,14 @@ class SessionManager(abc.ABC, SessionManagerServicer):
 
         # Find all configuration files.
         config_files = []
-        for search_path in all_search_paths.split(":"):
+        for path in search_paths.split(":"):
             # TODO: we *should not* hardcode this file name.
             # TODO: setting "*.data.xml" fails on e.g. "example-hsi-configs.data.xml".
-            config_glob = Path(search_path).rglob("example-configs.data.xml")
+            config_glob = Path(path).rglob("example-configs.data.xml")
             config_files.extend(config_glob)
 
         # Parse all configuration files.
-        sessions = []
+        configs = []
         for file in config_files:
             cfg = Configuration(f"oksconflibs:{file}")
             for session in cfg.get_dals("Session"):
@@ -104,25 +136,16 @@ class SessionManager(abc.ABC, SessionManagerServicer):
                     file=file.name,
                     session_id=session.id,
                 )
-                active_session = ActiveSession(
-                    name="dummy_session",
-                    user="dummy_user",
-                    config_key=config_key,
-                )
-                sessions.append(active_session)
-        all_sessions = AllActiveSessions(
-            active_sessions=sessions,
+                configs.append(config_key)
+
+        all_configs = AllConfigKeys(
+            config_keys=configs,
         )
 
         return Response(
             name=self.name,
             token=None,
-            data=pack_to_any(all_sessions),
+            data=pack_to_any(all_configs),
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
             children=[],
         )
-
-    # TODO: next PR.
-    # @unpack_request_data_to(None, pass_token=True)
-    # def list_all_configs(self, token: Token) -> Response:
-    #     pass

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -1,7 +1,10 @@
 """The session manager service."""
 
 import abc
+from os import getenv
+from pathlib import Path
 
+from conffwk import Configuration
 from druncschema.request_response_pb2 import (
     CommandDescription,
     Description,
@@ -72,19 +75,43 @@ class SessionManager(abc.ABC, SessionManagerServicer):
     def list_all_sessions(self, token: Token) -> Response:
         self.log.debug(f"{self.name} running list_all_sessions")
 
-        dummy_config = ConfigKey(
-            file="dummy_config_file",
-            session_id="dummy_config_session_id",
-        )
+        # Get search paths for available configurations.
+        all_search_paths = getenv("DUNEDAQ_DB_PATH")
+        if all_search_paths is None:
+            self.log.error("DUNEDAQ_DB_PATH not set")
+            return Response(
+                name=self.name,
+                token=None,
+                data=pack_to_any(None),
+                flag=ResponseFlag.FAILED,
+                children=[],
+            )
 
-        dummy_session = ActiveSession(
-            name="dummy_session",
-            user="dummy_user",
-            config_key=dummy_config,
-        )
+        # Find all configuration files.
+        config_files = []
+        for search_path in all_search_paths.split(":"):
+            # TODO: we *should not* hardcode this file name.
+            # TODO: setting "*.data.xml" fails on e.g. "example-hsi-configs.data.xml".
+            config_glob = Path(search_path).rglob("example-configs.data.xml")
+            config_files.extend(config_glob)
 
+        # Parse all configuration files.
+        sessions = []
+        for file in config_files:
+            cfg = Configuration(f"oksconflibs:{file}")
+            for session in cfg.get_dals("Session"):
+                config_key = ConfigKey(
+                    file=file.name,
+                    session_id=session.id,
+                )
+                active_session = ActiveSession(
+                    name="dummy_session",
+                    user="dummy_user",
+                    config_key=config_key,
+                )
+                sessions.append(active_session)
         all_sessions = AllActiveSessions(
-            active_sessions=[dummy_session],
+            active_sessions=sessions,
         )
 
         return Response(

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -122,19 +122,23 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         # Find all configuration files.
         config_files = []
         for path in search_paths.split(":"):
-            # TODO: we *should not* hardcode this file name.
-            # TODO: setting "*.data.xml" fails on e.g. "example-hsi-configs.data.xml".
-            config_glob = Path(path).rglob("example-configs.data.xml")
+            config_glob = Path(path).rglob("*.data.xml")
             config_files.extend(config_glob)
 
         # Parse all configuration files.
         configs = []
         for file in config_files:
-            cfg = Configuration(f"oksconflibs:{file}")
-            for session in cfg.get_dals("Session"):
+            try:
+                config = Configuration(f"oksconflibs:{file}")
+            except Exception as e:
+                self.log.error(e)
+                continue
+
+            # Parse all session configurations in this file.
+            for session_config in config.get_dals("Session"):
                 config_key = ConfigKey(
                     file=file.name,
-                    session_id=session.id,
+                    session_id=session_config.id,
                 )
                 configs.append(config_key)
 

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -1,7 +1,7 @@
 """Provides an interface to the session manager service."""
 
 from druncschema.request_response_pb2 import Description
-from druncschema.session_manager_pb2 import AllActiveSessions
+from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
 
 from drunc.utils.shell_utils import DecodedResponse, GRPCDriver
@@ -22,6 +22,5 @@ class SessionManagerDriver(GRPCDriver):
     def list_all_sessions(self) -> DecodedResponse:
         return self.send_command("list_all_sessions", outformat=AllActiveSessions)
 
-    # TODO: next PR.
-    # def list_all_configs(self) -> DecodedResponse:
-    #     return self.send_command('list_all_configs', outformat=AllConfigKeys)
+    def list_all_configs(self) -> DecodedResponse:
+        return self.send_command("list_all_configs", outformat=AllConfigKeys)


### PR DESCRIPTION
This PR (finally) implements the searching and returning of actual session configs over the gRPC list_all_configs call.

Configs are searched on `DUNEDAQ_DB_PATH`, so this must be set for this to work. DUNEDAQ_DB_PATH is set in the drunc_ui devel containers already, so this should work out of the box with those. On failure, a FAILURE response is returned for safety.

Currently the files must be named `example-configs.data.xml`, which is obviously less than ideal, but searching for `*.data.xml` failes on, for example, `example-hsi-configs.data.xml` for some reason.

Please reach out if something is not clear.

Resolves https://github.com/ImperialCollegeLondon/drunc/issues/3
