### PR TITLE
Pawel plesniak/file and stream handling python op mon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ log*
 .nfs*
 info.*.json
 .python-version
+*.xml.data
+*.hdf5

--- a/src/drunc/apps/__main_controller__.py
+++ b/src/drunc/apps/__main_controller__.py
@@ -1,9 +1,5 @@
 from drunc.controller.interface.controller import controller_cli
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    setup_root_logger,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, setup_root_logger
 
 
 def main():

--- a/src/drunc/apps/__main_controller_shell__.py
+++ b/src/drunc/apps/__main_controller_shell__.py
@@ -1,10 +1,6 @@
 from drunc.controller.interface.context import ControllerContext
 from drunc.controller.interface.shell import controller_shell
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    setup_root_logger,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, setup_root_logger
 
 
 def main() -> None:

--- a/src/drunc/apps/__main_pm__.py
+++ b/src/drunc/apps/__main_pm__.py
@@ -1,9 +1,5 @@
 from drunc.process_manager.interface.process_manager import process_manager_cli
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    setup_root_logger,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, setup_root_logger
 
 
 def main():

--- a/src/drunc/apps/__main_pm_shell__.py
+++ b/src/drunc/apps/__main_pm_shell__.py
@@ -1,10 +1,6 @@
 from drunc.process_manager.interface.context import ProcessManagerContext
 from drunc.process_manager.interface.shell import process_manager_shell
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    setup_root_logger,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, setup_root_logger
 
 
 def main():

--- a/src/drunc/apps/__main_session_manager__.py
+++ b/src/drunc/apps/__main_session_manager__.py
@@ -1,9 +1,5 @@
 from drunc.session_manager.interface.session_manager import session_manager_cli
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    setup_root_logger,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, setup_root_logger
 
 
 def main():

--- a/src/drunc/apps/__main_ssh_doctor__.py
+++ b/src/drunc/apps/__main_ssh_doctor__.py
@@ -10,27 +10,34 @@ from sh import Command
 
 from drunc.process_manager.oks_parser import collect_apps
 from drunc.process_manager.ssh_process_manager import on_parent_exit
-from drunc.utils.utils import (
-    log_levels,
-)
+from drunc.utils.utils import log_levels
 
-kDefaultAuth='default'
-kPublicKeyAuth='publickey'
-kKerberosAuth='gssapi-with-mic'
+kDefaultAuth = "default"
+kPublicKeyAuth = "publickey"
+kKerberosAuth = "gssapi-with-mic"
 
-def test_host_connection(host: str, preferred_auth:str=kDefaultAuth) -> bool:
+
+def test_host_connection(host: str, preferred_auth: str = kDefaultAuth) -> bool:
     ssh = Command("/usr/bin/ssh")
-    
-    print(f"[blue]{host}[/blue] \[{preferred_auth}]: ", end='')
+
+    print(f"[blue]{host}[/blue] \[{preferred_auth}]: ", end="")
 
     user_host = f"{getpass.getuser()}@{host}"
-    ssh_args = [
-        user_host,
-        "-tt",
-        "-o StrictHostKeyChecking=no",
-    ]+([f"-o PreferredAuthentications={preferred_auth} "] if preferred_auth!=kDefaultAuth else [])+[
-        f'echo "{user_host} established SSH successfully";',
-    ]
+    ssh_args = (
+        [
+            user_host,
+            "-tt",
+            "-o StrictHostKeyChecking=no",
+        ]
+        + (
+            [f"-o PreferredAuthentications={preferred_auth} "]
+            if preferred_auth != kDefaultAuth
+            else []
+        )
+        + [
+            f'echo "{user_host} established SSH successfully";',
+        ]
+    )
     logging.debug(f"SSH command: /usr/bin/ssh {' '.join(ssh_args)}")
 
     try:
@@ -49,11 +56,13 @@ def test_host_connection(host: str, preferred_auth:str=kDefaultAuth) -> bool:
         # print(f"Failed to SSH onto host [red]{user_host}[/red]")
         # print(e)
         return e
-    
+
     return True
 
-def test_session_ssh_connections(configuration: str, session_name: str, log_level: str, preferred_auth=kDefaultAuth):
 
+def test_session_ssh_connections(
+    configuration: str, session_name: str, log_level: str, preferred_auth=kDefaultAuth
+):
     # log = logging.getLogger()
     db = conffwk.Configuration(f"oksconflibs:{configuration}")
     session_dal = db.get_dal(class_name="Session", uid=session_name)
@@ -86,12 +95,13 @@ def test_session_ssh_connections(configuration: str, session_name: str, log_leve
     default="WARNING",
     help="Set the log level",
 )
-def main(log_level :  str):
+def main(log_level: str):
     FORMAT = "%(message)s"
     logging.basicConfig(
         level=logging.WARNING, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()]
     )
-    logging.getLogger('sh').setLevel(log_level)
+    logging.getLogger("sh").setLevel(log_level)
+
 
 @main.command()
 @click.argument("configuration", type=str, nargs=1)
@@ -101,11 +111,17 @@ def check_session(configuration: str, session: str) -> None:
     auths = [kDefaultAuth, kPublicKeyAuth, kKerberosAuth]
     results = {}
     for auth in auths:
-
-        print('-'*80)
-        print(f"Testing SSH connection to '{session}' host(s) " + (f"enforcing '{auth}' authentication" if auth != kDefaultAuth else "with default authentication"))
+        print("-" * 80)
+        print(
+            f"Testing SSH connection to '{session}' host(s) "
+            + (
+                f"enforcing '{auth}' authentication"
+                if auth != kDefaultAuth
+                else "with default authentication"
+            )
+        )
         print()
-        
+
         results[auth] = test_session_ssh_connections(configuration, session, auth)
     print()
 
@@ -113,19 +129,18 @@ def check_session(configuration: str, session: str) -> None:
 
     print()
 
+
 @main.command()
 @click.argument("host", type=str, nargs=1)
 def check_host(host):
-
     auths = [kDefaultAuth, kPublicKeyAuth, kKerberosAuth]
 
-    print('-'*80)
+    print("-" * 80)
     print(f"Testing SSH connection to '{host}' with {', '.join(auths)} authentications")
     print()
 
     results = {}
     for auth in auths:
-         
         results[auth] = test_host_connection(host, auth)
 
     print()

--- a/src/drunc/apps/__main_ssh_validator__.py
+++ b/src/drunc/apps/__main_ssh_validator__.py
@@ -7,11 +7,7 @@ from sh import Command
 
 from drunc.process_manager.oks_parser import collect_apps
 from drunc.process_manager.ssh_process_manager import on_parent_exit
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    log_levels,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, log_levels
 
 
 def validate_ssh_connection(configuration: str, session_name: str, log_level: str):

--- a/src/drunc/apps/__main_unified_shell__.py
+++ b/src/drunc/apps/__main_unified_shell__.py
@@ -1,10 +1,6 @@
 from drunc.unified_shell.context import UnifiedShellContext
 from drunc.unified_shell.shell import unified_shell
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    setup_root_logger,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, setup_root_logger
 
 
 def main():

--- a/src/drunc/broadcast/server/broadcast_sender.py
+++ b/src/drunc/broadcast/server/broadcast_sender.py
@@ -108,9 +108,11 @@ class BroadcastSender:
         from drunc.exceptions import DruncException
 
         self.broadcast(
-            btype=BroadcastType.DRUNC_EXCEPTION_RAISED
-            if isinstance(exception, DruncException)
-            else BroadcastType.UNHANDLED_EXCEPTION_RAISED,
+            btype=(
+                BroadcastType.DRUNC_EXCEPTION_RAISED
+                if isinstance(exception, DruncException)
+                else BroadcastType.UNHANDLED_EXCEPTION_RAISED
+            ),
             message=txt,
         )
 
@@ -133,9 +135,11 @@ class BroadcastSender:
         from drunc.exceptions import DruncException
 
         self.broadcast(
-            btype=BroadcastType.DRUNC_EXCEPTION_RAISED
-            if isinstance(exception, DruncException)
-            else BroadcastType.UNHANDLED_EXCEPTION_RAISED,
+            btype=(
+                BroadcastType.DRUNC_EXCEPTION_RAISED
+                if isinstance(exception, DruncException)
+                else BroadcastType.UNHANDLED_EXCEPTION_RAISED
+            ),
             message=txt,
         )
 

--- a/src/drunc/controller/children_interface/child_node.py
+++ b/src/drunc/controller/children_interface/child_node.py
@@ -102,9 +102,11 @@ class ChildNode:  # abc.ABC):
             type=descriptionType,
             name=descriptionName,
             endpoint=self.get_endpoint(),
