### PR TITLE
ProcMan: dedicated gRPC message types

### DIFF
--- a/src/drunc/controller/controller_driver.py
+++ b/src/drunc/controller/controller_driver.py
@@ -15,12 +15,10 @@ from drunc.utils.shell_utils import DecodedResponse, GRPCDriver
 
 class ControllerDriver(GRPCDriver):
     def __init__(self, address: str, token, **kwargs):
-        super(ControllerDriver, self).__init__(
+        super().__init__(
             name="controller_driver", address=address, token=token, **kwargs
         )
-
-    def create_stub(self, channel):
-        return ControllerStub(channel)
+        self.stub = ControllerStub(self.channel)
 
     def pack_empty_addressed_command(cmd):
         @wraps(cmd)

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -216,7 +216,7 @@ def logs(
         query=query,
     )
 
-    result = obj.get_driver("process_manager").logs(log_req).data
+    result = obj.get_driver("process_manager").logs(log_req)
 
     if result.uuid.uuid is not None:
         obj.rule(f"[yellow]{result.uuid.uuid}[/yellow] logs")

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -67,7 +67,7 @@ def boot(
             if not result:
                 break
             log.debug(
-                f"'{result.data.process_description.metadata.name}' ({result.data.uuid.uuid}) process started"
+                f"'{result.values[0].process_description.metadata.name}' ({result.values[0].uuid.uuid}) process started"
             )
     except InterruptedCommand:
         return
@@ -144,7 +144,7 @@ def dummy_boot(
             if not result:
                 break
             log.debug(
-                f"'{result.data.process_description.metadata.name}' ({result.data.uuid.uuid}) process started"
+                f"'{result.values[0].process_description.metadata.name}' ({result.values[0].uuid.uuid}) process started"
             )
     except InterruptedCommand:
         return

--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -45,9 +45,9 @@ def boot(
     log = get_logger("process_manager.shell")
     processes = obj.get_driver("process_manager").ps(ProcessQuery(user=user))
 
-    if len(processes.data.values) > 0:
+    if len(processes.values) > 0:
         click.confirm(
-            f"You already have {len(processes.data.values)} processes running, are you sure you want to boot a session?",
+            f"You already have {len(processes.values)} processes running, are you sure you want to boot a session?",
             abort=True,
         )
 
@@ -159,7 +159,7 @@ def terminate(obj: ProcessManagerContext) -> None:
     if not result:
         return
     obj.print(
-        tabulate_process_instance_list(result.data, "Terminated process", False)
+        tabulate_process_instance_list(result, "Terminated process", False)
     )  # rich tables require console printing
 
     obj.delete_driver("controller")
@@ -175,7 +175,7 @@ def kill(obj: ProcessManagerContext, query: ProcessQuery) -> None:
     if not result:
         return
     obj.print(
-        tabulate_process_instance_list(result.data, "Killed process", False)
+        tabulate_process_instance_list(result, "Killed process", False)
     )  # rich tables require console printing
 
     obj.delete_driver("controller")
@@ -191,7 +191,7 @@ def flush(obj: ProcessManagerContext, query: ProcessQuery) -> None:
     if not result:
         return
     obj.print(
-        tabulate_process_instance_list(result.data, "Flushed process", False)
+        tabulate_process_instance_list(result, "Flushed process", False)
     )  # rich tables require console printing
 
 
@@ -222,7 +222,6 @@ def logs(
         obj.rule(f"[yellow]{result.uuid.uuid}[/yellow] logs")
 
     for line in result.lines:
-
         if line == "":
             obj.print("")
             continue
@@ -262,9 +261,7 @@ def restart(obj: ProcessManagerContext, query: ProcessQuery) -> None:
     help="Whether to have a long output",
 )
 @click.pass_obj
-def ps(
-    obj: ProcessManagerContext, query: ProcessQuery, long_format: bool
-) -> None:
+def ps(obj: ProcessManagerContext, query: ProcessQuery, long_format: bool) -> None:
     log = get_logger("process_manager.shell")
     log.debug(f"Running ps with query {query}")
     results = obj.get_driver("process_manager").ps(query=query)
@@ -272,6 +269,6 @@ def ps(
         return
     obj.print(
         tabulate_process_instance_list(
-            results.data, title="Processes running", long=long_format
+            results, title="Processes running", long=long_format
         )
     )

--- a/src/drunc/process_manager/interface/context.py
+++ b/src/drunc/process_manager/interface/context.py
@@ -34,7 +34,7 @@ class ProcessManagerContext(ShellContext):  # boilerplatefest
             "process_manager": ProcessManagerDriver(
                 self.address,
                 self._token,
-                aio_channel=True,
+                aio_channel=False,
             )
         }
 

--- a/src/drunc/process_manager/interface/shell.py
+++ b/src/drunc/process_manager/interface/shell.py
@@ -48,7 +48,6 @@ def process_manager_shell(ctx, process_manager_address: str, log_level: str) -> 
     ctx.obj.reset(address=process_manager_address)
 
     try:
-
         desc = ctx.obj.get_driver("process_manager").describe()
     except ServerUnreachable as e:
         process_manager_shell_log = get_logger(
@@ -63,7 +62,7 @@ def process_manager_shell(ctx, process_manager_address: str, log_level: str) -> 
 
     process_manager_log = get_logger(
         logger_name="process_manager",
-        log_file_path=desc.data.info,
+        log_file_path=desc.info,
         override_log_file=False,
         rich_handler=True,
     )
@@ -72,10 +71,10 @@ def process_manager_shell(ctx, process_manager_address: str, log_level: str) -> 
         f"[green]{getpass.getuser()}[/green] connected to the process manager through a [green]drunc-process-manager-shell[/green] via address [green]{process_manager_address}[/green]"
     )
     process_manager_shell_log.info(
-        f"Connected to {process_manager_address}, running '{desc.data.name}.{desc.data.session}' (name.session), starting listening..."
+        f"Connected to {process_manager_address}, running '{desc.name}.{desc.session}' (name.session), starting listening..."
     )
-    if desc.data.HasField("broadcast"):
-        ctx.obj.start_listening(desc.data.broadcast)
+    if desc.HasField("broadcast"):
+        ctx.obj.start_listening(desc.broadcast)
 
     def cleanup():
         ctx.obj.terminate()

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -16,6 +16,7 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
     ProcessUUID,
 )
+from druncschema.request_response_pb2 import ResponseFlag
 from kubernetes import client, config
 
 from drunc.exceptions import DruncCommandException, DruncException
@@ -381,10 +382,16 @@ class K8sProcessManager(ProcessManager):
                 ).split("\n")
             ]
 
-    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
+    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstanceList:
         self.log.debug(f"{self.name} running boot command")
         this_uuid = str(uuid.uuid4())
-        return self.__boot(boot_request, this_uuid)
+        process = self.__boot(boot_request, this_uuid)
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=[process],
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     def __boot(self, boot_request: BootRequest, uuid: str) -> ProcessInstance:
         session = boot_request.process_description.metadata.session
@@ -415,7 +422,7 @@ class K8sProcessManager(ProcessManager):
 
     def _ps_impl(
         self, query: ProcessQuery, in_boot_request: bool = False
-    ) -> list[ProcessInstance]:
+    ) -> ProcessInstanceList:
         ret = []
         for proc_uuid in self._get_process_uid(query):
             podname = self.boot_request[proc_uuid].process_description.metadata.name
@@ -425,9 +432,14 @@ class K8sProcessManager(ProcessManager):
 
             ret.append(self._get_pi(proc_uuid, podname, session, return_code))
 
-        return ret
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=ret,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
-    def _restart_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+    def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         ret = []
         uuids = self._get_process_uid(query, in_boot_request=True)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
@@ -438,7 +450,6 @@ class K8sProcessManager(ProcessManager):
 
             self._kill_pod(podname, session)
 
-            same_uuid_br = []
             same_uuid_br = BootRequest()
             same_uuid_br.CopyFrom(self.boot_request[uuid])
             same_uuid = uuid
@@ -452,7 +463,12 @@ class K8sProcessManager(ProcessManager):
             del same_uuid_br
             del same_uuid
 
-        return ret
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=ret,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     # # ORDER MATTERS!
     # @broadcasted  # outer most wrapper 1st step

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -381,7 +381,8 @@ class K8sProcessManager(ProcessManager):
                 ).split("\n")
             ]
 
-    def _boot_impl(self, boot_request: BootRequest) -> ProcessUUID:
+    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
+        self.log.debug(f"{self.name} running boot command")
         this_uuid = str(uuid.uuid4())
         return self.__boot(boot_request, this_uuid)
 

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -368,16 +368,18 @@ class K8sProcessManager(ProcessManager):
     def _terminate(self):
         self.log.info("Terminating")
 
-
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         uuids = self._get_process_uid(log_request.query, in_boot_request=True)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
         for uuid in self._get_process_uid(log_request.query):
             podname = self.boot_request[uuid].process_description.metadata.name
             session = self.boot_request[uuid].process_description.metadata.session
-            return [LogLines(line=log) for log in self._core_v1_api.read_namespaced_pod_log(
-                podname, session, tail_lines=log_request.how_far
-            ).split("\n")]
+            return [
+                LogLines(line=log)
+                for log in self._core_v1_api.read_namespaced_pod_log(
+                    podname, session, tail_lines=log_request.how_far
+                ).split("\n")
+            ]
 
     def _boot_impl(self, boot_request: BootRequest) -> ProcessUUID:
         this_uuid = str(uuid.uuid4())
@@ -426,8 +428,8 @@ class K8sProcessManager(ProcessManager):
 
         return pil
 
-    def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
-        # ret = []
+    def _restart_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+        ret = []
         uuids = self._get_process_uid(query, in_boot_request=True)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
         for uuid in self._get_process_uid(query):
