### PR TITLE
Session manager type check, tidy up and commenting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,12 @@ dynamic = ["version", "readme"]
 dependencies = [
     "click==8.1.7",
     "click-shell==2.1",
+    "protobuf",
+    "types-protobuf",
     "grpcio==1.68.0",
-    "googleapis-common-protos==1.66.0",
     "grpcio-status==1.68.0",
     "grpcio-tools==1.68.0",
+    "types-grpcio",
     "gunicorn==23.0.0",
     "kafka-python==2.0.2",
     "nest-asyncio==1.6.0",

--- a/src/drunc/session_manager/configuration.py
+++ b/src/drunc/session_manager/configuration.py
@@ -4,4 +4,6 @@ from drunc.utils.configuration import ConfHandler
 
 
 class SessionManagerConfHandler(ConfHandler):
+    """TODO: Change this exception to something more useful."""
+
     pass

--- a/src/drunc/session_manager/interface/__init__.py
+++ b/src/drunc/session_manager/interface/__init__.py
@@ -1,0 +1,1 @@
+"""Interfaces for the drunc session manager."""

--- a/src/drunc/session_manager/interface/session_manager.py
+++ b/src/drunc/session_manager/interface/session_manager.py
@@ -1,3 +1,5 @@
+"""Session Manager CLI interface for Drunc."""
+
 from concurrent import futures
 from logging import getLogger
 
@@ -15,6 +17,12 @@ from drunc.utils.utils import (
 
 
 def serve(session_manager: SessionManager, address: str) -> None:
+    """Start the gRPC server for the session manager.
+
+    Args:
+        session_manager: The session manager instance to serve.
+        address: The address to bind the server to.
+    """
     logger = getLogger("drunc.session_manager")
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     add_SessionManagerServicer_to_server(session_manager, server)
@@ -39,6 +47,11 @@ def serve(session_manager: SessionManager, address: str) -> None:
 # )
 # def session_manager_cli(log_level: str, log_path: str):
 def session_manager_cli():
+    """CLI interface for the Drunc session manager.
+
+    This command starts the session manager service, which allows clients to manage
+    and interact with drunc sessions.
+    """
     app_name = "session_manager"
     log_level = "DEBUG"
 

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -26,7 +26,19 @@ from drunc.utils.utils import get_logger, pid_info_str
 
 
 class SessionManager(abc.ABC, SessionManagerServicer):
+    """Provides a gRPC service to manage and interact with sessions.
+
+    This class implements the server-side session manager logic, used to create
+    and manage sessions.
+    """
+
     def __init__(self, name: str, configuration: SessionManagerConfHandler):
+        """Cerate a new session manager instance.
+
+        Args:
+            name: The name of the session manager.
+            configuration: The configuration handler for the session manager.
+        """
         super().__init__()
 
         self.log = get_logger("session_manager")
@@ -36,15 +48,24 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         self.name = name
         self.configuration = configuration
 
+    # TODO: we cannot type-check yet, due to the decorators.
     @unpack_request_data_to(None, pass_token=True)
     def describe(self, token: Token) -> Response:
+        """Respond with a description of this session manager service.
+
+        Args:
+            token: The token for authentication.
+
+        Returns:
+            A response containing the service description.
+        """
         self.log.debug(f"{self.name} running describe")
 
         command_descriptions = [
             CommandDescription(
                 name="describe",
                 data_type=["None"],
-                help="Describe self (return a list of commands, the type of endpoint, the name and session).",
+                help="List the methods exposed by this endpoint.",
                 return_type="request_response_pb2.Description",
             ),
             CommandDescription(
@@ -76,8 +97,17 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             children=[],
         )
 
+    # TODO: we cannot type-check yet, due to the decorators.
     @unpack_request_data_to(None, pass_token=True)
     def list_all_sessions(self, token: Token) -> Response:
+        """Respond with a list of all active sessions.
+
+        Args:
+            token: The token for authentication.
+
+        Returns:
+            A response containing all active sessions.
+        """
         self.log.debug(f"{self.name} running list_all_sessions")
 
         dummy_config = ConfigKey(
@@ -103,8 +133,17 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             children=[],
         )
 
+    # TODO: we cannot type-check yet, due to the decorators.
     @unpack_request_data_to(None, pass_token=True)
     def list_all_configs(self, token: Token) -> Response:
+        """Respond with a list of all available configurations.
+
+        Args:
+            token: The token for authentication.
+
+        Returns:
+            A response containing all available configuration keys.
+        """
         self.log.debug(f"{self.name} running list_all_configs")
 
         # Get search paths for available configurations.
@@ -120,7 +159,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             )
 
         # Find all configuration files.
-        config_files = []
+        config_files: list[Path] = []
         for path in search_paths.split(":"):
             config_glob = Path(path).rglob("*.data.xml")
             config_files.extend(config_glob)

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -1,4 +1,4 @@
-"""Provides an interface to the session manager service."""
+"""Driver for the session manager service."""
 
 from druncschema.request_response_pb2 import Description
 from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
@@ -10,7 +10,7 @@ from drunc.utils.shell_utils import DecodedResponse, GRPCDriver
 
 
 class SessionManagerDriver(GRPCDriver):
-    """Driver for the session manager service.
+    """Provides an interface to the session manager service.
 
     This class provides the client-side methods required to interact with a remote
     session manager service, via gRPC connections.

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -3,24 +3,62 @@
 from druncschema.request_response_pb2 import Description
 from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
+from druncschema.token_pb2 import Token
+from grpc import Channel
 
 from drunc.utils.shell_utils import DecodedResponse, GRPCDriver
 
 
 class SessionManagerDriver(GRPCDriver):
-    def __init__(self, address: str, token, **kwargs):
-        super(SessionManagerDriver, self).__init__(
+    """Driver for the session manager service.
+
+    This class provides the client-side methods required to interact with a remote
+    session manager service, via gRPC connections.
+    """
+
+    def __init__(self, address: str, token: Token, **kwargs):
+        """Create a new session manager driver instance.
+
+        Args:
+            address: The address of the session manager service.
+            token: The token for authentication.
+            **kwargs: Additional keyword arguments for the driver.
+        """
+        super().__init__(
             name="session_manager_driver", address=address, token=token, **kwargs
         )
 
-    def create_stub(self, channel):
+    def create_stub(self, channel: Channel) -> SessionManagerStub:
+        """Create gRPC stubs for the session manager service.
+
+        Args:
+            channel: The gRPC channel to use for communication.
+
+        Returns:
+            An object containing session manager service method stubs.
+        """
         return SessionManagerStub(channel)
 
-    def describe(self) -> DecodedResponse:
+    def describe(self) -> DecodedResponse | None:
+        """Describe the session manager service.
+
+        Returns:
+            A decoded response object containing the description of the service.
+        """
         return self.send_command("describe", outformat=Description)
 
-    def list_all_sessions(self) -> DecodedResponse:
+    def list_all_sessions(self) -> DecodedResponse | None:
+        """List all active sessions managed by the session manager.
+
+        Returns:
+            A decoded response object containing a list of all active sessions.
+        """
         return self.send_command("list_all_sessions", outformat=AllActiveSessions)
 
-    def list_all_configs(self) -> DecodedResponse:
+    def list_all_configs(self) -> DecodedResponse | None:
+        """List all available configurations in the session manager.
+
+        Returns:
+            A decoded response object containing all available configuration keys.
+        """
         return self.send_command("list_all_configs", outformat=AllConfigKeys)

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -106,7 +106,7 @@ class GRPCDriver:
         self.token.CopyFrom(token)
 
     @abc.abstractmethod
-    def create_stub(self, channel):
+    def create_stub(self, channel) -> object:
         pass
 
     def _create_request(self, payload=None) -> Request:


### PR DESCRIPTION
Resolves https://github.com/ImperialCollegeLondon/drunc_ui/issues/455

... almost.

Adds comments, type checking and extra ruff fixes to the drunc-side session_manager code in `./src/drunc/session_manager`.

The only thing not addressed is type checking the server-side SM commands, since the current layered decorators with different signatures messes with mypy.