-            info=get_detector_name(self.configuration)
-            if self.configuration is not None
-            else None,
+            info=(
+                get_detector_name(self.configuration)
+                if self.configuration is not None
+                else None
+            ),
             session=os.getenv("DUNEDAQ_SESSION"),
             commands=None,
             broadcast=None,

--- a/src/drunc/controller/children_interface/client_side_child.py
+++ b/src/drunc/controller/children_interface/client_side_child.py
@@ -103,9 +103,9 @@ class ClientSideChild(ChildNode):
     def get_status(self, token):
         status = Status(
             state=self.state.get_operational_state(),
-            sub_state="idle"
-            if not self.state.get_executing_command()
-            else "executing_cmd",
+            sub_state=(
+                "idle" if not self.state.get_executing_command() else "executing_cmd"
+            ),
             in_error=self.state.in_error() or not self.commander.ping(),  # meh
             included=self.state.included(),
         )

--- a/src/drunc/controller/children_interface/rest_api_child.py
+++ b/src/drunc/controller/children_interface/rest_api_child.py
@@ -267,12 +267,14 @@ class AppCommander:
                 data=json.dumps(cmd),
                 headers=headers,
                 timeout=1.0,
-                proxies={
-                    "http": f"socks5h://{self.response_host}:{self.response_port}",
-                    "https": f"socks5h://{self.response_host}:{self.response_port}",
-                }
-                if self.proxy_host
-                else None,
+                proxies=(
+                    {
+                        "http": f"socks5h://{self.response_host}:{self.response_port}",
+                        "https": f"socks5h://{self.response_host}:{self.response_port}",
+                    }
+                    if self.proxy_host
+                    else None
+                ),
             )
         except requests.ConnectionError:
             self.log.error(f"Connection error to {self.app_url}")
@@ -497,9 +499,11 @@ class RESTAPIChildNode(ClientSideChild):
             response_data = pack_to_any(PlainText(text=json.dumps(r)))
 
             fsm_data = FSMCommandResponse(
-                flag=FSMResponseFlag.FSM_EXECUTED_SUCCESSFULLY
-                if success
-                else FSMResponseFlag.FSM_FAILED,
+                flag=(
+                    FSMResponseFlag.FSM_EXECUTED_SUCCESSFULLY
+                    if success
+                    else FSMResponseFlag.FSM_FAILED
+                ),
                 command_name=data.command_name,
                 data=response_data,
             )

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -79,7 +79,7 @@ class ControllerConfHandler(ConfHandler):
                 + ".json"
             )
 
-        self.log.error("Initializing OpMon with configuration %s", self.opmon_conf)
+        self.log.debug("Initializing OpMon with configuration %s", self.opmon_conf)
         try:
             if self.opmon_conf.opmon_type == "stream":
                 self.log.debug("Attemtpting to initialize KafkaOpMonPublisher")

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -80,7 +80,9 @@ class ControllerConfHandler(ConfHandler):
                 )
             else:
                 self.log.debug("Attemtpting to initialize OpMonPublisher")