@@ -445,16 +447,12 @@ class K8sProcessManager(ProcessManager):
             del self.boot_request[uuid]
             del uuid
 
-            ret = self.__boot(same_uuid_br, same_uuid)
+            ret = [self.__boot(same_uuid_br, same_uuid)]
+            # ret.append(self._get_pi(uuid, podname, session))
 
             del same_uuid_br
             del same_uuid
 
-            # ret.append(self._get_pi(uuid, podname, session))
-
-        # pil = ProcessInstanceList(
-        #     values=ret
-        # )
         return ret
 
     # # ORDER MATTERS!

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -414,7 +414,7 @@ class K8sProcessManager(ProcessManager):
 
     def _ps_impl(
         self, query: ProcessQuery, in_boot_request: bool = False
-    ) -> ProcessInstanceList:
+    ) -> list[ProcessInstance]:
         ret = []
         for proc_uuid in self._get_process_uid(query):
             podname = self.boot_request[proc_uuid].process_description.metadata.name
@@ -424,9 +424,7 @@ class K8sProcessManager(ProcessManager):
 
             ret.append(self._get_pi(proc_uuid, podname, session, return_code))
 
-        pil = ProcessInstanceList(values=ret)
-
-        return pil
+        return ret
 
     def _restart_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
         ret = []

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -173,19 +173,16 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
 
             n_running = sum(
                 1
-                for process in results.values
+                for process in results
                 if process.status_code == ProcessInstance.StatusCode.RUNNING
             )
             n_dead = sum(
                 1
-                for process in results.values
+                for process in results
                 if process.status_code == ProcessInstance.StatusCode.DEAD
             )
             n_session = len(
-                {
-                    process.process_description.metadata.session
-                    for process in results.values
-                }
+                {process.process_description.metadata.session for process in results}
             )
             self.opmon_publisher.publish(
                 message=ProcessStatus(
@@ -231,7 +228,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         )
 
     @abc.abstractmethod
-    def _boot_impl(self, br: BootRequest) -> ProcessInstance:
+    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -370,7 +367,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         )
 
     @abc.abstractmethod
