### PR TITLE
SessMan: dedicated gRPC message types

### DIFF
--- a/src/drunc/controller/children_interface/child_node.py
+++ b/src/drunc/controller/children_interface/child_node.py
@@ -1,6 +1,7 @@
 import os
 
 from druncschema.controller_pb2 import Status
+from druncschema.description_pb2 import OldDescription
 from druncschema.request_response_pb2 import Response
 
 from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
@@ -16,7 +17,6 @@ from drunc.utils.utils import (
 )
 
 from druncschema.request_response_pb2 import (  # isort: skip
-    Description,
     ResponseFlag,
 )
 from druncschema.token_pb2 import Token  # isort: skip
@@ -98,7 +98,7 @@ class ChildNode:  # abc.ABC):
                 descriptionType = self.configuration.data.controller.application_name
                 descriptionName = self.configuration.data.controller.id
 
-        d = Description(
+        d = OldDescription(
             type=descriptionType,
             name=descriptionName,
             endpoint=self.get_endpoint(),

--- a/src/drunc/controller/children_interface/grpc_child.py
+++ b/src/drunc/controller/children_interface/grpc_child.py
@@ -2,7 +2,8 @@ import time
 
 import grpc
 from druncschema.controller_pb2_grpc import ControllerStub
-from druncschema.request_response_pb2 import Description, Response
+from druncschema.description_pb2 import OldDescription
+from druncschema.request_response_pb2 import Response
 
 from drunc.broadcast.client.broadcast_handler import BroadcastHandler
 from drunc.broadcast.client.configuration import BroadcastClientConfHandler
@@ -45,7 +46,7 @@ class gRPCChildNode(ChildNode):
         self.channel = grpc.insecure_channel(self.uri)
         self.controller = ControllerStub(self.channel)
 
-        desc = Description()
+        desc = OldDescription()
         ntries = 20
 
         for itry in range(ntries):

--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -14,9 +14,10 @@ from druncschema.controller_pb2 import (
     Status,
 )
 from druncschema.controller_pb2_grpc import ControllerServicer
+from druncschema.description_pb2 import OldDescription
 from druncschema.generic_pb2 import PlainText, Stacktrace
 from druncschema.opmon.generic_pb2 import RunInfo
-from druncschema.request_response_pb2 import Description, Response, ResponseFlag
+from druncschema.request_response_pb2 import Response, ResponseFlag
 from druncschema.token_pb2 import Token
 from google.protobuf.any_pb2 import Any
 
@@ -611,7 +612,7 @@ class Controller(ControllerServicer):
 
         if execute_on_self:
             bd = self.describe_broadcast()
-            d = Description(
+            d = OldDescription(
                 type="controller",
                 name=self.name,
                 endpoint=self.uri if self.uri is not None else "unknown",

--- a/src/drunc/controller/controller_driver.py
+++ b/src/drunc/controller/controller_driver.py
@@ -7,8 +7,8 @@ from druncschema.controller_pb2 import (
     Status,
 )
 from druncschema.controller_pb2_grpc import ControllerStub
+from druncschema.description_pb2 import OldDescription
 from druncschema.generic_pb2 import PlainText
-from druncschema.request_response_pb2 import Description
 
 from drunc.utils.shell_utils import DecodedResponse, GRPCDriver
 
@@ -51,7 +51,10 @@ class ControllerDriver(GRPCDriver):
         self, addressed_command: AddressedCommand, timeout: int | float = 60
     ) -> DecodedResponse:
         return self.send_command(
-            "describe", data=addressed_command, outformat=Description, timeout=timeout
+            "describe",
+            data=addressed_command,
+            outformat=OldDescription,
+            timeout=timeout,
         )
 
     @pack_empty_addressed_command

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -15,8 +15,9 @@ from druncschema.controller_pb2 import (
     FSMResponseFlag,
     Status,
 )
+from druncschema.description_pb2 import OldDescription
 from druncschema.generic_pb2 import bool_msg, float_msg, int_msg, string_msg
-from druncschema.request_response_pb2 import Description, ResponseFlag
+from druncschema.request_response_pb2 import ResponseFlag
 from rich.console import ConsoleRenderable, Group, RichCast
 from rich.progress import (
     BarColumn,
@@ -48,8 +49,8 @@ def generate_none_status() -> Status:
     )
 
 
-def generate_none_description() -> Description:
-    return Description(
+def generate_none_description() -> OldDescription:
+    return OldDescription(
         type="none",
         name="none",
         endpoint="none",
@@ -103,7 +104,7 @@ def get_status_table(status: DecodedResponse, description: DecodedResponse):
     t.add_column("Endpoint")
 
     def add_status_to_table(table, status, description, prefix):
-        valid_description = check_message_type(description, "Description")
+        valid_description = check_message_type(description, "OldDescription")
         valid_status = check_message_type(status, "Status")
 
         if not valid_description or not valid_status:
@@ -228,7 +229,7 @@ def controller_setup(ctx, controller_address):
             "This context is not compatible with a controller, you need to add a 'took_control' bool member"
         )
 
-    desc = Description()
+    desc = OldDescription()
 
     timeout = 60
 

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -5,6 +5,7 @@ import time
 
 from druncschema.authoriser_pb2 import ActionType, SystemType
 from druncschema.broadcast_pb2 import BroadcastType
+from druncschema.description_pb2 import CommandDescription, OldDescription
 from druncschema.opmon.process_manager_pb2 import ProcessStatus
 from druncschema.process_manager_pb2 import (
     BootRequest,
@@ -19,8 +20,6 @@ from druncschema.process_manager_pb2 import (
 )
 from druncschema.process_manager_pb2_grpc import ProcessManagerServicer
 from druncschema.request_response_pb2 import (
-    CommandDescription,
-    Description,
     Request,
     Response,
     ResponseFlag,
@@ -106,7 +105,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 name="describe",
                 data_type=["None"],
                 help="Describe self (return a list of commands, the type of endpoint, the name and session).",
-                return_type="request_response_pb2.Description",
+                return_type="description_pb2.OldDescription",
             ),
             CommandDescription(
                 name="kill",
@@ -479,7 +478,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     def describe(self, request: Request, context: ServicerContext) -> Response:
         self.log.debug(f"{self.name} running describe")
         bd = self.describe_broadcast()
-        d = Description(
+        d = OldDescription(
             type="process_manager",
             name=self.name,
             info=self.configuration.log_path,
@@ -506,7 +505,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.READ, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def logs(self, request:Request, context:ServicerContext) -> Response:
+    def logs(self, request: Request, context: ServicerContext) -> Response:
         """Fetch logs for a process.
 
         Args:

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -6,6 +6,7 @@ import tempfile
 import time
 from time import sleep
 
+from druncschema.description_pb2 import OldDescription
 from druncschema.process_manager_pb2 import (
     BootRequest,
     LogLines,
@@ -18,7 +19,6 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
 )
 from druncschema.process_manager_pb2_grpc import ProcessManagerStub
-from druncschema.request_response_pb2 import Description
 
 from drunc.connectivity_service.client import ConnectivityServiceClient
 from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
@@ -393,9 +393,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             "terminate", outformat=ProcessInstanceList, timeout=timeout
         )
 
-    def kill(
-        self, query: ProcessQuery, timeout: int | float = 60
-    ) -> ProcessInstance:
+    def kill(self, query: ProcessQuery, timeout: int | float = 60) -> ProcessInstance:
         return self.send_command(
             "kill",
             data=query,
@@ -411,9 +409,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             timeout=timeout,
         )
 
-    def ps(
-        self, query: ProcessQuery, timeout: int | float = 60
-    ) -> ProcessInstanceList:
+    def ps(self, query: ProcessQuery, timeout: int | float = 60) -> ProcessInstanceList:
         return self.send_command(
             "ps",
             data=query,
@@ -441,9 +437,9 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             timeout=timeout,
         )
 
-    def describe(self, timeout: int | float = 60) -> Description:
+    def describe(self, timeout: int | float = 60) -> OldDescription:
         return self.send_command(
             "describe",
-            outformat=Description,
+            outformat=OldDescription,
             timeout=timeout,
         )

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -8,7 +8,6 @@ from conffwk import Configuration
 from druncschema.description_pb2 import CommandDescription, Description
 from druncschema.request_response_pb2 import (
     Request,
-    Response,
     ResponseFlag,
 )
 from druncschema.session_manager_pb2 import (
@@ -21,7 +20,6 @@ from druncschema.session_manager_pb2_grpc import SessionManagerServicer
 from grpc import ServicerContext
 
 from drunc.session_manager.configuration import SessionManagerConfHandler
-from drunc.utils.grpc_utils import pack_to_any
 from drunc.utils.utils import get_logger, pid_info_str
 
 
@@ -123,7 +121,9 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
         )
 
-    def list_all_configs(self, request: Request, context: ServicerContext) -> Response:
+    def list_all_configs(
+        self, request: Request, context: ServicerContext
+    ) -> AllConfigKeys:
         """Respond with a list of all available configurations.
 
         Args:
@@ -139,12 +139,11 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         search_paths = getenv("DUNEDAQ_DB_PATH")
         if search_paths is None:
             self.log.error("DUNEDAQ_DB_PATH not set")
-            return Response(
+            return AllConfigKeys(
                 name=self.name,
                 token=None,
-                data=pack_to_any(None),
+                config_keys=[],
                 flag=ResponseFlag.FAILED,
-                children=[],
             )
 
         # Find all configuration files.
@@ -170,14 +169,9 @@ class SessionManager(abc.ABC, SessionManagerServicer):
                 )
                 configs.append(config_key)
 
-        all_configs = AllConfigKeys(
-            config_keys=configs,
-        )
-
-        return Response(
+        return AllConfigKeys(
             name=self.name,
             token=None,
-            data=pack_to_any(all_configs),
+            config_keys=configs,
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-            children=[],
         )

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -91,7 +91,9 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             token=None,
         )
 
-    def list_all_sessions(self, request: Request, context: ServicerContext) -> Response:
+    def list_all_sessions(
+        self, request: Request, context: ServicerContext
+    ) -> AllActiveSessions:
         """Respond with a list of all active sessions.
 
         Args:
@@ -114,16 +116,11 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             config_key=dummy_config,
         )
 
-        all_sessions = AllActiveSessions(
-            active_sessions=[dummy_session],
-        )
-
-        return Response(
+        return AllActiveSessions(
             name=self.name,
             token=None,
-            data=pack_to_any(all_sessions),
+            active_sessions=[dummy_session],
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-            children=[],
         )
 
     def list_all_configs(self, request: Request, context: ServicerContext) -> Response:

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -5,6 +5,7 @@ from os import getenv
 from pathlib import Path
 
 from conffwk import Configuration
+from druncschema.description_pb2 import NewCommandDescription, NewDescription
 from druncschema.request_response_pb2 import (
     CommandDescription,
     Description,
@@ -48,6 +49,51 @@ class SessionManager(abc.ABC, SessionManagerServicer):
 
         self.name = name
         self.configuration = configuration
+
+    def new_describe(
+        self, request: Request, context: ServicerContext
+    ) -> NewDescription:
+        """Respond with a description of this session manager service.
+
+        Args:
+            request: The incoming request (not used).
+            context: The gRPC context (not used).
+
+        Returns:
+            A response containing the service description.
+        """
+        self.log.debug(f"{self.name} running describe")
+
+        commands = [
+            NewCommandDescription(
+                name="describe",
+                data_type=["None"],
+                help="List the methods exposed by this endpoint.",
+                return_type="request_response_pb2.Description",
+            ),
+            NewCommandDescription(
+                name="list_all_sessions",
+                data_type=["None"],
+                help="List all active sessions.",
+                return_type="session_manager_pb2.AllActiveSessions",
+            ),
+            NewCommandDescription(
+                name="list_all_configs",
+                data_type=["None"],
+                help="List all available configurations.",
+                return_type="session_manager_pb2.AllConfigKeys",
+            ),
+        ]
+
+        return NewDescription(
+            type="session_manager",
+            name=self.name,
+            session=self.name,
+            commands=commands,
+            children=[],
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+            token=None,
+        )
 
     def describe(self, request: Request, context: ServicerContext) -> Response:
         """Respond with a description of this session manager service.

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -5,10 +5,8 @@ from os import getenv
 from pathlib import Path
 
 from conffwk import Configuration
-from druncschema.description_pb2 import NewCommandDescription, NewDescription
+from druncschema.description_pb2 import CommandDescription, NewDescription
 from druncschema.request_response_pb2 import (
-    CommandDescription,
-    Description,
     Request,
     Response,
     ResponseFlag,
@@ -50,9 +48,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         self.name = name
         self.configuration = configuration
 
-    def new_describe(
-        self, request: Request, context: ServicerContext
-    ) -> NewDescription:
+    def describe(self, request: Request, context: ServicerContext) -> NewDescription:
         """Respond with a description of this session manager service.
 
         Args:
@@ -65,19 +61,19 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         self.log.debug(f"{self.name} running describe")
 
         commands = [
-            NewCommandDescription(
+            CommandDescription(
                 name="describe",
                 data_type=["None"],
                 help="List the methods exposed by this endpoint.",
                 return_type="request_response_pb2.Description",
             ),
-            NewCommandDescription(
+            CommandDescription(
                 name="list_all_sessions",
                 data_type=["None"],
                 help="List all active sessions.",
                 return_type="session_manager_pb2.AllActiveSessions",
             ),
-            NewCommandDescription(
+            CommandDescription(
                 name="list_all_configs",
                 data_type=["None"],
                 help="List all available configurations.",
@@ -93,54 +89,6 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             children=[],
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
             token=None,
-        )
-
-    def describe(self, request: Request, context: ServicerContext) -> Response:
-        """Respond with a description of this session manager service.
-
-        Args:
-            request: The incoming request (not used).
-            context: The gRPC context (not used).
-
-        Returns:
-            A response containing the service description.
-        """
-        self.log.debug(f"{self.name} running describe")
-
-        command_descriptions = [
-            CommandDescription(
-                name="describe",
-                data_type=["None"],
-                help="List the methods exposed by this endpoint.",
-                return_type="request_response_pb2.Description",
-            ),
-            CommandDescription(
-                name="list_all_sessions",
-                data_type=["None"],
-                help="List all active sessions.",
-                return_type="session_manager_pb2.AllActiveSessions",
-            ),
-            CommandDescription(
-                name="list_all_configs",
-                data_type=["None"],
-                help="List all available configurations.",
-                return_type="session_manager_pb2.AllConfigKeys",
-            ),
-        ]
-
-        description = Description(
-            type="session_manager",
-            name=self.name,
-            session=self.name,
-            commands=command_descriptions,
-        )
-
-        return Response(
-            name=self.name,
-            token=None,
-            data=pack_to_any(description),
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-            children=[],
         )
 
     def list_all_sessions(self, request: Request, context: ServicerContext) -> Response:

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -65,7 +65,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
                 name="describe",
                 data_type=["None"],
                 help="List the methods exposed by this endpoint.",
-                return_type="request_response_pb2.Description",
+                return_type="description_pb2.NewDescription",
             ),
             CommandDescription(
                 name="list_all_sessions",

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -5,7 +5,7 @@ from os import getenv
 from pathlib import Path
 
 from conffwk import Configuration
-from druncschema.description_pb2 import CommandDescription, NewDescription
+from druncschema.description_pb2 import CommandDescription, Description
 from druncschema.request_response_pb2 import (
     Request,
     Response,
@@ -48,7 +48,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         self.name = name
         self.configuration = configuration
 
-    def describe(self, request: Request, context: ServicerContext) -> NewDescription:
+    def describe(self, request: Request, context: ServicerContext) -> Description:
         """Respond with a description of this session manager service.
 
         Args:
@@ -65,7 +65,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
                 name="describe",
                 data_type=["None"],
                 help="List the methods exposed by this endpoint.",
-                return_type="description_pb2.NewDescription",
+                return_type="description_pb2.Description",
             ),
             CommandDescription(
                 name="list_all_sessions",
@@ -81,7 +81,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             ),
         ]
 
-        return NewDescription(
+        return Description(
             type="session_manager",
             name=self.name,
             session=self.name,

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -49,7 +49,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         self.name = name
         self.configuration = configuration
 
-    def describe(self, request:Request, context:ServicerContext) -> Response:
+    def describe(self, request: Request, context: ServicerContext) -> Response:
         """Respond with a description of this session manager service.
 
         Args:
@@ -97,7 +97,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             children=[],
         )
 
-    def list_all_sessions(self, request:Request, context:ServicerContext) -> Response:
+    def list_all_sessions(self, request: Request, context: ServicerContext) -> Response:
         """Respond with a list of all active sessions.
 
         Args:
@@ -132,7 +132,7 @@ class SessionManager(abc.ABC, SessionManagerServicer):
             children=[],
         )
 
-    def list_all_configs(self, request:Request, context:ServicerContext) -> Response:
+    def list_all_configs(self, request: Request, context: ServicerContext) -> Response:
         """Respond with a list of all available configurations.
 
         Args:

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -1,7 +1,6 @@
 """Driver for the session manager service."""
 
 from druncschema.description_pb2 import NewDescription
-from druncschema.request_response_pb2 import Description
 from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
 from druncschema.token_pb2 import Token
@@ -40,21 +39,13 @@ class SessionManagerDriver(GRPCDriver):
         """
         return SessionManagerStub(channel)
 
-    def new_describe(self) -> DecodedResponse | None:
-        """Describe the session manager service.
-
-        Returns:
-            A decoded response object containing the description of the service.
-        """
-        return self.send_command("new_describe", outformat=NewDescription)
-
     def describe(self) -> DecodedResponse | None:
         """Describe the session manager service.
 
         Returns:
             A decoded response object containing the description of the service.
         """
-        return self.send_command("describe", outformat=Description)
+        return self.send_command("describe", outformat=NewDescription)
 
     def list_all_sessions(self) -> DecodedResponse | None:
         """List all active sessions managed by the session manager.

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -43,7 +43,7 @@ class SessionManagerDriver(GRPCDriver):
         """Describe the session manager service.
 
         Returns:
-            A decoded response object containing the description of the service.
+            A response containing the description of the service.
         """
         return self.send_command("describe", outformat=Description)
 
@@ -51,7 +51,7 @@ class SessionManagerDriver(GRPCDriver):
         """List all active sessions managed by the session manager.
 
         Returns:
-            A decoded response object containing a list of all active sessions.
+            A response containing a list of all active sessions.
         """
         return self.send_command("list_all_sessions", outformat=AllActiveSessions)
 
@@ -59,6 +59,6 @@ class SessionManagerDriver(GRPCDriver):
         """List all available configurations in the session manager.
 
         Returns:
-            A decoded response object containing all available configuration keys.
+            A response containing all available configuration keys.
         """
         return self.send_command("list_all_configs", outformat=AllConfigKeys)

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -1,5 +1,6 @@
 """Driver for the session manager service."""
 
+from druncschema.description_pb2 import NewDescription
 from druncschema.request_response_pb2 import Description
 from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
@@ -38,6 +39,14 @@ class SessionManagerDriver(GRPCDriver):
             An object containing session manager service method stubs.
         """
         return SessionManagerStub(channel)
+
+    def new_describe(self) -> DecodedResponse | None:
+        """Describe the session manager service.
+
+        Returns:
+            A decoded response object containing the description of the service.
+        """
+        return self.send_command("new_describe", outformat=NewDescription)
 
     def describe(self) -> DecodedResponse | None:
         """Describe the session manager service.

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -1,6 +1,6 @@
 """Driver for the session manager service."""
 
-from druncschema.description_pb2 import NewDescription
+from druncschema.description_pb2 import Description
 from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
 from druncschema.token_pb2 import Token
@@ -45,7 +45,7 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A decoded response object containing the description of the service.
         """
-        return self.send_command("describe", outformat=NewDescription)
+        return self.send_command("describe", outformat=Description)
 
     def list_all_sessions(self) -> DecodedResponse | None:
         """List all active sessions managed by the session manager.

--- a/src/drunc/tests/controller/test_controller_driver.py
+++ b/src/drunc/tests/controller/test_controller_driver.py
@@ -1,5 +1,5 @@
 import pytest
-from druncschema.request_response_pb2 import Description
+from druncschema.description_pb2 import OldDescription
 from google.protobuf.json_format import MessageToDict
 
 from drunc.connectivity_service.client import ConnectivityServiceClient
@@ -181,7 +181,7 @@ def test_controller_driver_describe(many_controllers_running):
     address_commmand_permutations_deep_segments_config(
         controller_driver=controller_driver,
         command="describe",
-        expected_response=Description(
+        expected_response=OldDescription(
             name="<name>",
             type="controller",
             endpoint="<endpoint>",

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -221,9 +221,9 @@ class GRPCDriver:
 
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
         from druncschema.description_pb2 import Description
-        from druncschema.session_manager_pb2 import AllActiveSessions
+        from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 
-        if isinstance(response, (Description, AllActiveSessions)):
+        if isinstance(response, (Description, AllActiveSessions, AllConfigKeys)):
             return response
 
         return self.handle_response(response, command, outformat)

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -220,9 +220,9 @@ class GRPCDriver:
             self.__handle_grpc_error(e, command)
 
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
-        from druncschema.description_pb2 import NewDescription
+        from druncschema.description_pb2 import Description
 
-        if isinstance(response, (NewDescription,)):
+        if isinstance(response, (Description,)):
             return response
 
         return self.handle_response(response, command, outformat)

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -127,12 +127,6 @@ class GRPCDriver:
         raise error
 
     def handle_response(self, response, command, outformat):
-        # TODO: TEMP HACK -- DON'T FORGET TO FIX THIS!!!
-        from druncschema.description_pb2 import NewDescription
-
-        if isinstance(response, (NewDescription,)):
-            return response
-
         dr = DecodedResponse(
             name=response.name,
             token=response.token,
@@ -224,6 +218,13 @@ class GRPCDriver:
             response = cmd(request, timeout=timeout)
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, command)
+
+        # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
+        from druncschema.description_pb2 import NewDescription
+
+        if isinstance(response, (NewDescription,)):
+            return response
+
         return self.handle_response(response, command, outformat)
 
 

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -221,8 +221,9 @@ class GRPCDriver:
 
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
         from druncschema.description_pb2 import Description
+        from druncschema.session_manager_pb2 import AllActiveSessions
 
-        if isinstance(response, (Description,)):
+        if isinstance(response, (Description, AllActiveSessions)):
             return response
 
         return self.handle_response(response, command, outformat)

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -127,6 +127,12 @@ class GRPCDriver:
         raise error
 
     def handle_response(self, response, command, outformat):
+        # TODO: TEMP HACK -- DON'T FORGET TO FIX THIS!!!
+        from druncschema.description_pb2 import NewDescription
+
+        if isinstance(response, (NewDescription,)):
+            return response
+
         dr = DecodedResponse(
             name=response.name,
             token=response.token,
@@ -219,7 +225,6 @@ class GRPCDriver:
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, command)
         return self.handle_response(response, command, outformat)
-
 
 
 class ShellContext:


### PR DESCRIPTION
Resolves https://github.com/ImperialCollegeLondon/drunc_ui/issues/496

This is the first in a series of changes which will replace the existing generic gRPC messages (arbitrary data packed to any) to a simpler and more reliable system of purpose-built gRPC messages.

This first PR starts with the Session Manager. Next will come Process Manager and then Controller. There is a sister PR in the druncschema repository required to run this (https://github.com/DUNE-DAQ/druncschema/pull/58).

One can test by running `describe`, `list_all_sessions` and `list_all_configs` on a connected Session Manager driver.

Benefits:
1. type safety is better. We know what a message's type is for free
2. No more `Any`-type packing and unpacking. This is inefficient and hard to follow.
3. We will be able to make better use of in-built gRPC features, such as authentication.