-                self.opmon_publisher = OpMonPublisher(self.opmon_conf)
+                self.opmon_publisher = OpMonPublisher(
+                    conf=self.opmon_conf, log_level=self.log.getEffectiveLevel()
+                )
                 self.log.debug(
                     "%s OpMonPublisher initialized with configuration %s",
                     self.opmon_conf.opmon_type,

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -3,7 +3,7 @@ import threading
 
 from kafkaopmon.OpMonPublisher import OpMonPublisher as KafkaOpMonPublisher
 from opmonlib.publisher import OpMonPublisher
-from opmonlib.utils import parse_publisher_conf
+from opmonlib.utils import parse_opmon_conf
 
 from drunc.controller.children_interface.child_node import ChildNode
 from drunc.controller.children_interface.rest_api_child import (
@@ -67,7 +67,7 @@ class ControllerConfHandler(ConfHandler):
         opmon_uri = self.session.opmon_uri
         opmon_conf = self.data.controller.opmon_conf
 
-        self.opmon_conf = parse_publisher_conf(self.log, opmon_conf, opmon_uri)
+        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
         self.log.debug("Initializing OpMon with configuration %s", self.opmon_conf)
 
         try:

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -75,7 +75,7 @@ class ControllerConfHandler(ConfHandler):
         if self.opmon_conf.path == "./info.json":
             self.opmon_conf.path = (
                 "./info."
-                + self.oks_key.session
+                + self.opmon_conf.session
                 + "."
                 + self.data.controller.id
                 + ".json"

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -3,7 +3,7 @@ import threading
 
 from kafkaopmon.OpMonPublisher import OpMonPublisher as KafkaOpMonPublisher
 from opmonlib.publisher import OpMonPublisher
-from opmonlib.utils import parse_opmon_conf
+from opmonlib.utils import parse_publisher_conf
 
 from drunc.controller.children_interface.child_node import ChildNode
 from drunc.controller.children_interface.rest_api_child import (
@@ -67,7 +67,7 @@ class ControllerConfHandler(ConfHandler):
         opmon_uri = self.session.opmon_uri
         opmon_conf = self.data.controller.opmon_conf
 
-        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
+        self.opmon_conf = parse_publisher_conf(self.log, opmon_conf, opmon_uri)
         self.log.debug("Initializing OpMon with configuration %s", self.opmon_conf)
 
         try:

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -1,7 +1,9 @@
 import socket
 import threading
 
-from kafkaopmon.OpMonPublisher import OpMonPublisher
+from kafkaopmon.OpMonPublisher import OpMonPublisher as KafkaOpMonPublisher
+from opmonlib.publisher import OpMonPublisher
+from opmonlib.utils import parse_opmon_conf
 
 from drunc.controller.children_interface.child_node import ChildNode
 from drunc.controller.children_interface.rest_api_child import (
@@ -65,59 +67,30 @@ class ControllerConfHandler(ConfHandler):
         opmon_uri = self.session.opmon_uri
         opmon_conf = self.data.controller.opmon_conf
 
-        if not opmon_uri:
-            self.log.info("Missing 'opmon_uri' in configuration.")
-            return
-
-        if not opmon_conf:
-            self.log.info("Missing 'opmon_conf' in configuration.")
-            return
-
-        opmon_path = getattr(opmon_uri, "path", "")
-        opmon_type = getattr(opmon_uri, "type", "")
-        self.interval_s = getattr(opmon_conf, "interval_s", 0.0)
-
-        if not opmon_path or not opmon_type:
-            self.log.error("Invalid 'opmon_uri' format: Missing required fields.")
-            raise DruncCommandException(
-                "Invalid 'opmon_uri' format: Missing required fields."
-            )
-        if not self.interval_s:
-            self.log.warning(
-                "Missing 'interval_s' in 'opmon_conf', set to default interval_s = 10s"
-            )
-            self.interval_s = 10.0
-
+        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
         self.log.debug(
-            f"OpMon path {opmon_path} and type {opmon_type} is enabled, sleep time: {self.interval_s} s"
+            "Initializing %s OpMon with configuration %s", self.name, self.opmon_conf
         )
 
-        if "/" in opmon_path:
-            opmon_bootstrap, opmon_topic = opmon_path.split("/", 1)
-        else:
-            opmon_bootstrap = opmon_path
-            opmon_topic = "opmon_stream"
-
-        if opmon_type == "stream":
-            try:
-                self.opmon_publisher = OpMonPublisher(
-                    default_topic=opmon_topic, bootstrap=opmon_bootstrap
+        try:
+            if self.opmon_conf.opmon_type == "stream":
+                self.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)
+                self.log.debug(
+                    "KafkaOpMonPublisher initialized with configuration %s",
+                    self.opmon_conf,
                 )
-                self.log.info(
-                    f"OpMonPublisher initialized: {opmon_bootstrap}/{opmon_topic}"
+            else:
+                self.opmon_publisher = OpMonPublisher(self.opmon_conf)
+                self.log.debug(
+                    "%s OpMonPublisher initialized with configuration %s",
+                    self.opmon_conf.opmon_type,
+                    self.opmon_conf,
                 )
 
-            except Exception as e:
-                self.log.error(f"Failed to initialize OpMonPublisher: {e}")
-                raise DruncCommandException("Failed to initialize OpMonPublisher.")
-
-        elif opmon_type == "file":
-            self.log.info("OpMon type is file, no publisher is initialized")
-            pass
-
-        else:
-            self.log.error(f"Unsupported OpMon type: {opmon_type}")
-            raise DruncCommandException(f"Unsupported OpMon type: {opmon_type}")
+        except Exception as e:
+            self.log.error("Failed to initialize OpMonPublisher: %s", e)
+            raise DruncCommandException("Failed to initialize OpMonPublisher.")
+        return
 
     def get_dummy_children(self):
         ret = []

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -68,18 +68,18 @@ class ControllerConfHandler(ConfHandler):
         opmon_conf = self.data.controller.opmon_conf
 
         self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
-        self.log.debug(
-            "Initializing %s OpMon with configuration %s", self.name, self.opmon_conf
-        )
+        self.log.debug("Initializing OpMon with configuration %s", self.opmon_conf)
 
         try:
             if self.opmon_conf.opmon_type == "stream":
+                self.log.debug("Attemtpting to initialize KafkaOpMonPublisher")
                 self.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)
                 self.log.debug(
                     "KafkaOpMonPublisher initialized with configuration %s",
                     self.opmon_conf,
                 )
             else:
+                self.log.debug("Attemtpting to initialize OpMonPublisher")
                 self.opmon_publisher = OpMonPublisher(self.opmon_conf)
                 self.log.debug(
                     "%s OpMonPublisher initialized with configuration %s",

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -69,7 +69,7 @@ class ControllerConfHandler(ConfHandler):
             conf=self.data.controller.opmon_conf,
             uri=self.session.opmon_uri,
             session=self.session_name,
-            application=self.data.controller.id
+            application=self.data.controller.id,
         )
 
         if self.opmon_conf.path == "./info.json":
@@ -82,6 +82,7 @@ class ControllerConfHandler(ConfHandler):
             )
 
         self.log.debug("Initializing OpMon with configuration %s", self.opmon_conf)
+
         try:
             if self.opmon_conf.opmon_type == "stream":
                 self.log.debug("Attemtpting to initialize KafkaOpMonPublisher")

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -68,6 +68,8 @@ class ControllerConfHandler(ConfHandler):
             log=self.log,
             conf=self.data.controller.opmon_conf,
             uri=self.session.opmon_uri,
+            session=self.session.id,
+            application=self.data.controller.id
         )
 
         if self.opmon_conf.path == "./info.json":

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -54,7 +54,7 @@ class ControllerConfHandler(ConfHandler):
             )
         return this_segment
 
-    def _post_process_oks(self):
+    def _post_process_oks(self, *args, **kwargs):
         self.authoriser = None
         self.children = []
         self.data = self._grab_segment_conf_from_controller(self.data)
@@ -68,7 +68,7 @@ class ControllerConfHandler(ConfHandler):
             log=self.log,
             conf=self.data.controller.opmon_conf,
             uri=self.session.opmon_uri,
-            session=self.session.id,
+            session=self.session_name,
             application=self.data.controller.id
         )
 

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -4,16 +4,15 @@ import threading
 from kafkaopmon.OpMonPublisher import OpMonPublisher
 
 from drunc.controller.children_interface.child_node import ChildNode
-from drunc.exceptions import DruncCommandException, DruncSetupException
-from drunc.process_manager.configuration import get_commandline_parameters
-from drunc.utils.configuration import ConfHandler
-from drunc.utils.utils import ControlType
-
-import confmodel  # isort: skip
 from drunc.controller.children_interface.rest_api_child import (
     RESTAPIChildNodeConfHandler,
 )
-from drunc.utils.configuration import ConfTypes
+from drunc.exceptions import DruncCommandException, DruncSetupException
+from drunc.process_manager.configuration import get_commandline_parameters
+from drunc.utils.configuration import ConfHandler, ConfTypes
+from drunc.utils.utils import ControlType
+
+import confmodel  # isort: skip
 
 
 class ControllerConfData:  # the bastardised OKS

--- a/src/drunc/controller/configuration.py
+++ b/src/drunc/controller/configuration.py
@@ -64,12 +64,22 @@ class ControllerConfHandler(ConfHandler):
             self.this_host = socket.gethostname()
 
         self.opmon_publisher = None
-        opmon_uri = self.session.opmon_uri
-        opmon_conf = self.data.controller.opmon_conf
+        self.opmon_conf = parse_opmon_conf(
+            log=self.log,
+            conf=self.data.controller.opmon_conf,
+            uri=self.session.opmon_uri,
+        )
 
-        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
-        self.log.debug("Initializing OpMon with configuration %s", self.opmon_conf)
+        if self.opmon_conf.path == "./info.json":
+            self.opmon_conf.path = (
+                "./info."
+                + self.oks_key.session
+                + "."
+                + self.data.controller.id
+                + ".json"
+            )
 
+        self.log.error("Initializing OpMon with configuration %s", self.opmon_conf)
         try:
             if self.opmon_conf.opmon_type == "stream":
                 self.log.debug("Attemtpting to initialize KafkaOpMonPublisher")
@@ -84,9 +94,7 @@ class ControllerConfHandler(ConfHandler):
                     conf=self.opmon_conf, log_level=self.log.getEffectiveLevel()
                 )
                 self.log.debug(
-                    "%s OpMonPublisher initialized with configuration %s",
-                    self.opmon_conf.opmon_type,
-                    self.opmon_conf,
+                    "OpMonPublisher initialized with configuration %s", self.opmon_conf
                 )
 
         except Exception as e:

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -283,8 +283,6 @@ class Controller(ControllerServicer):
                     custom_origin = {}
 
                 self.opmon_publisher.publish(
-                    session=self.session,
-                    application=self.name,
                     message=message,
                     custom_origin=custom_origin,
                 )

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -16,11 +16,7 @@ from druncschema.controller_pb2 import (
 from druncschema.controller_pb2_grpc import ControllerServicer
 from druncschema.generic_pb2 import PlainText, Stacktrace
 from druncschema.opmon.generic_pb2 import RunInfo
-from druncschema.request_response_pb2 import (
-    Description,
-    Response,
-    ResponseFlag,
-)
+from druncschema.request_response_pb2 import Description, Response, ResponseFlag
 from druncschema.token_pb2 import Token
 from google.protobuf.any_pb2 import Any
 
@@ -39,18 +35,11 @@ from drunc.controller.decorators import (
 )
 from drunc.controller.exceptions import CannotSurrenderControl
 from drunc.controller.stateful_node import CannotExclude, CannotInclude, StatefulNode
-from drunc.controller.utils import (
-    get_detector_name,
-    get_status_message,
-)
+from drunc.controller.utils import get_detector_name, get_status_message
 from drunc.exceptions import DruncException
 from drunc.fsm.configuration import FSMConfHandler
 from drunc.fsm.utils import convert_fsm_transition
-from drunc.utils.grpc_utils import (
-    UnpackingError,
-    pack_to_any,
-    unpack_any,
-)
+from drunc.utils.grpc_utils import UnpackingError, pack_to_any, unpack_any
 from drunc.utils.utils import get_logger
 
 

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -2,7 +2,7 @@ import multiprocessing
 import threading
 import time
 import traceback
-from typing import Optional, List
+from typing import List, Optional
 
 from druncschema.authoriser_pb2 import ActionType, SystemType
 from druncschema.broadcast_pb2 import BroadcastType
@@ -27,8 +27,8 @@ from drunc.broadcast.server.broadcast_sender import BroadcastSender
 from drunc.broadcast.server.configuration import BroadcastSenderConfHandler
 from drunc.broadcast.server.decorators import broadcasted
 from drunc.connectivity_service.client import ConnectivityServiceClient
-from drunc.controller.children_interface.rest_api_child import ResponseListener
 from drunc.controller.children_interface.child_node import ChildNode
+from drunc.controller.children_interface.rest_api_child import ResponseListener
 from drunc.controller.decorators import (
     in_control,
     publish_command_time,
@@ -173,14 +173,14 @@ class Controller(ControllerServicer):
             connectivity_service=self.connectivity_service,
             session_name=self.session,
         )
-        # At this point, we already waited for 60s for the children applications to 
+        # At this point, we already waited for 60s for the children applications to
         # start and show up on the connectivity service
         # We now wait for each application to get from "initialising" to "ready"
-        # Unfortunately, if an application crashed on boot and never made it to the 
+        # Unfortunately, if an application crashed on boot and never made it to the
         # connectivity service,
-        # its parent controller will only notice it after 60s, so we need to wait for a 
+        # its parent controller will only notice it after 60s, so we need to wait for a
         # _bit more_ than 60s for that controller to come out of initialising state.
-        # Let's assume that parent controller takes 10s to get from initialising to 
+        # Let's assume that parent controller takes 10s to get from initialising to
         # ready, in error state.
         timeout = 60 + 10
 

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -35,7 +35,11 @@ from drunc.controller.decorators import (
 )
 from drunc.controller.exceptions import CannotSurrenderControl
 from drunc.controller.stateful_node import CannotExclude, CannotInclude, StatefulNode
-from drunc.controller.utils import get_detector_name, get_status_message
+from drunc.controller.utils import (
+    ControllerMonitoringMetrics,
+    get_detector_name,
+    get_status_message,
+)
 from drunc.exceptions import DruncException
 from drunc.fsm.configuration import FSMConfHandler
 from drunc.fsm.utils import convert_fsm_transition
@@ -97,13 +101,14 @@ class Controller(ControllerServicer):
         self.name = name
         self.session = session
         self.broadcast_service = None
-        self.runinfo = {}
+        self.monitoring_metrics = ControllerMonitoringMetrics()
 
         self.log = get_logger("controller")
         log_init = get_logger("controller.__init__")
         log_init.info(f"Initialising controller '{name}' with session '{session}'")
 
         self.configuration = configuration
+        self.runinfo = {}
         self.runinfo["Configuration"] = self.configuration.initial_data.removeprefix(
             "oksconflibs:"
         )
@@ -283,48 +288,53 @@ class Controller(ControllerServicer):
                 self.log.error(f"Failed to publish to OpMon: {e}")
 
     def threading_publish_state(self, interval_s: float = 10.0):
+        run_time_at_start = 0
         while not self.stop_event.is_set():
             try:
                 self.log.debug(f"Publishing periodic FSM status every {interval_s}s")
                 self.stateful_node.publish_state()
                 current_state = self.stateful_node.get_node_operational_state()
 
-                if current_state in ("initial", "configured"):
-                    run_type = ""
-                    trigger_rate = 0.0
-                    run_number = 0
-                    disable_data_storage = False
-                    run_time_at_start = 0
-                    run_time_since_start = 0
-                    self.runinfo = {}
+                if current_state in ("none", "initial", "configured"):
+                    self.monitoring_metrics = ControllerMonitoringMetrics()
 
                 if self.runinfo and self.runinfo.get("run", None) is not None:
-                    run_type = self.runinfo.get("production_vs_test", "")
-                    run_number = self.runinfo.get("run", 0)
-                    disable_data_storage = self.runinfo.get(
+                    self.monitoring_metrics.run_type = self.runinfo.get(
+                        "production_vs_test", ""
+                    )
+                    self.monitoring_metrics.run_number = self.runinfo.get("run", 0)
+                    self.monitoring_metrics.disable_data_storage = self.runinfo.get(
                         "disable_data_storage", False
                     )
-                    trigger_rate = self.runinfo.get("trigger_rate", 0.0)
-                    run_time_at_start = self.runinfo.get("run_time_at_start", 0)
+                    self.monitoring_metrics.trigger_rate = self.runinfo.get(
+                        "trigger_rate", 0.0
+                    )
+                    self.monitoring_metrics.run_time_at_start = self.runinfo.get(
+                        "run_time_at_start", 0
+                    )
 
                 if run_time_at_start:
-                    run_time_since_start = int(time.time() - run_time_at_start)
+                    self.monitoring_metrics.run_time_since_start = int(
+                        time.time() - run_time_at_start
+                    )
 
                 self.log.debug(f"Publishing periodic run info every {interval_s}s")
                 self.controller_publisher(
                     message=RunInfo(
-                        run_type=run_type,
-                        trigger_rate=trigger_rate,
-                        run_number=run_number,
-                        disable_data_storage=disable_data_storage,
-                        run_time_at_start=int(run_time_at_start),
-                        run_time_since_start=run_time_since_start,
+                        run_type=self.monitoring_metrics.run_type,
+                        trigger_rate=self.monitoring_metrics.trigger_rate,
+                        run_number=self.monitoring_metrics.run_number,
+                        disable_data_storage=self.monitoring_metrics.disable_data_storage,
+                        run_time_at_start=int(
+                            self.monitoring_metrics.run_time_at_start
+                        ),
+                        run_time_since_start=self.monitoring_metrics.run_time_since_start,
                         run_config_file=self.configuration.oks_path,
                         run_config_name=self.configuration.oks_key.session,
                     )
                 )
             except Exception as e:
-                self.log.warning(f"Error while publishing periodic status: {e}")
+                self.log.exception(f"Error while publishing periodic status: {e}")
             time.sleep(interval_s)
 
     def construct_error_node_response(

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -2,7 +2,7 @@ import multiprocessing
 import threading
 import time
 import traceback
-from typing import Optional
+from typing import Optional, List
 
 from druncschema.authoriser_pb2 import ActionType, SystemType
 from druncschema.broadcast_pb2 import BroadcastType
@@ -28,6 +28,7 @@ from drunc.broadcast.server.configuration import BroadcastSenderConfHandler
 from drunc.broadcast.server.decorators import broadcasted
 from drunc.connectivity_service.client import ConnectivityServiceClient
 from drunc.controller.children_interface.rest_api_child import ResponseListener
+from drunc.controller.children_interface.child_node import ChildNode
 from drunc.controller.decorators import (
     in_control,
     publish_command_time,
@@ -93,7 +94,7 @@ class ControllerActor:
 
 
 class Controller(ControllerServicer):
-    children_nodes = []  # type: List[ChildNode]
+    children_nodes: List[ChildNode] = []
 
     def __init__(self, configuration, name: str, session: str, token: Token):
         super().__init__()
@@ -172,11 +173,15 @@ class Controller(ControllerServicer):
             connectivity_service=self.connectivity_service,
             session_name=self.session,
         )
-        # At this point, we already waited for 60s for the children applications to start and show up on the connectivity service
+        # At this point, we already waited for 60s for the children applications to 
+        # start and show up on the connectivity service
         # We now wait for each application to get from "initialising" to "ready"
-        # Unfortunately, if an application crashed on boot and never made it to the connectivity service,
-        # its parent controller will only notice it after 60s, so we need to wait for a _bit more_ than 60s for that controller to come out of initialising state.
-        # Let's assume that parent controller takes 10s to get from initialising to ready, in error state.
+        # Unfortunately, if an application crashed on boot and never made it to the 
+        # connectivity service,
+        # its parent controller will only notice it after 60s, so we need to wait for a 
+        # _bit more_ than 60s for that controller to come out of initialising state.
+        # Let's assume that parent controller takes 10s to get from initialising to 
+        # ready, in error state.
         timeout = 60 + 10
 
         time_start = time.time()
@@ -271,7 +276,7 @@ class Controller(ControllerServicer):
     def async_interrupt_with_exception(self, *args, **kwargs):
         return self.broadcast_service._async_interrupt_with_exception(*args, **kwargs)
 
-    def controller_publisher(self, message, custom_origin: Optional[dict] = None):
+    def controller_publisher(self, message, custom_origin: dict | None = None):
         if self.opmon_publisher is not None:
             try:
                 if custom_origin is None:

--- a/src/drunc/controller/interface/controller.py
+++ b/src/drunc/controller/interface/controller.py
@@ -94,6 +94,7 @@ def controller_cli(
             obj_uid=name,
             session=configurationid,  # some of the function for enable/disable require the full dal of the session
         ),
+        session_name=sessionname
     )
 
     commandfacility = resolve_localhost_and_127_ip_to_network_ip(commandfacility)

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -88,9 +88,11 @@ def match_children(statuses: list, descriptions: list) -> defaultdict:
 
 def get_status_table(status: DecodedResponse, description: DecodedResponse):
     t = Table(
-        title=f"[dark_green]{description.data.session}[/dark_green] status"
-        if description.data
-        else "[dark_green]status[/dark_green]"
+        title=(
+            f"[dark_green]{description.data.session}[/dark_green] status"
+            if description.data
+            else "[dark_green]status[/dark_green]"
+        )
     )
     t.add_column("Name")
     t.add_column("Info")
@@ -113,9 +115,11 @@ def get_status_table(status: DecodedResponse, description: DecodedResponse):
             description.data.info if valid_description else NA,
             status.data.state if valid_status else NA,
             status.data.sub_state if valid_status else NA,
-            format_bool(status.data.in_error, false_is_good=True)
-            if valid_status
-            else NA,
+            (
+                format_bool(status.data.in_error, false_is_good=True)
+                if valid_status
+                else NA
+            ),
             format_bool(status.data.included) if valid_status else NA,
             description.data.endpoint if valid_description else NA,
         )
@@ -577,9 +581,11 @@ def run_one_fsm_command(
         table.add_row(
             prefix + response.name,
             bool_to_success(response.flag, message_type=ResponseFlag),
-            bool_to_success(response.data.flag, message_type=FSMResponseFlag)
-            if executed_command
-            else "[red]NA[/]",
+            (
+                bool_to_success(response.data.flag, message_type=FSMResponseFlag)
+                if executed_command
+                else "[red]NA[/]"
+            ),
         )
         for child_response in response.children:
             add_to_table(table, child_response, "  " + prefix)

--- a/src/drunc/controller/utils.py
+++ b/src/drunc/controller/utils.py
@@ -1,5 +1,6 @@
 import re
 import time
+from dataclasses import dataclass
 
 import grpc
 from google.protobuf import any_pb2
@@ -218,3 +219,15 @@ def address_command(
     if ret == {}:
         log.info(f"Target '{target}' not found in children of '{obj.name}'")
     return ret
+
+
+@dataclass
+class ControllerMonitoringMetrics:
+    """Store the metrics that the OpMon Controller publishes"""
+
+    run_type: str = ""
+    trigger_rate: float = 0.0
+    run_number: int = 0
+    disable_data_storage: bool = False
+    run_time_at_start: int = 0
+    run_time_since_start: int = 0

--- a/src/drunc/data/process_manager/ssh-CERN-kafka.json
+++ b/src/drunc/data/process_manager/ssh-CERN-kafka.json
@@ -21,7 +21,7 @@
         "type": "stream"
     },
     "opmon_conf":{
-        "level": "info",
+        "level": "debug",
         "interval_s" : 10.0
     }
 

--- a/src/drunc/data/process_manager/ssh-CERN-kafka.json
+++ b/src/drunc/data/process_manager/ssh-CERN-kafka.json
@@ -21,6 +21,7 @@
         "type": "stream"
     },
     "opmon_conf":{
+        "level": "info",
         "interval_s" : 10.0
     }
 

--- a/src/drunc/data/process_manager/ssh-standalone.json
+++ b/src/drunc/data/process_manager/ssh-standalone.json
@@ -18,7 +18,7 @@
         "type": "file"
     },
     "opmon_conf":{
-        "level": "info",
+        "level": "debug",
         "interval_s" : 10.0
     }
 }