-    def _ps_impl(self, q: ProcessQuery) -> ProcessInstanceList:
+    def _ps_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -378,44 +375,43 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.READ, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def ps(self, request: Request, context: ServicerContext) -> Response:
+    def ps(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
+        self.log.debug(f"{self.name} running ps")
+
         try:
             data = unpack_any(request.data, ProcessQuery)
         except UnpackingError as e:
             return unpack_error_response(self.__class__.__name__, str(e), request.token)
 
-        self.log.debug(f"{self.name} running ps")
-
         try:
-            resp = self._ps_impl(data)
-            return Response(
-                name=self.name,
-                token=None,
-                data=pack_to_any(resp),
-                flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-                children=[],
-            )
+            response = self._ps_impl(data)
         except NotImplementedError:
-            return Response(
+            return ProcessInstanceList(
                 name=self.name,
                 token=None,
-                data=pack_to_any(resp),
+                values=[],
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                children=[],
             )
+
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=response,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     # ORDER MATTERS!
     @broadcasted  # outer most wrapper 1st step
     @authentified_and_authorised(
         action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def flush(self, request: Request, context: ServicerContext) -> Response:
+    def flush(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
+        self.log.debug(f"{self.name} running flush")
+
         try:
             data = unpack_any(request.data, ProcessQuery)
         except UnpackingError as e:
             return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
-        self.log.debug(f"{self.name} running flush")
 
         ret = []
         for uuid in self._get_process_uid(data):
@@ -461,14 +457,11 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 del self.process_store[uuid]
                 ret += [pi]
 
-        pil = ProcessInstanceList(values=ret)
-
-        return Response(
+        return ProcessInstanceList(
             name=self.name,
             token=None,
-            data=pack_to_any(pil),
+            values=ret,
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-            children=[],
         )
 
     # ORDER MATTERS!

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -489,7 +489,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         return description
 
     @abc.abstractmethod
-    def _logs_impl(self, request_data: LogRequest) -> LogLines:
+    def _logs_impl(self, log_request: LogRequest) -> LogLines:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -497,15 +497,15 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.READ, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def logs(self, request: Request, context: ServicerContext) -> Response:
+    def logs(self, request: Request, context: ServicerContext) -> LogLines:
         """Fetch logs for a process.
 
         Args:
             request: The incoming request.
             context: The gRPC context (not used).
 
-        Yields:
-            Response objects containing log lines.
+        Returns:
+            A response containing log lines.
         """
         self.log.debug("Getting logs")
 
@@ -515,23 +515,21 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
             return unpack_error_response(self.__class__.__name__, str(e), request.token)
 
         try:
-            return Response(
-                name=self.name,
-                token=None,
-                data=pack_to_any(self._logs_impl(data)),
-                flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-                children=[],
-            )
+            response = self._logs_impl(data)
         except NotImplementedError:
-            return Response(
+            return LogLines(
                 name=self.name,
                 token=None,
-                data=None,
+                uuid=None,
+                lines=[],
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                children=[],
             )
 
-    def _ensure_one_process(self, uuids: [str], in_boot_request: bool = False) -> str:
+        return response
+
+    def _ensure_one_process(
+        self, uuids: list[str], in_boot_request: bool = False
+    ) -> str:
         if uuids == []:
             raise BadQuery("The process corresponding to the query doesn't exist")
         elif len(uuids) > 1:

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -21,7 +21,6 @@ from druncschema.process_manager_pb2 import (
 from druncschema.process_manager_pb2_grpc import ProcessManagerServicer
 from druncschema.request_response_pb2 import (
     Request,
-    Response,
     ResponseFlag,
 )
 from google.rpc import code_pb2
@@ -236,34 +235,33 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.CREATE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def boot(self, request: Request, context: ServicerContext) -> Response:
-        try:
-            data = unpack_any(request.data, BootRequest)
-        except UnpackingError as e:
-            return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
+    def boot(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
         self.log.debug(
             "{self.name} booting '{data.process_description.metadata.name}' "
             "from session '{data.process_description.metadata.session}'"
         )
 
         try:
+            data = unpack_any(request.data, BootRequest)
+        except UnpackingError as e:
+            return unpack_error_response(self.__class__.__name__, str(e), request.token)
+
+        try:
             response = self._boot_impl(data)
-            return Response(
-                name=self.name,
-                token=None,
-                data=pack_to_any(response),
-                flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-                children=[],
-            )
         except NotImplementedError:
-            return Response(
+            return ProcessInstanceList(
                 name=self.name,
                 token=None,
-                data=pack_to_any(response),
+                values=[],
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                children=[],
             )
+
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=[response],
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     @abc.abstractmethod
     def _terminate_impl(self) -> list[ProcessInstance]:

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -304,17 +304,12 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
     def restart(
-        self, request: Request, context: ServicerContext
+        self, request: ProcessQuery, context: ServicerContext
     ) -> ProcessInstanceList:
         self.log.debug(f"{self.name} running restart")
 
         try:
-            data = unpack_any(request.data, ProcessQuery)
-        except UnpackingError as e:
-            return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
-        try:
-            response = self._restart_impl(data)
+            response = self._restart_impl(request)
         except NotImplementedError:
             return ProcessInstanceList(
                 name=self.name,
@@ -373,16 +368,13 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.READ, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def ps(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
+    def ps(
+        self, request: ProcessQuery, context: ServicerContext
+    ) -> ProcessInstanceList:
         self.log.debug(f"{self.name} running ps")
 
         try:
-            data = unpack_any(request.data, ProcessQuery)
-        except UnpackingError as e:
-            return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
-        try:
-            response = self._ps_impl(data)
+            response = self._ps_impl(request)
         except NotImplementedError:
             return ProcessInstanceList(
                 name=self.name,

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -280,9 +280,8 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     def terminate(
         self, request: Request, context: ServicerContext
     ) -> ProcessInstanceList:
-        self.log.debug(f"{self.name} terminating")
+        self.log.debug(f"{self.name} running terminate")
 
-        # tototo
         try:
             response = self._terminate_impl()
         except NotImplementedError:
@@ -301,7 +300,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         )
 
     @abc.abstractmethod
-    def _restart_impl(self, q: ProcessQuery) -> ProcessInstanceList:
+    def _restart_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -309,31 +308,32 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def restart(self, request: Request, context: ServicerContext) -> Response:
+    def restart(
+        self, request: Request, context: ServicerContext
+    ) -> ProcessInstanceList:
+        self.log.debug(f"{self.name} running restart")
+
         try:
             data = unpack_any(request.data, ProcessQuery)
         except UnpackingError as e:
             return unpack_error_response(self.__class__.__name__, str(e), request.token)
 
-        self.log.debug(f"{self.name} running restart")
-
         try:
             response = self._restart_impl(data)
-            return Response(
-                name=self.name,
-                token=None,
-                data=pack_to_any(response),
-                flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-                children=[],
-            )
         except NotImplementedError:
-            return Response(
+            return ProcessInstanceList(
                 name=self.name,
                 token=None,
-                data=pack_to_any(response),
+                values=[],
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                children=[],
             )
+
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=response,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     @abc.abstractmethod
     def _kill_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
@@ -352,7 +352,6 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         except UnpackingError as e:
             return unpack_error_response(self.__class__.__name__, str(e), request.token)
 
-        # tototo
         try:
             response = self._kill_impl(data)
         except NotImplementedError:

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -5,7 +5,7 @@ import time
 
 from druncschema.authoriser_pb2 import ActionType, SystemType
 from druncschema.broadcast_pb2 import BroadcastType
-from druncschema.description_pb2 import CommandDescription, OldDescription
+from druncschema.description_pb2 import CommandDescription, Description
 from druncschema.opmon.process_manager_pb2 import ProcessStatus
 from druncschema.process_manager_pb2 import (
     BootRequest,
@@ -105,7 +105,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 name="describe",
                 data_type=["None"],
                 help="Describe self (return a list of commands, the type of endpoint, the name and session).",
-                return_type="description_pb2.OldDescription",
+                return_type="description_pb2.Description",
             ),
             CommandDescription(
                 name="kill",
@@ -475,26 +475,24 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.READ, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def describe(self, request: Request, context: ServicerContext) -> Response:
+    def describe(self, request: Request, context: ServicerContext) -> Description:
         self.log.debug(f"{self.name} running describe")
-        bd = self.describe_broadcast()
-        d = OldDescription(
+
+        description = Description(
             type="process_manager",
             name=self.name,
             info=self.configuration.log_path,
             session="no_session" if not self.session else self.session,
             commands=self.commands,
-        )
-        if bd:
-            d.broadcast.CopyFrom(pack_to_any(bd))
-
-        return Response(
-            name=self.name,
-            token=None,
-            data=pack_to_any(d),
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
             children=[],
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+            token=None,
         )
+
+        if broadcast_description := self.describe_broadcast():
+            description.broadcast.CopyFrom(pack_to_any(broadcast_description))
+
+        return description
 
     @abc.abstractmethod
     def _logs_impl(self, request_data: LogRequest) -> LogLines:

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -334,16 +334,13 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def kill(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
+    def kill(
+        self, request: ProcessQuery, context: ServicerContext
+    ) -> ProcessInstanceList:
         self.log.debug(f"{self.name} running kill")
 
         try:
-            data = unpack_any(request.data, ProcessQuery)
-        except UnpackingError as e:
-            return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
-        try:
-            response = self._kill_impl(data)
+            response = self._kill_impl(request)
         except NotImplementedError:
             return ProcessInstanceList(
                 name=self.name,
@@ -395,16 +392,13 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def flush(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
+    def flush(
+        self, request: ProcessQuery, context: ServicerContext
+    ) -> ProcessInstanceList:
         self.log.debug(f"{self.name} running flush")
 
-        try:
-            data = unpack_any(request.data, ProcessQuery)
-        except UnpackingError as e:
-            return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
         ret = []
-        for uuid in self._get_process_uid(data):
+        for uuid in self._get_process_uid(request):
             if uuid not in self.boot_request:
                 pu = ProcessUUID(uuid=uuid)
                 pi = ProcessInstance(
@@ -487,7 +481,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.READ, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def logs(self, request: Request, context: ServicerContext) -> LogLines:
+    def logs(self, request: LogRequest, context: ServicerContext) -> LogLines:
         """Fetch logs for a process.
 
         Args:
@@ -500,12 +494,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         self.log.debug("Getting logs")
 
         try:
-            data = unpack_any(request.data, LogRequest)
-        except UnpackingError as e:
-            return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
-        try:
-            response = self._logs_impl(data)
+            response = self._logs_impl(request)
         except NotImplementedError:
             return LogLines(
                 name=self.name,
@@ -542,7 +531,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         query: ProcessQuery,
         in_boot_request: bool = False,
         order_by: str = "random",
-    ) -> [str]:
+    ) -> list[str]:
         order_by = order_by.lower()
         if order_by not in ["random", "leaf_first", "root_first"]:
             raise DruncCommandException(f"Order by '{order_by}' is not supported")

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -39,10 +39,7 @@ from drunc.process_manager.configuration import (
 )
 from drunc.utils.configuration import ConfTypes
 from drunc.utils.grpc_utils import (
-    UnpackingError,
     pack_to_any,
-    unpack_any,
-    unpack_error_response,
 )
 from drunc.utils.utils import get_logger, pid_info_str
 
@@ -235,19 +232,16 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.CREATE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def boot(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
+    def boot(
+        self, request: BootRequest, context: ServicerContext
+    ) -> ProcessInstanceList:
         self.log.debug(
             "{self.name} booting '{data.process_description.metadata.name}' "
             "from session '{data.process_description.metadata.session}'"
         )
 
         try:
-            data = unpack_any(request.data, BootRequest)
-        except UnpackingError as e:
-            return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
-        try:
-            response = self._boot_impl(data)
+            response = self._boot_impl(request)
         except NotImplementedError:
             return ProcessInstanceList(
                 name=self.name,

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -224,7 +224,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         )
 
     @abc.abstractmethod
-    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
+    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -250,15 +250,10 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
             )
 
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=[response],
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-        )
+        return response
 
     @abc.abstractmethod
-    def _terminate_impl(self) -> list[ProcessInstance]:
+    def _terminate_impl(self) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -281,15 +276,10 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
             )
 
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=response,
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-        )
+        return response
 
     @abc.abstractmethod
-    def _restart_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+    def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -312,15 +302,10 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
             )
 
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=response,
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-        )
+        return response
 
     @abc.abstractmethod
-    def _kill_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+    def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -343,15 +328,10 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
             )
 
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=response,
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-        )
+        return response
 
     @abc.abstractmethod
-    def _ps_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+    def _ps_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -374,12 +354,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
             )
 
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=response,
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-        )
+        return response
 
     # ORDER MATTERS!
     @broadcasted  # outer most wrapper 1st step

--- a/src/drunc/process_manager/process_manager.py
+++ b/src/drunc/process_manager/process_manager.py
@@ -117,13 +117,13 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 name="restart",
                 data_type=["process_manager_pb2.ProcessQuery"],
                 help="Restart the process from the process query (which must correspond to one process).",
-                return_type="process_manager_pb2.ProcessInstance",
+                return_type="process_manager_pb2.ProcessInstanceList",
             ),
             CommandDescription(
                 name="boot",
                 data_type=["generic_pb2.BootRequest", "None"],
                 help="Start a process.",
-                return_type="process_manager_pb2.ProcessInstance",
+                return_type="process_manager_pb2.ProcessInstanceList",
             ),
             CommandDescription(
                 name="terminate",
@@ -147,7 +147,7 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
                 name="ps",
                 data_type=["process_manager_pb2.ProcessQuery"],
                 help="Get the status of the listed process from the process query input (can be multiple).",
-                return_type="process_manager_pb2.ProcessInstance",
+                return_type="process_manager_pb2.ProcessInstanceList",
             ),
         ]
 
@@ -251,12 +251,11 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         )
 
         try:
-            resp = self._boot_impl(data)
-
+            response = self._boot_impl(data)
             return Response(
                 name=self.name,
                 token=None,
-                data=pack_to_any(resp),
+                data=pack_to_any(response),
                 flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
                 children=[],
             )
@@ -264,13 +263,13 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
             return Response(
                 name=self.name,
                 token=None,
-                data=pack_to_any(resp),
+                data=pack_to_any(response),
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
                 children=[],
             )
 
     @abc.abstractmethod
-    def _terminate_impl(self) -> ProcessInstanceList:
+    def _terminate_impl(self) -> list[ProcessInstance]:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -278,25 +277,28 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def terminate(self, request: Request, context: ServicerContext) -> Response:
+    def terminate(
+        self, request: Request, context: ServicerContext
+    ) -> ProcessInstanceList:
         self.log.debug(f"{self.name} terminating")
+
+        # tototo
         try:
-            resp = self._terminate_impl()
-            return Response(
-                name=self.name,
-                token=None,
-                data=pack_to_any(resp),
-                flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-                children=[],
-            )
+            response = self._terminate_impl()
         except NotImplementedError:
-            return Response(
+            return ProcessInstanceList(
                 name=self.name,
                 token=None,
-                data=pack_to_any(resp),
+                values=[],
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                children=[],
             )
+
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=response,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     @abc.abstractmethod
     def _restart_impl(self, q: ProcessQuery) -> ProcessInstanceList:
@@ -316,11 +318,11 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
         self.log.debug(f"{self.name} running restart")
 
         try:
-            resp = self._restart_impl(data)
+            response = self._restart_impl(data)
             return Response(
                 name=self.name,
                 token=None,
-                data=pack_to_any(resp),
+                data=pack_to_any(response),
                 flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
                 children=[],
             )
@@ -328,13 +330,13 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
             return Response(
                 name=self.name,
                 token=None,
-                data=pack_to_any(resp),
+                data=pack_to_any(response),
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
                 children=[],
             )
 
     @abc.abstractmethod
-    def _kill_impl(self, q: ProcessQuery) -> ProcessInstanceList:
+    def _kill_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
         raise NotImplementedError
 
     # ORDER MATTERS!
@@ -342,31 +344,31 @@ class ProcessManager(abc.ABC, ProcessManagerServicer):
     @authentified_and_authorised(
         action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
     )  # 2nd step
-    def kill(self, request: Request, context: ServicerContext) -> Response:
+    def kill(self, request: Request, context: ServicerContext) -> ProcessInstanceList:
+        self.log.debug(f"{self.name} running kill")
+
         try:
             data = unpack_any(request.data, ProcessQuery)
         except UnpackingError as e:
             return unpack_error_response(self.__class__.__name__, str(e), request.token)
 
-        self.log.debug(f"{self.name} running kill")
-
+        # tototo
         try:
-            resp = self._kill_impl(data)
-            return Response(
-                name=self.name,
-                token=None,
-                data=pack_to_any(resp),
-                flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-                children=[],
-            )
+            response = self._kill_impl(data)
         except NotImplementedError:
-            return Response(
+            return ProcessInstanceList(
                 name=self.name,
                 token=None,
-                data=pack_to_any(resp),
+                values=[],
                 flag=ResponseFlag.NOT_EXECUTED_NOT_IMPLEMENTED,
-                children=[],
             )
+
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=response,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     @abc.abstractmethod
     def _ps_impl(self, q: ProcessQuery) -> ProcessInstanceList:

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -4,6 +4,7 @@ import os
 import signal
 import tempfile
 import time
+from collections.abc import Iterator
 from time import sleep
 
 from druncschema.description_pb2 import Description
@@ -12,7 +13,6 @@ from druncschema.process_manager_pb2 import (
     LogLines,
     LogRequest,
     ProcessDescription,
-    ProcessInstance,
     ProcessInstanceList,
     ProcessMetadata,
     ProcessQuery,
@@ -54,7 +54,7 @@ class ProcessManagerDriver(GRPCDriver):
         db,
         session_name: str,
         override_logs: bool,
-    ) -> BootRequest:
+    ) -> Iterator[BootRequest]:
         from drunc.process_manager.oks_parser import collect_apps, collect_infra_apps
 
         env = {
@@ -164,7 +164,7 @@ class ProcessManagerDriver(GRPCDriver):
             int | float
         ) = 0,  # This may be useful if you have are using SSHPM, and have SSHD's maxstartups setting set to a low value.
         **kwargs,
-    ) -> ProcessInstance:
+    ) -> Iterator[ProcessInstanceList]:
         from daqconf.consolidate import consolidate_db
 
         self.log.info(f"Booting session [green]{session_name}[/green]")
@@ -236,7 +236,7 @@ To debug it, close drunc and run the following command:
             yield self.send_command(
                 "boot",
                 data=br,
-                outformat=ProcessInstance,
+                outformat=ProcessInstanceList,
                 timeout=timeout,
             )
 
@@ -340,7 +340,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         sleep: int,
         n_sleeps: int,
         timeout: int | float = 60,
-    ):  # -> ProcessInstance:
+    ) -> Iterator[ProcessInstanceList]:
         pwd = os.getcwd()
 
         # Construct the list of commands to send to the dummy_boot process
@@ -381,7 +381,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             yield self.send_command(
                 "boot",
                 data=breq,
-                outformat=ProcessInstance,
+                outformat=ProcessInstanceList,
                 timeout=timeout,
             )
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -6,7 +6,7 @@ import tempfile
 import time
 from time import sleep
 
-from druncschema.description_pb2 import OldDescription
+from druncschema.description_pb2 import Description
 from druncschema.process_manager_pb2 import (
     BootRequest,
     LogLines,
@@ -437,9 +437,9 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             timeout=timeout,
         )
 
-    def describe(self, timeout: int | float = 60) -> OldDescription:
+    def describe(self, timeout: int | float = 60) -> Description:
         return self.send_command(
             "describe",
-            outformat=OldDescription,
+            outformat=Description,
             timeout=timeout,
         )

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -27,7 +27,7 @@ from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
 from drunc.controller.utils import get_segment_lookup_timeout
 from drunc.exceptions import DruncSetupException, DruncShellException
 from drunc.process_manager.utils import get_log_path, get_rte_script
-from drunc.utils.grpc_utils import copy_token
+from drunc.utils.grpc_utils import copy_token, handle_grpc_error
 from drunc.utils.shell_utils import GRPCDriver
 from drunc.utils.utils import (
     get_control_type_and_uri_from_connectivity_service,
@@ -238,7 +238,7 @@ To debug it, close drunc and run the following command:
             try:
                 response = self.stub.boot(request, timeout=timeout)
             except grpc.RpcError as e:
-                self.handle_grpc_error(e)
+                handle_grpc_error(e)
 
             yield response
 
@@ -384,7 +384,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             try:
                 response = self.stub.boot(request, timeout=timeout)
             except grpc.RpcError as e:
-                self.handle_grpc_error(e)
+                handle_grpc_error(e)
 
             yield response
 
@@ -397,7 +397,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         try:
             response = self.stub.terminate(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -409,7 +409,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         try:
             response = self.stub.kill(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -419,7 +419,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         try:
             response = self.stub.logs(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -431,7 +431,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         try:
             response = self.stub.ps(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -443,7 +443,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         try:
             response = self.stub.flush(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -455,7 +455,7 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         try:
             response = self.stub.restart(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -465,6 +465,6 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         try:
             response = self.stub.describe(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -390,7 +390,9 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         timeout: int | float = 60,
     ) -> ProcessInstanceList:
         return self.send_command(
-            "terminate", outformat=ProcessInstanceList, timeout=timeout
+            "terminate",
+            outformat=ProcessInstanceList,
+            timeout=timeout,
         )
 
     def kill(

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Iterator
 from time import sleep
 
+import grpc
 from druncschema.description_pb2 import Description
 from druncschema.process_manager_pb2 import (
     BootRequest,
@@ -19,12 +20,18 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
 )
 from druncschema.process_manager_pb2_grpc import ProcessManagerStub
+from druncschema.request_response_pb2 import Request
 
 from drunc.connectivity_service.client import ConnectivityServiceClient
 from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
 from drunc.controller.utils import get_segment_lookup_timeout
 from drunc.exceptions import DruncSetupException, DruncShellException
 from drunc.process_manager.utils import get_log_path, get_rte_script
+from drunc.utils.grpc_utils import (
+    copy_token,
+    rethrow_if_timeout,
+    rethrow_if_unreachable_server,
+)
 from drunc.utils.shell_utils import GRPCDriver
 from drunc.utils.utils import (
     get_control_type_and_uri_from_connectivity_service,
@@ -38,13 +45,10 @@ class ProcessManagerDriver(GRPCDriver):
     controller_address = ""
 
     def __init__(self, address: str, token, **kwargs):
-        super(ProcessManagerDriver, self).__init__(
-            name="process_manager.driver", address=address, token=token, **kwargs
+        super().__init__(
+            name="process_manager_driver", address=address, token=token, **kwargs
         )
-        self.log.debug("set up process_manager.driver")
-
-    def create_stub(self, channel):
-        return ProcessManagerStub(channel)
+        self.stub = ProcessManagerStub(self.channel)
 
     def _convert_oks_to_boot_request(
         self,
@@ -442,8 +446,14 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         )
 
     def describe(self, timeout: int | float = 60) -> Description:
-        return self.send_command(
-            "describe",
-            outformat=Description,
-            timeout=timeout,
-        )
+        token = copy_token(self.token)
+        request = Request(token=token)
+
+        try:
+            response = self.stub.describe(request, timeout=timeout)
+        except grpc.RpcError as e:
+            rethrow_if_unreachable_server(e)
+            rethrow_if_timeout(e)
+            raise e
+
+        return response

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -133,6 +133,7 @@ class ProcessManagerDriver(GRPCDriver):
 
             self.log.debug(f"{name}'s env:\n{env}")
             breq = BootRequest(
+                token=copy_token(self.token),
                 process_description=ProcessDescription(
                     metadata=ProcessMetadata(
                         user=user,
@@ -204,7 +205,7 @@ To debug it, close drunc and run the following command:
         last_boot_on_host_at = {}
         previous_host = None
 
-        for br in self._convert_oks_to_boot_request(
+        for request in self._convert_oks_to_boot_request(
             oks_conf=conf_file,
             user=user,
             session_dal=session_dal,
@@ -214,14 +215,14 @@ To debug it, close drunc and run the following command:
             **kwargs,
         ):
             if (
-                br.process_description.metadata.name
+                request.process_description.metadata.name
                 not in [app.id for app in session_dal.infrastructure_applications]
                 and csc
                 and not csc.is_ready(timeout=10)
             ):
                 raise DruncSetupException("Connectivity service is not ready in time")
 
-            this_host = next(iter(br.process_restriction.allowed_hosts))
+            this_host = next(iter(request.process_restriction.allowed_hosts))
 
             time_diff = time.time() - last_boot_on_host_at.get(this_host, 0)
 
@@ -233,12 +234,13 @@ To debug it, close drunc and run the following command:
 
             previous_host = this_host
             last_boot_on_host_at[this_host] = time.time()
-            yield self.send_command(
-                "boot",
-                data=br,
-                outformat=ProcessInstanceList,
-                timeout=timeout,
-            )
+
+            try:
+                response = self.stub.boot(request, timeout=timeout)
+            except grpc.RpcError as e:
+                self.handle_grpc_error(e)
+
+            yield response
 
         top_controller_name = session_dal.segment.controller.id
 
@@ -359,7 +361,8 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         )
 
         for process in range(n_processes):
-            breq = BootRequest(
+            request = BootRequest(
+                token=copy_token(self.token),
                 process_description=ProcessDescription(
                     metadata=ProcessMetadata(
                         user=user,
@@ -376,14 +379,14 @@ To find the controller address, you can look up \'{top_controller_name}_control\
                 ),
                 process_restriction=ProcessRestriction(allowed_hosts=["localhost"]),
             )
-            self.log.debug(f"{breq=}\n\n")
+            self.log.debug(f"{request=}\n\n")
 
-            yield self.send_command(
-                "boot",
-                data=breq,
-                outformat=ProcessInstanceList,
-                timeout=timeout,
-            )
+            try:
+                response = self.stub.boot(request, timeout=timeout)
+            except grpc.RpcError as e:
+                self.handle_grpc_error(e)
+
+            yield response
 
     def terminate(
         self,

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -393,7 +393,9 @@ To find the controller address, you can look up \'{top_controller_name}_control\
             "terminate", outformat=ProcessInstanceList, timeout=timeout
         )
 
-    def kill(self, query: ProcessQuery, timeout: int | float = 60) -> ProcessInstance:
+    def kill(
+        self, query: ProcessQuery, timeout: int | float = 60
+    ) -> ProcessInstanceList:
         return self.send_command(
             "kill",
             data=query,
@@ -429,11 +431,11 @@ To find the controller address, you can look up \'{top_controller_name}_control\
 
     def restart(
         self, query: ProcessQuery, timeout: int | float = 60
-    ) -> ProcessInstance:
+    ) -> ProcessInstanceList:
         return self.send_command(
             "restart",
             data=query,
-            outformat=ProcessInstance,
+            outformat=ProcessInstanceList,
             timeout=timeout,
         )
 

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -389,29 +389,36 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         self,
         timeout: int | float = 60,
     ) -> ProcessInstanceList:
-        return self.send_command(
-            "terminate",
-            outformat=ProcessInstanceList,
-            timeout=timeout,
-        )
+        request = Request(token=copy_token(self.token))
+
+        try:
+            response = self.stub.terminate(request, timeout=timeout)
+        except grpc.RpcError as e:
+            self.handle_grpc_error(e)
+
+        return response
 
     def kill(
         self, request: ProcessQuery, timeout: int | float = 60
     ) -> ProcessInstanceList:
-        return self.send_command(
-            "kill",
-            data=request,
-            outformat=ProcessInstanceList,
-            timeout=timeout,
-        )
+        request.token.CopyFrom(self.token)
+
+        try:
+            response = self.stub.kill(request, timeout=timeout)
+        except grpc.RpcError as e:
+            self.handle_grpc_error(e)
+
+        return response
 
     def logs(self, request: LogRequest, timeout: int | float = 60) -> LogLines:
-        return self.send_command(
-            "logs",
-            data=request,
-            outformat=LogLines,
-            timeout=timeout,
-        )
+        request.token.CopyFrom(self.token)
+
+        try:
+            response = self.stub.logs(request, timeout=timeout)
+        except grpc.RpcError as e:
+            self.handle_grpc_error(e)
+
+        return response
 
     def ps(
         self, request: ProcessQuery, timeout: int | float = 60

--- a/src/drunc/process_manager/process_manager_driver.py
+++ b/src/drunc/process_manager/process_manager_driver.py
@@ -27,11 +27,7 @@ from drunc.connectivity_service.exceptions import ApplicationLookupUnsuccessful
 from drunc.controller.utils import get_segment_lookup_timeout
 from drunc.exceptions import DruncSetupException, DruncShellException
 from drunc.process_manager.utils import get_log_path, get_rte_script
-from drunc.utils.grpc_utils import (
-    copy_token,
-    rethrow_if_timeout,
-    rethrow_if_unreachable_server,
-)
+from drunc.utils.grpc_utils import copy_token
 from drunc.utils.shell_utils import GRPCDriver
 from drunc.utils.utils import (
     get_control_type_and_uri_from_connectivity_service,
@@ -400,60 +396,65 @@ To find the controller address, you can look up \'{top_controller_name}_control\
         )
 
     def kill(
-        self, query: ProcessQuery, timeout: int | float = 60
+        self, request: ProcessQuery, timeout: int | float = 60
     ) -> ProcessInstanceList:
         return self.send_command(
             "kill",
-            data=query,
+            data=request,
             outformat=ProcessInstanceList,
             timeout=timeout,
         )
 
-    def logs(self, req: LogRequest, timeout: int | float = 60) -> LogLines:
+    def logs(self, request: LogRequest, timeout: int | float = 60) -> LogLines:
         return self.send_command(
             "logs",
-            data=req,
+            data=request,
             outformat=LogLines,
             timeout=timeout,
         )
 
-    def ps(self, query: ProcessQuery, timeout: int | float = 60) -> ProcessInstanceList:
-        return self.send_command(
-            "ps",
-            data=query,
-            outformat=ProcessInstanceList,
-            timeout=timeout,
-        )
+    def ps(
+        self, request: ProcessQuery, timeout: int | float = 60
+    ) -> ProcessInstanceList:
+        request.token.CopyFrom(self.token)
+
+        try:
+            response = self.stub.ps(request, timeout=timeout)
+        except grpc.RpcError as e:
+            self.handle_grpc_error(e)
+
+        return response
 
     def flush(
-        self, query: ProcessQuery, timeout: int | float = 60
+        self, request: ProcessQuery, timeout: int | float = 60
     ) -> ProcessInstanceList:
-        return self.send_command(
-            "flush",
-            data=query,
-            outformat=ProcessInstanceList,
-            timeout=timeout,
-        )
+        request.token.CopyFrom(self.token)
+
+        try:
+            response = self.stub.flush(request, timeout=timeout)
+        except grpc.RpcError as e:
+            self.handle_grpc_error(e)
+
+        return response
 
     def restart(
-        self, query: ProcessQuery, timeout: int | float = 60
+        self, request: ProcessQuery, timeout: int | float = 60
     ) -> ProcessInstanceList:
-        return self.send_command(
-            "restart",
-            data=query,
-            outformat=ProcessInstanceList,
-            timeout=timeout,
-        )
+        request.token.CopyFrom(self.token)
+
+        try:
+            response = self.stub.restart(request, timeout=timeout)
+        except grpc.RpcError as e:
+            self.handle_grpc_error(e)
+
+        return response
 
     def describe(self, timeout: int | float = 60) -> Description:
-        token = copy_token(self.token)
-        request = Request(token=token)
+        request = Request(token=copy_token(self.token))
 
         try:
             response = self.stub.describe(request, timeout=timeout)
         except grpc.RpcError as e:
-            rethrow_if_unreachable_server(e)
-            rethrow_if_timeout(e)
-            raise e
+            self.handle_grpc_error(e)
 
         return response

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -71,7 +71,7 @@ class SSHProcessManager(ProcessManager):
 
         self.ssh = sh.Command("/usr/bin/ssh")
 
-    def kill_processes(self, uuids: list) -> ProcessInstanceList:
+    def kill_processes(self, uuids: list) -> list[ProcessInstance]:
         ret = []
         for proc_uuid in uuids:
             process = self.process_store[proc_uuid]
@@ -117,11 +117,11 @@ class SSHProcessManager(ProcessManager):
             ]
             del self.process_store[proc_uuid]
 
-        pil = ProcessInstanceList(values=ret)
-        return pil
+        return ret
 
-    def _terminate_impl(self) -> ProcessInstanceList:
+    def _terminate_impl(self) -> list[ProcessInstance]:
         self.log.info("Terminating")
+
         if self.process_store:
             self.log.info("Killing all the known processes before exiting")
             uuids = self._get_process_uid(
@@ -130,7 +130,7 @@ class SSHProcessManager(ProcessManager):
             return self.kill_processes(uuids)
         else:
             self.log.info("No known process to kill before exiting")
-            return ProcessInstanceList()
+            return []
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         self.log.debug(f"Retrieving logs for {log_request.query}")
@@ -178,7 +178,8 @@ class SSHProcessManager(ProcessManager):
         except Exception as e:
             if uid not in self.process_store:
                 return LogLines(
-                    uuid=ProcessUUID(uuid=uid), lines=[f"Could not retrieve logs: {e!s}"]
+                    uuid=ProcessUUID(uuid=uid),
+                    lines=[f"Could not retrieve logs: {e!s}"],
                 )
             else:
                 return LogLines(
@@ -186,7 +187,7 @@ class SSHProcessManager(ProcessManager):
                     lines=[
                         f"Could not retrieve logs: {e!s}",
                         f"stdout: {self.process_store[uid].stdout}",
-                        f"stderr: {self.process_store[uid].stderr}"
+                        f"stderr: {self.process_store[uid].stderr}",
                     ],
                 )
 
@@ -435,11 +436,12 @@ class SSHProcessManager(ProcessManager):
 
         return ret
 
-    def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+    def _kill_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
         self.log.info(f"{self.name} killing {query.names} in session {self.session}")
+
         if self.process_store:
             uuids = self._get_process_uid(query, order_by="leaf_first")
             return self.kill_processes(uuids)
         else:
             self.log.info("No known process to kill before exiting")
-            return ProcessInstanceList()
+            return []

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -14,6 +14,7 @@ from druncschema.process_manager_pb2 import (
     LogRequest,
     ProcessDescription,
     ProcessInstance,
+    ProcessInstanceList,
     ProcessQuery,
     ProcessRestriction,
     ProcessUUID,
@@ -119,7 +120,7 @@ class SSHProcessManager(ProcessManager):
 
         return ret
 
-    def _terminate_impl(self) -> list[ProcessInstance]:
+    def _terminate_impl(self) -> ProcessInstanceList:
         self.log.info("Terminating")
 
         if self.process_store:
@@ -127,10 +128,17 @@ class SSHProcessManager(ProcessManager):
             uuids = self._get_process_uid(
                 query=ProcessQuery(names=[".*"]), order_by="leaf_first"
             )
-            return self.kill_processes(uuids)
+            processes = self.kill_processes(uuids)
         else:
             self.log.info("No known process to kill before exiting")
-            return []
+            processes = []
+
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=processes,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         self.log.debug(f"Retrieving logs for {log_request.query}")
@@ -369,7 +377,7 @@ class SSHProcessManager(ProcessManager):
 
         return pi
 
-    def _ps_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+    def _ps_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         ret = []
 
         for proc_uuid in self._get_process_uid(query):
@@ -409,19 +417,29 @@ class SSHProcessManager(ProcessManager):
             )
             ret += [pi]
 
-        return ret
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=ret,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
-    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
+    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstanceList:
         self.log.debug(f"{self.name} running boot command")
         this_uuid = str(uuid.uuid4())
-        return self.__boot(boot_request, this_uuid)
+        process = self.__boot(boot_request, this_uuid)
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=[process],
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
-    def _restart_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+    def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         self.log.info(f"{self.name} restarting {query.names} in session {self.session}")
         uuids = self._get_process_uid(query, in_boot_request=True)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
 
-        same_uuid_br = []
         same_uuid_br = BootRequest()
         same_uuid_br.CopyFrom(self.boot_request[uuid])
         same_uuid = uuid
@@ -440,14 +458,26 @@ class SSHProcessManager(ProcessManager):
         del same_uuid_br
         del same_uuid
 
-        return ret
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=ret,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
-    def _kill_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
+    def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         self.log.info(f"{self.name} killing {query.names} in session {self.session}")
 
         if self.process_store:
             uuids = self._get_process_uid(query, order_by="leaf_first")
-            return self.kill_processes(uuids)
+            processes = self.kill_processes(uuids)
         else:
             self.log.info("No known process to kill before exiting")
-            return []
+            processes = []
+
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=processes,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -14,7 +14,6 @@ from druncschema.process_manager_pb2 import (
     LogRequest,
     ProcessDescription,
     ProcessInstance,
-    ProcessInstanceList,
     ProcessQuery,
     ProcessRestriction,
     ProcessUUID,
@@ -361,7 +360,7 @@ class SSHProcessManager(ProcessManager):
 
         return pi
 
-    def _ps_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+    def _ps_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
         ret = []
 
         for proc_uuid in self._get_process_uid(query):
@@ -401,9 +400,7 @@ class SSHProcessManager(ProcessManager):
             )
             ret += [pi]
 
-        pil = ProcessInstanceList(values=ret)
-
-        return pil
+        return ret
 
     def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
         self.log.debug(f"{self.name} running _boot_impl")

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -18,6 +18,7 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
     ProcessUUID,
 )
+from druncschema.request_response_pb2 import ResponseFlag
 
 from drunc.exceptions import DruncCommandException
 from drunc.process_manager.process_manager import ProcessManager
@@ -175,27 +176,35 @@ class SSHProcessManager(ProcessManager):
                 _err_to_out=True,
             )
         except Exception as e:
-            if uid not in self.process_store:
-                return LogLines(
-                    uuid=ProcessUUID(uuid=uid),
-                    lines=[f"Could not retrieve logs: {e!s}"],
-                )
-            else:
-                return LogLines(
-                    uuid=ProcessUUID(uuid=uid),
-                    lines=[
-                        f"Could not retrieve logs: {e!s}",
+            lines = [f"Could not retrieve logs: {e!s}"]
+            if uid in self.process_store:
+                lines.extend(
+                    [
                         f"stdout: {self.process_store[uid].stdout}",
                         f"stderr: {self.process_store[uid].stderr}",
-                    ],
+                    ]
                 )
+
+            return LogLines(
+                name=self.name,
+                token=None,
+                uuid=ProcessUUID(uuid=uid),
+                lines=lines,
+                flag=ResponseFlag.UNHANDLED_EXCEPTION_THROWN,
+            )
 
         f.close()
         with open(f.name) as fi:
             lines = fi.readlines()
             if "Connection to " in lines[-1] and " closed." in lines[-1]:
                 lines = lines[:-1]
-            return LogLines(uuid=ProcessUUID(uuid=uid), lines=lines)
+            return LogLines(
+                name=self.name,
+                token=None,
+                uuid=ProcessUUID(uuid=uid),
+                lines=lines,
+                flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+            )
 
         os.remove(f.name)
 

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -72,7 +72,7 @@ class SSHProcessManager(ProcessManager):
 
         self.ssh = sh.Command("/usr/bin/ssh")
 
-    def kill_processes(self, uuids: list) -> list[ProcessInstance]:
+    def kill_processes(self, uuids: list) -> ProcessInstanceList:
         ret = []
         for proc_uuid in uuids:
             process = self.process_store[proc_uuid]
@@ -118,7 +118,12 @@ class SSHProcessManager(ProcessManager):
             ]
             del self.process_store[proc_uuid]
 
-        return ret
+        return ProcessInstanceList(
+            name=self.name,
+            token=None,
+            values=ret,
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        )
 
     def _terminate_impl(self) -> ProcessInstanceList:
         self.log.info("Terminating")
@@ -128,15 +133,13 @@ class SSHProcessManager(ProcessManager):
             uuids = self._get_process_uid(
                 query=ProcessQuery(names=[".*"]), order_by="leaf_first"
             )
-            processes = self.kill_processes(uuids)
-        else:
-            self.log.info("No known process to kill before exiting")
-            processes = []
+            return self.kill_processes(uuids)
 
+        self.log.info("No known process to kill before exiting")
         return ProcessInstanceList(
             name=self.name,
             token=None,
-            values=processes,
+            values=[],
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
         )
 
@@ -470,14 +473,12 @@ class SSHProcessManager(ProcessManager):
 
         if self.process_store:
             uuids = self._get_process_uid(query, order_by="leaf_first")
-            processes = self.kill_processes(uuids)
-        else:
-            self.log.info("No known process to kill before exiting")
-            processes = []
+            return self.kill_processes(uuids)
 
+        self.log.info("No known process to kill before exiting")
         return ProcessInstanceList(
             name=self.name,
             token=None,
-            values=processes,
+            values=[],
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
         )

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -412,7 +412,7 @@ class SSHProcessManager(ProcessManager):
         return ret
 
     def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
-        self.log.debug(f"{self.name} running _boot_impl")
+        self.log.debug(f"{self.name} running boot command")
         this_uuid = str(uuid.uuid4())
         return self.__boot(boot_request, this_uuid)
 

--- a/src/drunc/process_manager/ssh_process_manager.py
+++ b/src/drunc/process_manager/ssh_process_manager.py
@@ -410,7 +410,7 @@ class SSHProcessManager(ProcessManager):
         this_uuid = str(uuid.uuid4())
         return self.__boot(boot_request, this_uuid)
 
-    def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+    def _restart_impl(self, query: ProcessQuery) -> list[ProcessInstance]:
         self.log.info(f"{self.name} restarting {query.names} in session {self.session}")
         uuids = self._get_process_uid(query, in_boot_request=True)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
@@ -429,7 +429,7 @@ class SSHProcessManager(ProcessManager):
         del self.boot_request[uuid]
         del uuid
 
-        ret = self.__boot(same_uuid_br, same_uuid)
+        ret = [self.__boot(same_uuid_br, same_uuid)]
 
         del same_uuid_br
         del same_uuid

--- a/src/drunc/session_manager/session_manager.py
+++ b/src/drunc/session_manager/session_manager.py
@@ -82,7 +82,6 @@ class SessionManager(abc.ABC, SessionManagerServicer):
         return Description(
             type="session_manager",
             name=self.name,
-            session=self.name,
             commands=commands,
             children=[],
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -6,7 +6,7 @@ from druncschema.session_manager_pb2_grpc import SessionManagerStub
 from druncschema.token_pb2 import Token
 from grpc import Channel
 
-from drunc.utils.shell_utils import DecodedResponse, GRPCDriver
+from drunc.utils.shell_utils import GRPCDriver
 
 
 class SessionManagerDriver(GRPCDriver):
@@ -39,7 +39,7 @@ class SessionManagerDriver(GRPCDriver):
         """
         return SessionManagerStub(channel)
 
-    def describe(self) -> DecodedResponse | None:
+    def describe(self) -> Description:
         """Describe the session manager service.
 
         Returns:
@@ -47,7 +47,7 @@ class SessionManagerDriver(GRPCDriver):
         """
         return self.send_command("describe", outformat=Description)
 
-    def list_all_sessions(self) -> DecodedResponse | None:
+    def list_all_sessions(self) -> AllActiveSessions:
         """List all active sessions managed by the session manager.
 
         Returns:
@@ -55,7 +55,7 @@ class SessionManagerDriver(GRPCDriver):
         """
         return self.send_command("list_all_sessions", outformat=AllActiveSessions)
 
-    def list_all_configs(self) -> DecodedResponse | None:
+    def list_all_configs(self) -> AllConfigKeys:
         """List all available configurations in the session manager.
 
         Returns:

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -40,13 +40,12 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing the description of the service.
         """
-        token = copy_token(self.token)
-        request = Request(token=token)
+        request = Request(token=copy_token(self.token))
 
         try:
             response = self.stub.describe(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.__handle_grpc_error(e, "describe")
+            self.handle_grpc_error(e)
 
         return response
 
@@ -59,13 +58,12 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing a list of all active sessions.
         """
-        token = copy_token(self.token)
-        request = Request(token=token)
+        request = Request(token=copy_token(self.token))
 
         try:
             response = self.stub.list_all_sessions(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.__handle_grpc_error(e, "list_all_sessions")
+            self.handle_grpc_error(e)
 
         return response
 
@@ -78,12 +76,11 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing all available configuration keys.
         """
-        token = copy_token(self.token)
-        request = Request(token=token)
+        request = Request(token=copy_token(self.token))
 
         try:
             response = self.stub.list_all_configs(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.__handle_grpc_error(e, "list_all_configs")
+            self.handle_grpc_error(e)
 
         return response

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -1,10 +1,11 @@
 """Driver for the session manager service."""
 
+import grpc
 from druncschema.description_pb2 import Description
 from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
 from druncschema.token_pb2 import Token
-from grpc import Channel
+from google.protobuf.empty_pb2 import Empty
 
 from drunc.utils.shell_utils import GRPCDriver
 
@@ -27,17 +28,9 @@ class SessionManagerDriver(GRPCDriver):
         super().__init__(
             name="session_manager_driver", address=address, token=token, **kwargs
         )
-
-    def create_stub(self, channel: Channel) -> SessionManagerStub:
-        """Create gRPC stubs for the session manager service.
-
-        Args:
-            channel: The gRPC channel to use for communication.
-
-        Returns:
-            An object containing session manager service method stubs.
-        """
-        return SessionManagerStub(channel)
+        self.address = address
+        self.channel = grpc.insecure_channel(self.address)
+        self.stub = SessionManagerStub(self.channel)
 
     def describe(self) -> Description:
         """Describe the session manager service.
@@ -45,7 +38,13 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing the description of the service.
         """
-        return self.send_command("describe", outformat=Description)
+
+        try:
+            response = self.stub.describe(Empty())
+        except grpc.RpcError as e:
+            self.__handle_grpc_error(e, "describe")
+
+        return response
 
     def list_all_sessions(self) -> AllActiveSessions:
         """List all active sessions managed by the session manager.
@@ -53,7 +52,13 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing a list of all active sessions.
         """
-        return self.send_command("list_all_sessions", outformat=AllActiveSessions)
+
+        try:
+            response = self.stub.list_all_sessions(Empty())
+        except grpc.RpcError as e:
+            self.__handle_grpc_error(e, "list_all_sessions")
+
+        return response
 
     def list_all_configs(self) -> AllConfigKeys:
         """List all available configurations in the session manager.
@@ -61,4 +66,10 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing all available configuration keys.
         """
-        return self.send_command("list_all_configs", outformat=AllConfigKeys)
+
+        try:
+            response = self.stub.list_all_configs(Empty())
+        except grpc.RpcError as e:
+            self.__handle_grpc_error(e, "list_all_configs")
+
+        return response

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -7,7 +7,7 @@ from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
 from druncschema.token_pb2 import Token
 
-from drunc.utils.grpc_utils import copy_token
+from drunc.utils.grpc_utils import copy_token, handle_grpc_error
 from drunc.utils.shell_utils import GRPCDriver
 
 
@@ -45,7 +45,7 @@ class SessionManagerDriver(GRPCDriver):
         try:
             response = self.stub.describe(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -63,7 +63,7 @@ class SessionManagerDriver(GRPCDriver):
         try:
             response = self.stub.list_all_sessions(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response
 
@@ -81,6 +81,6 @@ class SessionManagerDriver(GRPCDriver):
         try:
             response = self.stub.list_all_configs(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         return response

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -32,43 +32,52 @@ class SessionManagerDriver(GRPCDriver):
         self.channel = grpc.insecure_channel(self.address)
         self.stub = SessionManagerStub(self.channel)
 
-    def describe(self) -> Description:
+    def describe(self, timeout: int | float = 60) -> Description:
         """Describe the session manager service.
+
+        Args:
+            timeout: The timeout for the gRPC call in seconds.
 
         Returns:
             A response containing the description of the service.
         """
 
         try:
-            response = self.stub.describe(Empty())
+            response = self.stub.describe(Empty(), timeout=timeout)
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, "describe")
 
         return response
 
-    def list_all_sessions(self) -> AllActiveSessions:
+    def list_all_sessions(self, timeout: int | float = 60) -> AllActiveSessions:
         """List all active sessions managed by the session manager.
+
+        Args:
+            timeout: The timeout for the gRPC call in seconds.
 
         Returns:
             A response containing a list of all active sessions.
         """
 
         try:
-            response = self.stub.list_all_sessions(Empty())
+            response = self.stub.list_all_sessions(Empty(), timeout=timeout)
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, "list_all_sessions")
 
         return response
 
-    def list_all_configs(self) -> AllConfigKeys:
+    def list_all_configs(self, timeout: int | float = 60) -> AllConfigKeys:
         """List all available configurations in the session manager.
+
+        Args:
+            timeout: The timeout for the gRPC call in seconds.
 
         Returns:
             A response containing all available configuration keys.
         """
 
         try:
-            response = self.stub.list_all_configs(Empty())
+            response = self.stub.list_all_configs(Empty(), timeout=timeout)
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, "list_all_configs")
 

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -2,11 +2,12 @@
 
 import grpc
 from druncschema.description_pb2 import Description
+from druncschema.request_response_pb2 import Request
 from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 from druncschema.session_manager_pb2_grpc import SessionManagerStub
 from druncschema.token_pb2 import Token
-from google.protobuf.empty_pb2 import Empty
 
+from drunc.utils.grpc_utils import copy_token
 from drunc.utils.shell_utils import GRPCDriver
 
 
@@ -39,9 +40,11 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing the description of the service.
         """
+        token = copy_token(self.token)
+        request = Request(token=token)
 
         try:
-            response = self.stub.describe(Empty(), timeout=timeout)
+            response = self.stub.describe(request, timeout=timeout)
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, "describe")
 
@@ -56,9 +59,11 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing a list of all active sessions.
         """
+        token = copy_token(self.token)
+        request = Request(token=token)
 
         try:
-            response = self.stub.list_all_sessions(Empty(), timeout=timeout)
+            response = self.stub.list_all_sessions(request, timeout=timeout)
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, "list_all_sessions")
 
@@ -73,9 +78,11 @@ class SessionManagerDriver(GRPCDriver):
         Returns:
             A response containing all available configuration keys.
         """
+        token = copy_token(self.token)
+        request = Request(token=token)
 
         try:
-            response = self.stub.list_all_configs(Empty(), timeout=timeout)
+            response = self.stub.list_all_configs(request, timeout=timeout)
         except grpc.RpcError as e:
             self.__handle_grpc_error(e, "list_all_configs")
 

--- a/src/drunc/session_manager/session_manager_driver.py
+++ b/src/drunc/session_manager/session_manager_driver.py
@@ -28,8 +28,6 @@ class SessionManagerDriver(GRPCDriver):
         super().__init__(
             name="session_manager_driver", address=address, token=token, **kwargs
         )
-        self.address = address
-        self.channel = grpc.insecure_channel(self.address)
         self.stub = SessionManagerStub(self.channel)
 
     def describe(self, timeout: int | float = 60) -> Description:

--- a/src/drunc/unified_shell/commands.py
+++ b/src/drunc/unified_shell/commands.py
@@ -30,9 +30,9 @@ def boot(
         ProcessQuery(user=user, session=session_name)
     )
 
-    if len(processes.data.values) > 0:
+    if len(processes.values) > 0:
         click.confirm(
-            f"You already have {len(processes.data.values)} processes running in session {session_name}, are you sure you want to boot a session?",
+            f"You already have {len(processes.values)} processes running in session {session_name}, are you sure you want to boot a session?",
             abort=True,
         )
 

--- a/src/drunc/unified_shell/commands.py
+++ b/src/drunc/unified_shell/commands.py
@@ -50,7 +50,7 @@ def boot(
             if not result:
                 break
             log.debug(
-                f"'{result.data.process_description.metadata.name}' ({result.data.uuid.uuid}) started"
+                f"'{result.values[0].process_description.metadata.name}' ({result.values[0].uuid.uuid}) started"
             )
     except InterruptedCommand:
         log.warning("Booting interrupted")

--- a/src/drunc/unified_shell/shell.py
+++ b/src/drunc/unified_shell/shell.py
@@ -118,8 +118,7 @@ def unified_shell(
     ctx.obj.session_name = session_name
 
     db = conffwk.Configuration(ctx.obj.configuration_file)
-    session_dal = db.get_dal(class_name="Session",
-                             uid=ctx.obj.configuration_id)
+    session_dal = db.get_dal(class_name="Session", uid=ctx.obj.configuration_id)
     app_log_path = session_dal.log_path
 
     connectivity_service_address = f"{session_dal.connectivity_service.host}:{session_dal.connectivity_service.service.port}"
@@ -133,8 +132,7 @@ def unified_shell(
             f"Spawning [green]process_manager[/green] with configuration {process_manager}"
         )
         # Check if process_manager is a packaged config
-        process_manager_conf_file = get_process_manager_configuration(
-            process_manager)
+        process_manager_conf_file = get_process_manager_configuration(process_manager)
 
         ready_event = mp.Event()
         port = mp.Value("i", 0)
@@ -189,7 +187,6 @@ def unified_shell(
         unified_shell_log.debug("Runnning [green]describe[/green]")
         try:
             desc = ctx.obj.get_driver().describe()
-            desc = desc.data
         except Exception as e:
             unified_shell_log.error(
                 f"[red]Could not connect to the process manager at the address[/red] [green]{process_manager_address}[/]"
@@ -279,12 +276,10 @@ def unified_shell(
     # Let's do this
     unified_shell_log.debug("Retrieving the session database")
     db = conffwk.Configuration(ctx.obj.configuration_file)
-    session_dal = db.get_dal(class_name="Session",
-                             uid=ctx.obj.configuration_id)
+    session_dal = db.get_dal(class_name="Session", uid=ctx.obj.configuration_id)
 
     controller_name = session_dal.segment.controller.id
-    unified_shell_log.debug(
-        "Initializing the [green]ControllerConfHandler[/green]")
+    unified_shell_log.debug("Initializing the [green]ControllerConfHandler[/green]")
     controller_configuration = ControllerConfHandler(
         type=ConfTypes.OKSFileName,
         data=ctx.obj.configuration_file,
@@ -309,16 +304,12 @@ def unified_shell(
     )
 
     unified_shell_log.debug("Initializing the [green]StatefulNode[/green]")
-    stateful_node = StatefulNode(
-        fsm_configuration=fsmch,
-        top_segment_controller=False
-    )
+    stateful_node = StatefulNode(fsm_configuration=fsmch, top_segment_controller=False)
 
     unified_shell_log.debug(
         "Retrieving the transitions from the [green]StatefulNode[/green]"
     )
-    transitions = convert_fsm_transition(
-        stateful_node.get_all_fsm_transitions())
+    transitions = convert_fsm_transition(stateful_node.get_all_fsm_transitions())
     fsm_logger.setLevel(log_level)
     fsm_conf_logger.setLevel(log_level)
     # End of shameful code

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -1,4 +1,3 @@
-
 import grpc
 from druncschema.generic_pb2 import PlainText
 from druncschema.request_response_pb2 import Response, ResponseFlag
@@ -98,3 +97,17 @@ def interrupt_if_unreachable_server(grpc_error):
             return grpc_error._state.details
         elif hasattr(grpc_error, "_details"):
             return grpc_error._details
+
+
+def copy_token(token: Token) -> Token:
+    """Create a copy of the original token.
+
+    Args:
+        token: The original token to copy.
+
+    Returns:
+        A copy of the original token.
+    """
+    token_copy = Token()
+    token_copy.CopyFrom(token)
+    return token_copy

--- a/src/drunc/utils/grpc_utils.py
+++ b/src/drunc/utils/grpc_utils.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 import grpc
 from druncschema.generic_pb2 import PlainText
 from druncschema.request_response_pb2 import Response, ResponseFlag
@@ -89,6 +91,17 @@ def rethrow_if_timeout(grpc_error):
     if hasattr(grpc_error, "_state"):
         if grpc_error._state.code == grpc.StatusCode.DEADLINE_EXCEEDED:
             raise ServerTimeout(grpc_error._state.details) from grpc_error
+
+
+def handle_grpc_error(error: grpc.RpcError) -> NoReturn:
+    """Handle gRPC errors by rethrowing them with appropriate context.
+
+    Args:
+        error: The gRPC error to handle.
+    """
+    rethrow_if_unreachable_server(error)
+    rethrow_if_timeout(error)
+    raise error
 
 
 def interrupt_if_unreachable_server(grpc_error):

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -111,7 +111,7 @@ class GRPCDriver:
         else:
             return Request(token=token2)
 
-    def __handle_grpc_error(self, error, command):
+    def handle_grpc_error(self, error):
         rethrow_if_unreachable_server(error)
         rethrow_if_timeout(error)
         raise error
@@ -207,7 +207,7 @@ class GRPCDriver:
         try:
             response = cmd(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.__handle_grpc_error(e, command)
+            self.handle_grpc_error(e)
 
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
         from druncschema.description_pb2 import Description

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -15,12 +15,7 @@ from drunc.exceptions import (
     DruncSetupException,
     DruncShellException,
 )
-from drunc.utils.grpc_utils import (
-    UnpackingError,
-    rethrow_if_timeout,
-    rethrow_if_unreachable_server,
-    unpack_any,
-)
+from drunc.utils.grpc_utils import UnpackingError, handle_grpc_error, unpack_any
 from drunc.utils.utils import get_logger
 
 
@@ -111,11 +106,6 @@ class GRPCDriver:
         else:
             return Request(token=token2)
 
-    def handle_grpc_error(self, error):
-        rethrow_if_unreachable_server(error)
-        rethrow_if_timeout(error)
-        raise error
-
     def handle_response(self, response, command, outformat):
         dr = DecodedResponse(
             name=response.name,
@@ -193,7 +183,7 @@ class GRPCDriver:
         try:
             response = cmd(request, timeout=timeout)
         except grpc.RpcError as e:
-            self.handle_grpc_error(e)
+            handle_grpc_error(e)
 
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
         from druncschema.description_pb2 import Description

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -131,15 +131,6 @@ class GRPCDriver:
                     self.log.error(f"Error unpacking data: {e}")
                     dr.data = response.data
 
-            for c_response in response.children:
-                try:
-                    dr.children.append(
-                        self.handle_response(c_response, command, outformat)
-                    )
-                except DruncServerSideError as e:
-                    self.log.error(f"Exception thrown from child: {e}")
-            return dr
-
         else:
 
             def text(verb="not executed", reason=""):
@@ -154,7 +145,6 @@ class GRPCDriver:
             if response.data.Is(Stacktrace.DESCRIPTOR):
                 stack = unpack_any(response.data, Stacktrace)
                 dr.data = stack
-                # stack_txt = 'Stacktrace [bold red]on remote server![/bold red]\n' # Temporary - bold doesn't work
                 stack_txt = "Stacktrace on remote server!\n"
                 last_one = ""
 
@@ -180,14 +170,13 @@ class GRPCDriver:
             else:
                 self.log.error(text("failed", error_txt))
 
-            for c_response in response.children:
-                try:
-                    dr.children.append(
-                        self.handle_response(c_response, command, outformat)
-                    )
-                except DruncServerSideError as e:
-                    self.log.error(f"Exception thrown from child: {e}")
-            return dr
+        for c_response in response.children:
+            try:
+                dr.children.append(self.handle_response(c_response, command, outformat))
+            except DruncServerSideError as e:
+                self.log.error(f"Exception thrown from child: {e}")
+
+        return dr
 
     def send_command(
         self,
@@ -197,9 +186,6 @@ class GRPCDriver:
         decode_children=False,
         timeout: int | float = 60,
     ):
-        if not self.stub:
-            raise DruncShellException("No stub initialised")
-
         cmd = getattr(self.stub, command)  # this throws if the command doesn't exist
 
         request = self._create_request(data)

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -94,15 +94,10 @@ class GRPCDriver:
                 f"You need to provide a valid IP address for the driver. Provided '{address}'"
             )
 
-        self._address = address
-        self._channel = grpc.insecure_channel(self._address)
-        self._stub = self.create_stub(self._channel)
+        self.address = address
+        self.channel = grpc.insecure_channel(self.address)
         self.token = Token()
         self.token.CopyFrom(token)
-
-    @abc.abstractmethod
-    def create_stub(self, channel) -> object:
-        pass
 
     def _create_request(self, payload=None) -> Request:
         token2 = Token()
@@ -202,10 +197,10 @@ class GRPCDriver:
         decode_children=False,
         timeout: int | float = 60,
     ):
-        if not self._stub:
+        if not self.stub:
             raise DruncShellException("No stub initialised")
 
-        cmd = getattr(self._stub, command)  # this throws if the command doesn't exist
+        cmd = getattr(self.stub, command)  # this throws if the command doesn't exist
 
         request = self._create_request(data)
 
@@ -217,12 +212,9 @@ class GRPCDriver:
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
         from druncschema.description_pb2 import Description
         from druncschema.process_manager_pb2 import ProcessInstanceList
-        from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 
         new_message_types = (
             Description,
-            AllActiveSessions,
-            AllConfigKeys,
             ProcessInstanceList,
         )
 

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -221,12 +221,14 @@ class GRPCDriver:
 
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
         from druncschema.description_pb2 import Description
+        from druncschema.process_manager_pb2 import ProcessInstanceList
         from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 
         new_message_types = (
             Description,
             AllActiveSessions,
             AllConfigKeys,
+            ProcessInstanceList,
         )
 
         if isinstance(response, new_message_types):

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -94,14 +94,9 @@ class GRPCDriver:
                 f"You need to provide a valid IP address for the driver. Provided '{address}'"
             )
 
-        self.address = address
-
-        if aio_channel:
-            self.channel = grpc.aio.insecure_channel(self.address)
-        else:
-            self.channel = grpc.insecure_channel(self.address)
-
-        self.stub = self.create_stub(self.channel)
+        self._address = address
+        self._channel = grpc.insecure_channel(self._address)
+        self._stub = self.create_stub(self._channel)
         self.token = Token()
         self.token.CopyFrom(token)
 
@@ -186,7 +181,7 @@ class GRPCDriver:
             elif response.flag in [
                 ResponseFlag.NOT_EXECUTED_NOT_IN_CONTROL,
             ]:
-                self.log.warn(text())
+                self.log.warning(text())
             else:
                 self.log.error(text("failed", error_txt))
 
@@ -207,10 +202,10 @@ class GRPCDriver:
         decode_children=False,
         timeout: int | float = 60,
     ):
-        if not self.stub:
+        if not self._stub:
             raise DruncShellException("No stub initialised")
 
-        cmd = getattr(self.stub, command)  # this throws if the command doesn't exist
+        cmd = getattr(self._stub, command)  # this throws if the command doesn't exist
 
         request = self._create_request(data)
 

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -173,7 +173,6 @@ class GRPCDriver:
         command: str,
         data=None,
         outformat=None,
-        decode_children=False,
         timeout: int | float = 60,
     ):
         cmd = getattr(self.stub, command)  # this throws if the command doesn't exist
@@ -187,14 +186,8 @@ class GRPCDriver:
 
         # TODO: TEMP HACK UNTIL UNPACKING IS REMOVED
         from druncschema.description_pb2 import Description
-        from druncschema.process_manager_pb2 import ProcessInstanceList
 
-        new_message_types = (
-            Description,
-            ProcessInstanceList,
-        )
-
-        if isinstance(response, new_message_types):
+        if isinstance(response, Description):
             return response
 
         return self.handle_response(response, command, outformat)

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -223,7 +223,13 @@ class GRPCDriver:
         from druncschema.description_pb2 import Description
         from druncschema.session_manager_pb2 import AllActiveSessions, AllConfigKeys
 
-        if isinstance(response, (Description, AllActiveSessions, AllConfigKeys)):
+        new_message_types = (
+            Description,
+            AllActiveSessions,
+            AllConfigKeys,
+        )
+
+        if isinstance(response, new_message_types):
             return response
 
         return self.handle_response(response, command, outformat)


### PR DESCRIPTION
Resolves #495.

This is the second in a series of changes replacing the generic Any-packed messages with dedicated ones. In this change, the `ProcessManager` is addressed. Took a bit longer than expected -- I wanted to be sure that I wasn't accidentally leaving something out. Might need a quick chat to step through the changes.

I am working on separating the 'drivers' out into separate classes, since caveats in each driver type make subclassing more messier than not. Even the gRPC stub classes are not covariant.

NB: As for which messages, I just used existing ones for now, and left deciding on a proper set of messages for later. Token can be omitted from these messages as we can pass this information in via metadata, as intended.