### PR TITLE
k8s process manager

### DIFF
--- a/src/drunc/process_manager/interface/context.py
+++ b/src/drunc/process_manager/interface/context.py
@@ -34,7 +34,7 @@ class ProcessManagerContext(ShellContext):  # boilerplatefest
             "process_manager": ProcessManagerDriver(
                 self.address,
                 self._token,
-                aio_channel=True,
+                aio_channel=False,
             )
         }
 

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -235,6 +235,20 @@ class K8sProcessManager(ProcessManager):
             ),
         )
         try:
+            pods = self._core_v1_api.list_namespaced_pod(session)
+            if any(p.metadata.name == podname for p in pods.items):
+                self.log.warning(f'Pod "{session}.{podname}" already exists. Deleting it...')
+                self._core_v1_api.delete_namespaced_pod(
+                    podname, session, grace_period_seconds=0
+                )
+                for _ in range(10):
+                    sleep(1)
+                    pods = self._core_v1_api.list_namespaced_pod(session)
+                    if all(p.metadata.name != podname for p in pods.items):
+                        break
+                else:
+                    raise DruncException(f'Timed out waiting for pod "{session}.{podname}" to be deleted')
+
             self._core_v1_api.create_namespaced_pod(session, pod)
             self.log.info(f'Creating "{session}.{podname}"')
             self._add_creator_label(podname, "pod")
@@ -354,11 +368,20 @@ class K8sProcessManager(ProcessManager):
             return_code = None
         else:
             if not self.is_alive(podname, session):
-                return_code = (
+                container_statuses = (
                     self._core_v1_api.read_namespaced_pod_status(podname, session)
-                    .status.container_statuses[0]
-                    .state.terminated.exit_code
+                    .status.container_statuses
                 )
+
+                if container_statuses:
+                    state = container_statuses[0].state
+                    self.log.debug(f"{podname} state: {state}")
+                    if state and state.terminated:
+                        return_code = state.terminated.exit_code
+                    else:
+                        return_code = None
+                else:
+                    return_code = None
             else:
                 return_code = None
         return return_code
@@ -368,6 +391,8 @@ class K8sProcessManager(ProcessManager):
     def _terminate(self):
         self.log.info("Terminating")
 
+    def _terminate_impl(self):
+        return self._terminate()
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         uuids = self._get_process_uid(log_request.query, in_boot_request=True)
@@ -375,9 +400,9 @@ class K8sProcessManager(ProcessManager):
         for uuid in self._get_process_uid(log_request.query):
             podname = self.boot_request[uuid].process_description.metadata.name
             session = self.boot_request[uuid].process_description.metadata.session
-            return [LogLines(line=log) for log in self._core_v1_api.read_namespaced_pod_log(
+            return LogLines(lines=[log for log in self._core_v1_api.read_namespaced_pod_log(
                 podname, session, tail_lines=log_request.how_far
-            ).split("\n")]
+            ).split("\n")])
 
     def _boot_impl(self, boot_request: BootRequest) -> ProcessUUID:
         this_uuid = str(uuid.uuid4())

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -433,6 +433,14 @@ class K8sProcessManager(ProcessManager):
                 break
         else:
             raise DruncException(f'Not able to boot "{session}.{podnames}":{uuid}')
+        
+        try:
+            pod_info = self._core_v1_api.read_namespaced_pod(podnames, session)
+            node_name = pod_info.spec.node_name
+            self.boot_request[uuid].process_description.metadata.hostname = node_name
+        except Exception as e:
+            self.log.warning(f"Could not retrieve node name for pod {session}.{podnames}: {e}")
+
         return self._get_pi(uuid, podnames, session)
 
     def _ps_impl(

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -159,8 +159,11 @@ class K8sProcessManager(ProcessManager):
         hostname = socket.gethostname()
         # / HACK
 
-        # pod_image = self.configuration.data.image
-        pod_image = "ghcr.io/dune-daq/alma9:latest"
+        pod_image = self.configuration.data.image
+        #pod_image = boot_request.process_description.metadata.pod_image or "ghcr.io/dune-daq/alma9:latest"
+
+        # if not pod_image:
+        #     raise DruncException("No image specified in BootRequest")
 
         pod = self._pod_v1_api(
             api_version="v1",
@@ -183,8 +186,9 @@ class K8sProcessManager(ProcessManager):
                         # args = ["-c", "sleep 3600"],
                         env=self._env_vars(boot_request.process_description.env),
                         volume_mounts=[
-                            self._volume_mount("pwd", os.getcwd()),
+                            #self._volume_mount("pwd", os.getcwd()),
                             self._volume_mount("cvmfs", "/cvmfs/"),
+                            self._volume_mount("nfs", "/nfs/"),
                         ],
                         working_dir=boot_request.process_description.process_execution_directory,
                         restart_policy="Never",
@@ -201,8 +205,9 @@ class K8sProcessManager(ProcessManager):
                     )
                 ],
                 volumes=[
-                    self._volume("pwd", os.getcwd()),
+                    #self._volume("pwd", os.getcwd()),
                     self._volume("cvmfs", "/cvmfs/"),
+                    self._volume("nfs", "/nfs/"),
                 ],
                 # HACK
                 affinity=(


### PR DESCRIPTION
To run this k8s PM
1. SSH into np04-srv-016 and set the k8s configuration:
> export KUBECONFIG=/nfs/home/np04daq/.kube/config.016

2. Set up the DAQ Environment
> cd NFD_DEV_250721_A9 (or latter release.)
> source env.sh

3. Launch the k8s process manager on a chosen port (e.g., 5001)
> drunc-process-manager k8s 5001

You should see output like
>[2025/07/29 15:23:43] INFO       process_manager.py:90          process_manager:                              process_manager communicating through       
                                 address 10.73.136.36:5001       

4.In a new shell, after sourcing the DAQ environment again, connect to the process manager:
>drunc-process-manager-shell grpc://10.73.136.36:5001

where you will be able to send process manager commands like: boot, ps, kill, etc..

5. Boot the applications
>boot oksconflibs:/nfs/home/wasu/NFD_DEV_250721_A9/sourcecode/daqsystemtest/config/daqsystemtest/example-configs.data.xml claudia-test ehn1-local-1x1-config

You should see something like
> Controller endpoint: '10.244.11.222:45105', point your 'drunc-controller-shell' to it.    

6.In a third shell, connect to the controller:
>drunc-controller-shell grpc://10.244.11.222:45105

Now you can send FSM commands as usual.


To delete all the pods, from process manager shell
>kill --session claudia-test