--- a/src/drunc/data/process_manager/ssh-standalone.json
+++ b/src/drunc/data/process_manager/ssh-standalone.json
@@ -12,5 +12,13 @@
     },
     "environment": {
         "GRPC_ENABLE_FORK_SUPPORT": "false"
+    },
+    "opmon_uri": {
+        "path": "./info.json",
+        "type": "file"
+    },
+    "opmon_conf":{
+        "level": "info",
+        "interval_s" : 10.0
     }
 }

--- a/src/drunc/data/process_manager/ssh-standalone.json
+++ b/src/drunc/data/process_manager/ssh-standalone.json
@@ -18,7 +18,7 @@
         "type": "file"
     },
     "opmon_conf":{
-        "level": "debug",
+        "level": "info",
         "interval_s" : 10.0
     }
 }

--- a/src/drunc/fsm/actions/usvc_provided_run_number.py
+++ b/src/drunc/fsm/actions/usvc_provided_run_number.py
@@ -3,10 +3,7 @@ from typing import Optional
 
 import requests
 
-from drunc.fsm.actions.utils import (
-    get_dotdrunc_json,
-    validate_run_type,
-)
+from drunc.fsm.actions.utils import get_dotdrunc_json, validate_run_type
 from drunc.fsm.core import FSMAction
 from drunc.fsm.exceptions import CannotGetRunNumber, DotDruncJsonIncorrectFormat
 from drunc.utils.utils import get_logger

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -4,6 +4,7 @@ from importlib.resources import path
 from urllib.parse import urlparse
 
 from kafkaopmon.OpMonPublisher import KafkaOpMonPublisher
