### PR TITLE
Wait for connectivity service before starting applications

### DIFF
--- a/src/drunc/connectivity_service/client.py
+++ b/src/drunc/connectivity_service/client.py
@@ -3,7 +3,7 @@ import time
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 
 from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
-from drunc.utils.utils import get_logger, http_post
+from drunc.utils.utils import get_logger, http_get, http_post
 
 
 class ConnectivityServiceClient:
@@ -20,6 +20,25 @@ class ConnectivityServiceClient:
         self.log.debug(
             f"Connectivity service address: {self.address}, session: {self.session}"
         )
+
+    def is_ready(self, timeout: int = 10):
+        start = time.time()
+
+        while time.time() - start < timeout:
+            try:
+                r = http_get(
+                    self.address + "/",
+                    headers={"Content-Type": "application/json"},
+                    as_json=True,
+                    timeout=0.5,
+                    ignore_errors=True,
+                    data=None,
+                )
+                r.raise_for_status()
+                return True
+            except (HTTPError, ConnectionError, ReadTimeout):
+                time.sleep(0.5)
+        return False
 
     def retract(self, uid, fail_quickly=False):
         data = {

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -186,6 +186,14 @@ To debug it, close drunc and run the following command:
         db = conffwk.Configuration(conf_file)
         session_dal = db.get_dal(class_name="Session", uid=conf_id)
 
+        csc = None
+        if session_dal.connectivity_service:
+            connection_server = session_dal.connectivity_service.host
+            connection_port = session_dal.connectivity_service.service.port
+            csc = ConnectivityServiceClient(
+                session_name, f"{connection_server}:{connection_port}"
+            )
+
         async for br in self._convert_oks_to_boot_request(
             oks_conf=conf_file,
             user=user,
@@ -195,6 +203,14 @@ To debug it, close drunc and run the following command:
             override_logs=override_logs,
             **kwargs,
         ):
+            if (
+                br.process_description.metadata.name
+                not in [app.id for app in session_dal.infrastructure_applications]
+                and csc
+                and not csc.is_ready(timeout=10)
+            ):
+                raise DruncSetupException("Connectivity service is not ready in time")
+
             yield await self.send_command_aio(
                 "boot",
                 data=br,
@@ -209,13 +225,7 @@ To debug it, close drunc and run the following command:
 
             env = {}
             collect_variables(session_dal.environment, env)
-            if session_dal.connectivity_service:
-                connection_server = session_dal.connectivity_service.host
-                connection_port = session_dal.connectivity_service.service.port
-                csc = ConnectivityServiceClient(
-                    session_name, f"{connection_server}:{connection_port}"
-                )
-
+            if csc:
                 try:
                     timeout = (
                         get_segment_lookup_timeout(session_dal.segment, 60) + 60


### PR DESCRIPTION
This PR:
- Implement a `is_ready` on the `ConnectivityServerClient`
- And use it to check that the connectivity service can be accessed before starting the application