+from opmonlib.publisher import OpMonPublisher
 from opmonlib.utils import parse_opmon_conf
 
 from drunc.broadcast.server.configuration import KafkaBroadcastSenderConfData
@@ -69,21 +70,24 @@ class ProcessManagerConfHandler(ConfHandler):
             "OpMon configuration parsed with configuration %s", self.opmon_conf
         )
 
-        if self.opmon_conf.type == "stream":
-            try:
+        try:
+            if self.opmon_conf.type == "stream":
                 new_data.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)
                 self.log.info(
-                    "OpMonPublisher initialized with configuration %s", self.opmon_conf
+                    "KafkaOpMonPublisher initialized with configuration %s",
+                    self.opmon_conf,
+                )
+            else:
+                new_data.opmon_publisher = OpMonPublisher(self.opmon_conf)
+                self.log.info(
+                    "%s OpMonPublisher initialized with configuration %s",
+                    self.opmon_conf.type,
+                    self.opmon_conf,
                 )
 
-            except Exception as e:
-                self.log.error("Failed to initialize OpMonPublisher: %s", e)
-                raise DruncCommandException("Failed to initialize OpMonPublisher.")
-        else:
-            self.log.error("Unsupported OpMon type: %s", self.opmon_conf.type)
-            raise DruncCommandException(
-                "Unsupported OpMon type: %s", self.opmon_conf.type
-            )
+        except Exception as e:
+            self.log.error("Failed to initialize OpMonPublisher: %s", e)
+            raise DruncCommandException("Failed to initialize OpMonPublisher.")
 
         return new_data
 

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -3,7 +3,7 @@ from enum import Enum
 from importlib.resources import path
 from urllib.parse import urlparse
 
-from kafkaopmon.OpMonPublisher import KafkaOpMonPublisher
+from kafkaopmon.OpMonPublisher import OpMonPublisher as KafkaOpMonPublisher
 from opmonlib.publisher import OpMonPublisher
 from opmonlib.utils import parse_opmon_conf
 
@@ -66,22 +66,22 @@ class ProcessManagerConfHandler(ConfHandler):
 
         self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
 
-        self.log.info(
-            "OpMon configuration parsed with configuration %s", self.opmon_conf
+        self.log.debug(
+            "Initializing process manager OpMon with configuration %s", self.opmon_conf
         )
 
         try:
-            if self.opmon_conf.type == "stream":
+            if self.opmon_conf.opmon_type == "stream":
                 new_data.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)
-                self.log.info(
+                self.log.debug(
                     "KafkaOpMonPublisher initialized with configuration %s",
                     self.opmon_conf,
                 )
             else:
                 new_data.opmon_publisher = OpMonPublisher(self.opmon_conf)
-                self.log.info(
+                self.log.debug(
                     "%s OpMonPublisher initialized with configuration %s",
-                    self.opmon_conf.type,
+                    self.opmon_conf.opmon_type,
                     self.opmon_conf,
                 )
 

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -61,17 +61,20 @@ class ProcessManagerConfHandler(ConfHandler):
                 raise UnknownProcessManagerType(data["type"])
 
         new_data.opmon_publisher = None
-        opmon_uri = data.get("opmon_uri", None)
-        opmon_conf = data.get("opmon_conf", None)
-
-        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
+        self.opmon_conf = parse_opmon_conf(
+            log=self.log,
+            conf=data.get("opmon_conf", None),
+            uri=data.get("opmon_uri", None),
+        )
 
         if self.opmon_conf.path == "./info.json":
             self.opmon_conf.path = "./info." + data["name"] + ".json"
 
-        self.log.debug(
+        self.log.error(
             "Initializing process manager OpMon with configuration %s", self.opmon_conf
         )
+        self.log.error(f"{data=}")
+        self.log.error(f"{self.__dict__}")
         try:
             if self.opmon_conf.opmon_type == "stream":
                 new_data.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from kafkaopmon.OpMonPublisher import OpMonPublisher as KafkaOpMonPublisher
 from opmonlib.publisher import OpMonPublisher
-from opmonlib.utils import parse_opmon_conf
+from opmonlib.utils import parse_publisher_conf
 
 from drunc.broadcast.server.configuration import KafkaBroadcastSenderConfData
 from drunc.exceptions import DruncCommandException
@@ -64,7 +64,7 @@ class ProcessManagerConfHandler(ConfHandler):
         opmon_uri = data.get("opmon_uri", None)
         opmon_conf = data.get("opmon_conf", None)
 
-        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
+        self.opmon_conf = parse_publisher_conf(self.log, opmon_conf, opmon_uri)
 
         if self.opmon_conf.path == "./info.json":
             self.opmon_conf.path = "./info." + data["name"] + ".json"

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -70,11 +70,9 @@ class ProcessManagerConfHandler(ConfHandler):
         if self.opmon_conf.path == "./info.json":
             self.opmon_conf.path = "./info." + data["name"] + ".json"
 
-        self.log.error(
+        self.log.debug(
             "Initializing process manager OpMon with configuration %s", self.opmon_conf
         )
-        self.log.error(f"{data=}")
-        self.log.error(f"{self.__dict__}")
         try:
             if self.opmon_conf.opmon_type == "stream":
                 new_data.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -65,6 +65,8 @@ class ProcessManagerConfHandler(ConfHandler):
             log=self.log,
             conf=data.get("opmon_conf", None),
             uri=data.get("opmon_uri", None),
+            session=new_data.type.name,
+            application="process_manager"
         )
 
         if self.opmon_conf.path == "./info.json":

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -3,7 +3,8 @@ from enum import Enum
 from importlib.resources import path
 from urllib.parse import urlparse
 
-from kafkaopmon.OpMonPublisher import OpMonPublisher
+from kafkaopmon.OpMonPublisher import KafkaOpMonPublisher
+from opmonlib.utils import parse_opmon_conf
 
 from drunc.broadcast.server.configuration import KafkaBroadcastSenderConfData
 from drunc.exceptions import DruncCommandException
@@ -62,54 +63,27 @@ class ProcessManagerConfHandler(ConfHandler):
         opmon_uri = data.get("opmon_uri", None)
         opmon_conf = data.get("opmon_conf", None)
 
-        if not opmon_uri:
-            self.log.info("Missing 'opmon_uri' in configuration.")
-            return new_data
-
-        if not opmon_conf:
-            self.log.info("Missing 'opmon_conf' in configuration.")
-            return new_data
-
-        opmon_path = opmon_uri.get("path", "")
-        opmon_type = opmon_uri.get("type", "")
-        new_data.interval_s = opmon_conf.get("interval_s", 0.0)
-
-        if not opmon_path or not opmon_type:
-            self.log.error("Invalid 'opmon_uri' format: Missing required fields.")
-            raise DruncCommandException(
-                "Invalid 'opmon_uri' format: Missing required fields."
-            )
-        if not new_data.interval_s:
-            self.log.warning(
-                "Missing 'interval_s' in 'opmon_conf', set to default interval_s = 10s"
-            )
-            new_data.interval_s = 10.0
+        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
 
         self.log.info(
-            f"OpMon path {opmon_path} and type {opmon_type} is enabled, sleep time: {new_data.interval_s} s"
+            "OpMon configuration parsed with configuration %s", self.opmon_conf
         )
 
-        if "/" in opmon_path:
-            opmon_bootstrap, opmon_topic = opmon_path.split("/", 1)
-        else:
-            opmon_bootstrap = opmon_path
-            opmon_topic = "opmon_stream"
-
-        if opmon_type == "stream":
+        if self.opmon_conf.type == "stream":
             try:
-                new_data.opmon_publisher = OpMonPublisher(
-                    default_topic=opmon_topic, bootstrap=opmon_bootstrap
-                )
+                new_data.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)
                 self.log.info(
-                    f"OpMonPublisher initialized: {opmon_bootstrap}/{opmon_topic}"
+                    "OpMonPublisher initialized with configuration %s", self.opmon_conf
                 )
 
             except Exception as e:
-                self.log.error(f"Failed to initialize OpMonPublisher: {e}")
+                self.log.error("Failed to initialize OpMonPublisher: %s", e)
                 raise DruncCommandException("Failed to initialize OpMonPublisher.")
         else:
-            self.log.error(f"Unsupported OpMon type: {opmon_type}")
-            raise DruncCommandException(f"Unsupported OpMon type: {opmon_type}")
+            self.log.error("Unsupported OpMon type: %s", self.opmon_conf.type)
+            raise DruncCommandException(
+                "Unsupported OpMon type: %s", self.opmon_conf.type
+            )
 
         return new_data
 

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -66,10 +66,12 @@ class ProcessManagerConfHandler(ConfHandler):
 
         self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
 
+        if self.opmon_conf.path == "./info.json":
+            self.opmon_conf.path = "./info." + data["name"] + ".json"
+
         self.log.debug(
             "Initializing process manager OpMon with configuration %s", self.opmon_conf
         )
-
         try:
             if self.opmon_conf.opmon_type == "stream":
                 new_data.opmon_publisher = KafkaOpMonPublisher(self.opmon_conf)
@@ -78,7 +80,9 @@ class ProcessManagerConfHandler(ConfHandler):
                     self.opmon_conf,
                 )
             else:
-                new_data.opmon_publisher = OpMonPublisher(self.opmon_conf)
+                new_data.opmon_publisher = OpMonPublisher(
+                    conf=self.opmon_conf, rich_handler=True
+                )
                 self.log.debug(
                     "%s OpMonPublisher initialized with configuration %s",
                     self.opmon_conf.opmon_type,

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -66,11 +66,17 @@ class ProcessManagerConfHandler(ConfHandler):
             conf=data.get("opmon_conf", None),
             uri=data.get("opmon_uri", None),
             session=new_data.type.name,
-            application="process_manager"
+            application="process_manager",
         )
 
         if self.opmon_conf.path == "./info.json":
-            self.opmon_conf.path = "./info." + data["name"] + ".json"
+            self.opmon_conf.path = (
+                "./info."
+                + self.opmon_conf.session
+                + "."
+                + self.opmon_conf.application
+                + ".json"
+            )
 
         self.log.debug(
             "Initializing process manager OpMon with configuration %s", self.opmon_conf

--- a/src/drunc/process_manager/configuration.py
+++ b/src/drunc/process_manager/configuration.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from kafkaopmon.OpMonPublisher import OpMonPublisher as KafkaOpMonPublisher
 from opmonlib.publisher import OpMonPublisher
-from opmonlib.utils import parse_publisher_conf
+from opmonlib.utils import parse_opmon_conf
 
 from drunc.broadcast.server.configuration import KafkaBroadcastSenderConfData
 from drunc.exceptions import DruncCommandException
@@ -64,7 +64,7 @@ class ProcessManagerConfHandler(ConfHandler):
         opmon_uri = data.get("opmon_uri", None)
         opmon_conf = data.get("opmon_conf", None)
 
-        self.opmon_conf = parse_publisher_conf(self.log, opmon_conf, opmon_uri)
+        self.opmon_conf = parse_opmon_conf(self.log, opmon_conf, opmon_uri)
 
         if self.opmon_conf.path == "./info.json":
             self.opmon_conf.path = "./info." + data["name"] + ".json"

--- a/src/drunc/process_manager/interface/process_manager.py
+++ b/src/drunc/process_manager/interface/process_manager.py
@@ -12,7 +12,7 @@ from drunc.process_manager.configuration import (
     get_process_manager_configuration,
 )
 from drunc.process_manager.process_manager import ProcessManager
-from drunc.process_manager.utils import get_log_path, get_pm_conf_name_from_dir
+from drunc.process_manager.utils import get_log_path
 from drunc.utils.configuration import parse_conf_url
 from drunc.utils.utils import (
     create_logger_handler,
@@ -37,22 +37,7 @@ def run_pm(
     generated_port: bool = None,
 ) -> None:
     appName = "process_manager"
-    pmConfFileName = get_pm_conf_name_from_dir(
-        pm_conf
-    )  # Treating the pm conf data filename as the session
-
-    log_path = get_log_path(
-        user=getpass.getuser(),
-        session_name=pmConfFileName,
-        application_name=appName,
-        override_logs=override_logs,
-        app_log_path=log_path,
-    )
     log = get_logger(logger_name=appName)
-    create_logger_handler(
-        log_file_path=log_path,
-        rich_handler=True,
-    )
 
     log.debug("Running [green]run_pm[/green]")
     if signal_handler is not None:
@@ -65,6 +50,18 @@ def run_pm(
     conf_path, conf_type = parse_conf_url(pm_conf)
     pmch = ProcessManagerConfHandler(
         log_path=log_path, type=conf_type, data=conf_path.split(":")[1]
+    )
+
+    log_path = get_log_path(
+        user=getpass.getuser(),
+        session_name=pmch.data.type.name,
+        application_name=appName,
+        override_logs=override_logs,
+        app_log_path=log_path,
+    )
+    create_logger_handler(
+        log_file_path=log_path,
+        rich_handler=True,
     )
 
     for key, value in pmch.data.environment.items():

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -210,25 +210,27 @@ class K8sProcessManager(ProcessManager):
                     self._volume("cvmfs", "/cvmfs/"),
                 ],
                 # HACK
-                affinity=self._k8s_client.V1Affinity(
-                    self._k8s_client.V1NodeAffinity(
-                        required_during_scheduling_ignored_during_execution=self._k8s_client.V1NodeSelector(
-                            node_selector_terms=[
-                                self._k8s_client.V1NodeSelectorTerm(
-                                    match_expressions=[
-                                        {
-                                            "key": "kubernetes.io/hostname",
-                                            "operator": "In",
-                                            "values": [hostname],
-                                        }
-                                    ]
-                                )
-                            ]
+                affinity=(
+                    self._k8s_client.V1Affinity(
+                        self._k8s_client.V1NodeAffinity(
+                            required_during_scheduling_ignored_during_execution=self._k8s_client.V1NodeSelector(
+                                node_selector_terms=[
+                                    self._k8s_client.V1NodeSelectorTerm(
+                                        match_expressions=[
+                                            {
+                                                "key": "kubernetes.io/hostname",
+                                                "operator": "In",
+                                                "values": [hostname],
+                                            }
+                                        ]
+                                    )
+                                ]
+                            )
                         )
                     )
-                )
-                if hostname.startswith("np04")
-                else None,
+                    if hostname.startswith("np04")
+                    else None
+                ),
                 # / HACK
                 security_context=self._pod_security_context_v1_api(
                     run_as_user=os.getuid(),
@@ -298,9 +300,11 @@ class K8sProcessManager(ProcessManager):
         pi = ProcessInstance(
             process_description=pd,
             process_restriction=pr,
-            status_code=ProcessInstance.StatusCode.RUNNING
-            if self.is_alive(podname, session)
-            else ProcessInstance.StatusCode.DEAD,
+            status_code=(
+                ProcessInstance.StatusCode.RUNNING
+                if self.is_alive(podname, session)
+                else ProcessInstance.StatusCode.DEAD
+            ),
             return_code=return_code,
             uuid=pu,
         )

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -190,8 +190,6 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 }
             )
             self.opmon_publisher.publish(
-                session=self.session,
-                application=self.name,
                 message=ProcessStatus(
                     n_running=n_running, n_dead=n_dead, n_session=n_session
                 ),

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -439,9 +439,11 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 pi = ProcessInstance(
                     process_description=pd,
                     process_restriction=pr,
-                    status_code=ProcessInstance.StatusCode.RUNNING
-                    if self.process_store[uuid].is_alive()
-                    else ProcessInstance.StatusCode.DEAD,
+                    status_code=(
+                        ProcessInstance.StatusCode.RUNNING
+                        if self.process_store[uuid].is_alive()
+                        else ProcessInstance.StatusCode.DEAD
+                    ),
                     return_code=return_code,
                     uuid=pu,
                 )

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -598,12 +598,12 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         if conf.data.type == ProcessManagerTypes.SSH:
             from drunc.process_manager.ssh_process_manager import SSHProcessManager
 
-            log.info("Starting [green]SSH process_manager[/green]")
+            log.debug("Starting [green]SSH process_manager[/green]")
             return SSHProcessManager(conf, **kwargs)
         elif conf.data.type == ProcessManagerTypes.K8s:
             from drunc.process_manager.k8s_process_manager import K8sProcessManager
 
-            log.info("Starting [green]K8s process_manager[/green]")
+            log.debug("Starting [green]K8s process_manager[/green]")
             return K8sProcessManager(conf, **kwargs)
         else:
             log.error(f"ProcessManager type {conf.get('type')} is unsupported!")

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -176,13 +176,15 @@ class ProcessManagerDriver(GRPCDriver):
                 conf_file_no_scheme = conf_file.replace("oksconflibs:", "")
                 consolidate_db(conf_file_no_scheme, f"{fname}")
             except Exception as e:
-                self.log.critical(f"""\nInvalid configuration passed (cannot consolidate your configuration)
+                self.log.critical(
+                    f"""\nInvalid configuration passed (cannot consolidate your configuration)
 {e}
 To debug it, close drunc and run the following command:
 
 [yellow]oks_dump --files-only {conf_file_no_scheme}[/]
 
-""")
+"""
+                )
                 return
 
         import conffwk  # isort: skip
@@ -261,7 +263,8 @@ To debug it, close drunc and run the following command:
                         title=f"Looking for [green]{top_controller_name}[/] on the connectivity service...",
                     )
                 except ApplicationLookupUnsuccessful:
-                    self.log.error(f"""
+                    self.log.error(
+                        f"""
 Could not find \'{top_controller_name}\' on the connectivity service.
 
 Two possibilities:
@@ -280,7 +283,8 @@ And look for messages like:
 [yellow]Registering root-controller to the connectivity service at grpc://xxx.xxx.xxx.xxx:xxxxx[/]
 To find the controller address, you can look up \'{top_controller_name}_control\' on http://{resolve_localhost_to_hostname(connection_server)}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs as above. Then just connect this shell to the controller with:
 [yellow]connect {{controller_address}}:{{controller_port}}>[/]
-""")
+"""
+                    )
                     return
 
                 return uri.replace("grpc://", "")
@@ -314,10 +318,12 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             if session_dal.connectivity_service:
                 connection_server = session_dal.connectivity_service.host
                 connection_port = session_dal.connectivity_service.service.port
-                self.log.warning(f"""This shell didn't connect to the {top_controller_name}.
+                self.log.warning(
+                    f"""This shell didn't connect to the {top_controller_name}.
 To find the controller address, you can look up \'{top_controller_name}_control\' on http://{resolve_localhost_to_hostname(connection_server)}:{connection_port} (you may need a SOCKS proxy from outside CERN), or use the address from the logs as above. Then just connect this shell to the controller with:
 [yellow]connect {{controller_address}}:{{controller_port}}>[/]
-""")
+"""
+                )
             else:
                 self.log.warning(
                     f"This shell didn't connect to the {top_controller_name}. You can use the connect command to connect to the controller."

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -160,8 +160,9 @@ class ProcessManagerDriver(GRPCDriver):
         log_level: str,
         override_logs: bool = True,
         timeout: int | float = 60,
-        sleep_between_app_boot: int
-        | float = 0,  # This may be useful if you have are using SSHPM, and have SSHD's maxstartups setting set to a low value.
+        sleep_between_app_boot: (
+            int | float
+        ) = 0,  # This may be useful if you have are using SSHPM, and have SSHD's maxstartups setting set to a low value.
         **kwargs,
     ) -> ProcessInstance:
         from daqconf.consolidate import consolidate_db

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -56,8 +56,14 @@ class SSHProcessManager(ProcessManager):
         self.disable_host_key_check = False
 
         if self.configuration.data.settings:
-            self.disable_localhost_host_key_check = self.configuration.data.settings.get('disable_localhost_host_key_check', False)
-            self.disable_host_key_check = self.configuration.data.settings.get('disable_host_key_check', False)
+            self.disable_localhost_host_key_check = (
+                self.configuration.data.settings.get(
+                    "disable_localhost_host_key_check", False
+                )
+            )
+            self.disable_host_key_check = self.configuration.data.settings.get(
+                "disable_host_key_check", False
+            )
 
         # self.children_logs_depth = 1000
         # self.children_logs = {}
@@ -133,7 +139,10 @@ class SSHProcessManager(ProcessManager):
         user = self.boot_request[uid].process_description.metadata.user
         host = self.boot_request[uid].process_description.metadata.hostname
         user_host = f"{user}@{host}"
-        disable_host_key_check = self.disable_host_key_check or (self.disable_localhost_host_key_check and host in ('localhost', '127.0.0.1', '::1'))
+        disable_host_key_check = self.disable_host_key_check or (
+            self.disable_localhost_host_key_check
+            and host in ("localhost", "127.0.0.1", "::1")
+        )
 
         # https://stackoverflow.com/questions/7167008/efficiently-finding-the-last-line-in-a-text-file
         # "Not the straight forward way"...
@@ -141,7 +150,6 @@ class SSHProcessManager(ProcessManager):
         nlines = log_request.how_far
         if not nlines:
             nlines = 100
-
 
         try:
             cmd = [
@@ -151,7 +159,15 @@ class SSHProcessManager(ProcessManager):
             ]
             self.log.debug(f"cmd: {cmd}")
             arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no"]
-            arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"] if disable_host_key_check else []
+            arguments += (
+                [
+                    "-o LogLevel=error",
+                    "-o GlobalKnownHostsFile=/dev/null",
+                    "-o UserKnownHostsFile=/dev/null",
+                ]
+                if disable_host_key_check
+                else []
+            )
             arguments += cmd
 
             self.ssh(
@@ -232,8 +248,10 @@ class SSHProcessManager(ProcessManager):
 
                 log_file = boot_request.process_description.process_logs_path
                 env_var = boot_request.process_description.env
-                disable_host_key_check = self.disable_host_key_check or (self.disable_localhost_host_key_check and host in ('localhost', '127.0.0.1', '::1'))
-
+                disable_host_key_check = self.disable_host_key_check or (
+                    self.disable_localhost_host_key_check
+                    and host in ("localhost", "127.0.0.1", "::1")
+                )
 
                 # Add EXIT trap and use it kill child processes on the ssh client side when the ssh connection is closed
                 cmd = (
@@ -258,12 +276,16 @@ class SSHProcessManager(ProcessManager):
                 if cmd[-1] == ";":
                     cmd = cmd[:-1]
 
-                arguments = [
-                    user_host,
-                    "-tt",
-                    "-o StrictHostKeyChecking=no"
-                ]
-                arguments += ["-o LogLevel=error", "-o GlobalKnownHostsFile=/dev/null", "-o UserKnownHostsFile=/dev/null"]  if disable_host_key_check else []
+                arguments = [user_host, "-tt", "-o StrictHostKeyChecking=no"]
+                arguments += (
+                    [
+                        "-o LogLevel=error",
+                        "-o GlobalKnownHostsFile=/dev/null",
+                        "-o UserKnownHostsFile=/dev/null",
+                    ]
+                    if disable_host_key_check
+                    else []
+                )
                 arguments += [
                     f"{{ {cmd} ; }} &> {log_file}",
                 ]
@@ -329,9 +351,11 @@ class SSHProcessManager(ProcessManager):
         pi = ProcessInstance(
             process_description=pd,
             process_restriction=pr,
-            status_code=ProcessInstance.StatusCode.RUNNING
-            if alive
-            else ProcessInstance.StatusCode.DEAD,
+            status_code=(
+                ProcessInstance.StatusCode.RUNNING
+                if alive
+                else ProcessInstance.StatusCode.DEAD
+            ),
             return_code=return_code,
             uuid=pu,
         )
@@ -368,9 +392,11 @@ class SSHProcessManager(ProcessManager):
             pi = ProcessInstance(
                 process_description=pd,
                 process_restriction=pr,
-                status_code=ProcessInstance.StatusCode.RUNNING
-                if self.process_store[proc_uuid].is_alive()
-                else ProcessInstance.StatusCode.DEAD,
+                status_code=(
+                    ProcessInstance.StatusCode.RUNNING
+                    if self.process_store[proc_uuid].is_alive()
+                    else ProcessInstance.StatusCode.DEAD
+                ),
                 return_code=return_code,
                 uuid=pu,
             )

--- a/src/drunc/process_manager/utils.py
+++ b/src/drunc/process_manager/utils.py
@@ -186,10 +186,6 @@ def get_log_path(
     return log_path
 
 
-def get_pm_conf_name_from_dir(pm_conf_path: str) -> str:
-    return pm_conf_path.split("/")[-1].split(".")[0]
-
-
 # # ------------------------------------------------
 # # pexpect.spawn(...,preexec_fn=on_parent_exit('SIGTERM'))
 

--- a/src/drunc/session_manager/interface/session_manager.py
+++ b/src/drunc/session_manager/interface/session_manager.py
@@ -7,11 +7,7 @@ from druncschema.session_manager_pb2_grpc import add_SessionManagerServicer_to_s
 
 from drunc.session_manager.configuration import SessionManagerConfHandler
 from drunc.session_manager.session_manager import SessionManager
-from drunc.utils.utils import (
-    create_logger_handler,
-    get_logger,
-    setup_root_logger,
-)
+from drunc.utils.utils import create_logger_handler, get_logger, setup_root_logger
 
 
 def serve(session_manager: SessionManager, address: str) -> None:

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -270,6 +270,7 @@ def unified_shell(
             obj_uid=controller_name,
             session=ctx.obj.configuration_id,  # some of the function for enable/disable require the full dal of the session
         ),
+        session_name=session_name,
     )
 
     fsm_logger = get_logger("controller.FSM")

--- a/src/drunc/utils/configuration.py
+++ b/src/drunc/utils/configuration.py
@@ -76,6 +76,7 @@ class ConfHandler:
         self.controller_id = 0
         self.process_id = 0
         self.process_id_infra = 0
+        self.session_name = kwargs.get("session_name")
 
         if type == ConfTypes.OKSFileName and oks_key is None:
             raise DruncSetupException("Need to provide a key for the OKS file")

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -32,8 +32,6 @@ from rich.progress import (
 )
 from rich.theme import Theme
 
-from erskafka.ERSPublisher import ERSPublisher
-from opmonlib.publisher import OpMonPublisher
 from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
 from drunc.exceptions import DruncException, DruncSetupException
 
@@ -82,28 +80,6 @@ class LoggingFormatter(logging.Formatter):
         record.levelname = level_name.ljust(component_width)[:component_width]
         return super().format(record)
 
-# Custom filter for special_handler
-class ERSFilter(logging.Filter):
-    def filter(self, record):
-        return getattr(record, 'ers', False)
-
-class ERSHandler(logging.Handler):
-    def __init__(self, topic, kafka_config):
-        super().__init__()
-        self.topic = topic
-        self.producer = Producer(kafka_config)
-
-    def emit(self, record):
-        try:
-            log_entry = self.format(record)
-            self.producer.produce(self.topic, key=record.name, value=log_entry)
-            self.producer.poll(0)  # Trigger delivery
-        except Exception as e:
-            self.handleError(record)
-
-    def close(self):
-        self.producer.flush()
-        super().close()
 
 def setup_root_logger(log_level: str) -> logging.Logger:
     log_level = log_level.upper()
@@ -140,7 +116,7 @@ def get_logger(logger_name: str, *args, **kwargs):
     return logging.getLogger(f"drunc.{logger_name}")
 
 
-def create_logger_handler(log_file_path: str = None, rich_handler: bool = False, ers_conf: ERSConf):
+def create_logger_handler(log_file_path: str = None, rich_handler: bool = False):
     function_logger = get_logger("utils.get_logger")
     logger_level = logging.getLogger("drunc").level
     if not logger_level:
@@ -179,8 +155,6 @@ def create_logger_handler(log_file_path: str = None, rich_handler: bool = False,
     if stdHandler:
         drunc_logger.addHandler(stdHandler)
         function_logger.debug("Added appropriate stream handler to drunc")
-
-
 
     function_logger.debug("Finished setting up logger")
 

--- a/src/drunc/utils/utils.py
+++ b/src/drunc/utils/utils.py
@@ -32,6 +32,8 @@ from rich.progress import (
 )
 from rich.theme import Theme
 
+from erskafka.ERSPublisher import ERSPublisher
+from opmonlib.publisher import OpMonPublisher
 from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
 from drunc.exceptions import DruncException, DruncSetupException
 
@@ -80,6 +82,28 @@ class LoggingFormatter(logging.Formatter):
         record.levelname = level_name.ljust(component_width)[:component_width]
         return super().format(record)
 
+# Custom filter for special_handler
+class ERSFilter(logging.Filter):
+    def filter(self, record):
+        return getattr(record, 'ers', False)
+
+class ERSHandler(logging.Handler):
+    def __init__(self, topic, kafka_config):
+        super().__init__()
+        self.topic = topic
+        self.producer = Producer(kafka_config)
+
+    def emit(self, record):
+        try:
+            log_entry = self.format(record)
+            self.producer.produce(self.topic, key=record.name, value=log_entry)
+            self.producer.poll(0)  # Trigger delivery
+        except Exception as e:
+            self.handleError(record)
+
+    def close(self):
+        self.producer.flush()
+        super().close()
 
 def setup_root_logger(log_level: str) -> logging.Logger:
     log_level = log_level.upper()
@@ -116,7 +140,7 @@ def get_logger(logger_name: str, *args, **kwargs):
     return logging.getLogger(f"drunc.{logger_name}")
 
 
-def create_logger_handler(log_file_path: str = None, rich_handler: bool = False):
+def create_logger_handler(log_file_path: str = None, rich_handler: bool = False, ers_conf: ERSConf):
     function_logger = get_logger("utils.get_logger")
     logger_level = logging.getLogger("drunc").level
     if not logger_level:
@@ -155,6 +179,8 @@ def create_logger_handler(log_file_path: str = None, rich_handler: bool = False)
     if stdHandler:
         drunc_logger.addHandler(stdHandler)
         function_logger.debug("Added appropriate stream handler to drunc")
+
+
 
     function_logger.debug("Finished setting up logger")
 


### PR DESCRIPTION
Allows for drunc to publish to local files for use with the integration test bundle.
Requires
https://github.com/DUNE-DAQ/opmonlib/pull/51
https://github.com/DUNE-DAQ/kafkaopmon/pull/28
Note - this will all need to be merged on the same day

When using this PR with `process-manager` configuration `ssh-CERN-kafka`, there should be no difference. When using it with `ssh-standalone`, there will now be a new file called `info.SSHProcessManager.json` which contains all the OpMon metrics published from the process manager. Similarly, the controllers will have all their OpMon metrics present in the logs. To see the metrics from the process-manager in the terminal, you can change the `ssh-standalone` process manager opmon configuration type from `file` to `stdout`. 