### PR TITLE
K8s rebase pm rework

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Description
+Addresses issue # 
+_Please include a summary of the change and which issue is fixed (if any). Please also
+include relevant motivation and context. List any dependencies that are required for
+this change._
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] Documentation (non-breaking change that adds or improves the documentation)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Optimization (non-breaking, back-end change that speeds up the code)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Breaking change (whatever its nature)
+
+## Key checklist
+
+- [ ] All tests pass (eg. `python -m pytest`)
+- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
+
+## Further checks
+
+- [ ] Code is commented, particularly in hard-to-understand areas
+- [ ] Tests added or an issue has been opened to tackle that in the future.
+  (Indicate issue here: # (issue))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: v0.9.6
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
+        name: Check linting with Ruff
+        entry: ruff check .

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -129,12 +129,18 @@ class K8sProcessManager(ProcessManager):
                 raise DruncException("Session (namespace) must be provided to label a pod.")
             try:
                 self._core_v1_api.patch_namespaced_pod(name=obj_name, namespace=session, body=body)
+                self.log.info(
+                    f'Added label "{key}.{self.drunc_label}:{label}" to pod "{session}.{obj_name}"'
+                )
             except self._api_error_v1_api as e:
                 self.log.error(f"Failed to apply label to pod {session}/{obj_name}: {e}")
 
         elif obj_type == "namespace":
             try:
                 self._core_v1_api.patch_namespace(name=obj_name, body=body)
+                self.log.info(
+                    f'Added label "{key}.{self.drunc_label}:{label}" to namespace "{obj_name}"'
+                )
             except self._api_error_v1_api as e:
                 self.log.error(f"Failed to apply label to namespace {obj_name}: {e}")
         else:

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -3,16 +3,17 @@ import getpass
 import os
 import re
 import socket
-import subprocess
 import tempfile
 import threading
 import uuid
-from time import sleep
+from time import sleep, time
 from collections import deque
+from urllib.parse import urlparse
 
 # Third-Party Imports
 from grpc import ServicerContext
 from kubernetes import client, config, watch
+from kubernetes.stream import portforward
 
 # Local Application Imports
 from drunc.authoriser.decorators import authentified_and_authorised
@@ -96,7 +97,10 @@ class K8sProcessManager(ProcessManager):
         self.watchers = []
         self._start_watcher()
         self.sessions_pending_deletion = set()
-        self.port_forwards = {}
+
+        self.connection_server_name = "local-connection-server"
+        self.connection_server_port = 5000
+        self.local_connection_server_is_booted = False # Flag to track if the local server is in use
 
         try:
             timeout_val = self.configuration.data.kill_timeout
@@ -206,6 +210,32 @@ class K8sProcessManager(ProcessManager):
         except self._api_error_v1_api as e:
             if e.status != 409: self.log.error(f"Failed to create headless service for {podname}: {e}")
 
+    def _create_clusterip_service(self, podname, session, pod_uid):
+        service_manifest = client.V1Service(
+            api_version="v1", kind="Service",
+            metadata=self._meta_v1_api(
+                name=podname, namespace=session,
+                labels={f"creator.{self.drunc_label}": self.__class__.__name__},
+                owner_references=[client.V1OwnerReference(
+                    api_version="v1", kind="Pod", name=podname, uid=pod_uid,
+                    controller=True, block_owner_deletion=True
+                )]
+            ),
+            spec=client.V1ServiceSpec(
+                selector={"app": podname},
+                ports=[client.V1ServicePort(
+                    protocol="TCP",
+                    port=self.connection_server_port,
+                    target_port=self.connection_server_port
+                )]
+            ),
+        )
+        try:
+            self._core_v1_api.create_namespaced_service(namespace=session, body=service_manifest)
+            self.log.info(f'Created ClusterIP service "{session}.{podname}" on port {self.connection_server_port}')
+        except self._api_error_v1_api as e:
+            if e.status != 409: self.log.error(f"Failed to create ClusterIP service for {podname}: {e}")
+
     def _create_pod(self, podname, session, boot_request: BootRequest):
         pod_image = self.configuration.data.image
         exec_and_args_list = boot_request.process_description.executable_and_arguments
@@ -222,6 +252,35 @@ class K8sProcessManager(ProcessManager):
                     client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
                 ]
             ))
+
+        main_container = client.V1Container(
+            name=podname, image=pod_image, command=["sh", "-c"],
+            args=[main_command_str],
+            env=[client.V1EnvVar(name=k, value=v) for k, v in boot_request.process_description.env.items()],
+            ports=[],
+            volume_mounts=[
+                client.V1VolumeMount(name="nfs", mount_path="/nfs"),
+                client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
+            ],
+            working_dir=boot_request.process_description.process_execution_directory,
+            security_context=client.V1SecurityContext(run_as_user=os.getuid(), run_as_group=os.getgid()),
+        )
+
+        all_containers = [main_container]
+
+        ### MODIFICATION ###: Only add the sidecar if the local connection server has been booted
+        if podname != self.connection_server_name and self.local_connection_server_is_booted:
+            self.log.info(f"Adding proxy sidecar to pod '{podname}'")
+            sidecar_container = client.V1Container(
+                name="proxy-sidecar",
+                image="alpine/socat",
+                args=[
+                    "TCP-LISTEN:5000,fork,reuseaddr",
+                    f"TCP:{self.connection_server_name}.{session}:{self.connection_server_port}"
+                ]
+            )
+            all_containers.append(sidecar_container)
+
         pod_manifest = client.V1Pod(
             api_version="v1", kind="Pod",
             metadata=self._meta_v1_api(
@@ -231,18 +290,7 @@ class K8sProcessManager(ProcessManager):
             spec=self._pod_spec_v1_api(
                 init_containers=init_containers,
                 restart_policy="Never",
-                containers=[client.V1Container(
-                    name=podname, image=pod_image, command=["sh", "-c"],
-                    args=[main_command_str],
-                    env=[client.V1EnvVar(name=k, value=v) for k, v in boot_request.process_description.env.items()],
-                    ports=[client.V1ContainerPort(container_port=50051)],
-                    volume_mounts=[
-                        client.V1VolumeMount(name="nfs", mount_path="/nfs"),
-                        client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
-                    ],
-                    working_dir=boot_request.process_description.process_execution_directory,
-                    security_context=client.V1SecurityContext(run_as_user=os.getuid(), run_as_group=os.getgid()),
-                )],
+                containers=all_containers,
                 volumes=[
                     client.V1Volume(name="nfs", host_path=client.V1HostPathVolumeSource(path="/nfs")),
                     client.V1Volume(name="cvmfs", host_path=client.V1HostPathVolumeSource(path="/cvmfs")),
@@ -253,13 +301,17 @@ class K8sProcessManager(ProcessManager):
             created_pod = self._core_v1_api.create_namespaced_pod(session, pod_manifest)
             self.log.info(f'Creating pod "{session}.{podname}"')
             pod_uid = created_pod.metadata.uid
-            self._create_headless_service(podname, session, pod_uid)
+
+            if podname == self.connection_server_name:
+                self._create_clusterip_service(podname, session, pod_uid)
+            else:
+                self._create_headless_service(podname, session, pod_uid)
+
         except self._api_error_v1_api as e:
             self.log.error(f'Couldn\'t create pod "{session}.{podname}": {e}')
             raise e
 
     def _get_process_uid(self, query: ProcessQuery, order_by: str = None):
-        # First, find all processes that match the query
         initial_match = set()
         for proc_uuid, boot_req in self.boot_request.items():
             meta = boot_req.process_description.metadata
@@ -272,29 +324,22 @@ class K8sProcessManager(ProcessManager):
                any(re.search(name_reg, meta.name) for name_reg in query.names):
                 initial_match.add(proc_uuid)
 
-        # If no ordering is required, return the matched list
         if order_by != "leaf_first":
             return list(initial_match)
 
         self.log.debug("Sorting processes in leaf-first order using tree_id.")
 
-        # Create a list of tuples (uuid, tree_id) for the matched processes.
         procs_to_sort = []
         for uuid in initial_match:
             if uuid in self.boot_request:
                 tree_id = self.boot_request[uuid].process_description.metadata.tree_id
                 procs_to_sort.append((uuid, tree_id))
 
-        # Sort the list. The key is a tuple: (-len(tree_id), tree_id).
-        # -len sorts by length in descending order (longest ID string is a leaf).
-        # tree_id is the secondary key for stable sorting of nodes at the same depth.
         procs_to_sort.sort(key=lambda p: (-len(p[1]), p[1]))
 
-        # Extract just the UUIDs from the now-sorted list.
         sorted_uuids = [uuid for uuid, tree_id in procs_to_sort]
 
         return sorted_uuids
-
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         uuids = self._get_process_uid(log_request.query)
@@ -318,6 +363,7 @@ class K8sProcessManager(ProcessManager):
     def __boot(self, boot_request: BootRequest, uuid: str) -> ProcessInstance:
         session = boot_request.process_description.metadata.session
         podname = boot_request.process_description.metadata.name
+
         if uuid in self.boot_request:
             raise DruncCommandException(f'"{session}.{podname}":{uuid} already exists!')
 
@@ -328,6 +374,34 @@ class K8sProcessManager(ProcessManager):
         self._create_pod(podname, session, boot_request)
         self._add_label(podname, "pod", "uuid", uuid, session=session)
         self.log.info(f'"{session}.{podname}":{uuid} boot request sent.')
+
+        ### MODIFICATION ###: Only block and prompt for the connection server
+        if podname == self.connection_server_name:
+            self.log.info(f"Waiting for '{podname}' to become ready...")
+            start_time = time()
+            timeout = 60
+            while time() - start_time < timeout:
+                try:
+                    pod_status = self._core_v1_api.read_namespaced_pod_status(podname, session)
+                    if pod_status.status.phase == 'Running' and pod_status.status.pod_ip:
+                        self.log.info(f"'{podname}' is ready with IP {pod_status.status.pod_ip}.")
+                        self.local_connection_server_is_booted = True # Set the flag for sidecars
+                        break
+                except self._api_error_v1_api as e:
+                    if e.status == 404:
+                        pass
+                    else:
+                        raise e
+                sleep(1)
+            else:
+                raise DruncException(f"'{podname}' did not become ready in {timeout} seconds.")
+
+            self.log.info("--- MANUAL STEP REQUIRED ---")
+            self.log.info("The orchestrator needs a port-forward tunnel to connect to the server.")
+            self.log.info("Please run this command in a NEW terminal (after setting KUBECONFIG):")
+            self.log.info(f"kubectl port-forward -n {session} pod/{podname} {self.connection_server_port}:{self.connection_server_port}")
+            input("Press Enter here after the port-forward is running in the other terminal...")
+            self.log.info("Resuming...")
 
         pd, pr, pu = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=uuid)
         pd.CopyFrom(self.boot_request[uuid].process_description)
@@ -373,15 +447,12 @@ class K8sProcessManager(ProcessManager):
         if uuid not in self.boot_request:
             raise DruncCommandException(f"Cannot restart process with UUID {uuid}: Not found.")
 
-        # Store the original boot request before we kill the process
         br_copy = BootRequest()
         br_copy.CopyFrom(self.boot_request[uuid])
 
-        # Use the full kill implementation to ensure a complete cleanup
         kill_query = ProcessQuery(uuids=[ProcessUUID(uuid=uuid)])
         self._kill_impl(kill_query)
 
-        # Now, boot the new instance with the same config and UUID
         restarted_process = self.__boot(br_copy, uuid)
 
         return ProcessInstanceList(values=[restarted_process])
@@ -419,6 +490,7 @@ class K8sProcessManager(ProcessManager):
             if proc_uuid not in self.boot_request: continue
             pd = self.boot_request[proc_uuid].process_description
             podname, session = pd.metadata.name, pd.metadata.session
+            
             self.log.info(f'Killing pod "{session}/{podname}" (UUID {proc_uuid})')
             try:
                 self._kill_pod(podname, session, grace_period=self.kill_timeout)
@@ -446,7 +518,6 @@ class K8sProcessManager(ProcessManager):
         return self._kill_impl(all_processes_query)
 
     def _flush_impl(self, query: ProcessQuery) -> ProcessInstanceList:
-        # This implementation is a safe no-op for now.
         self.log.info(
             "The 'flush' command is not needed for the K8sProcessManager. "
             "Cleanup of dead processes is handled automatically in real-time."

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -48,23 +48,24 @@ class K8sPodWatcherThread(threading.Thread):
                 )
                 for event in stream:
                     pod = event["object"]
-                    event_type = event["type"]
                     metadata = pod.metadata
                     status = pod.status
                     phase = status.phase
+                    
                     uuid = metadata.labels.get(f"uuid.{self.pm.drunc_label}")
+                    session = metadata.namespace
 
                     if not uuid:
                         continue
 
-                    if event_type in ["MODIFIED", "DELETED"] and phase in ["Succeeded", "Failed"]:
+                    if event["type"] in ["MODIFIED", "DELETED"] and phase in ["Succeeded", "Failed"]:
                         exit_code = -1
                         reason = "Unknown"
                         if status.container_statuses and status.container_statuses[0].state.terminated:
                             terminated_state = status.container_statuses[0].state.terminated
                             exit_code = terminated_state.exit_code
                             reason = terminated_state.reason
-                        self.pm.notify_termination(uuid, exit_code, reason)
+                        self.pm.notify_termination(uuid, exit_code, reason, session)
 
             except Exception as e:
                 self.pm.log.error(f"K8s watcher thread error: {e}. Restarting watch.")
@@ -87,6 +88,7 @@ class K8sProcessManager(ProcessManager):
         self.drunc_label = "drunc.daq"
         self.watchers = []
         self._start_watcher()
+        self.sessions_pending_deletion = set()
 
         namespaces = self._core_v1_api.list_namespace(
             label_selector=f"creator.{self.drunc_label}={self.__class__.__name__}"
@@ -105,18 +107,16 @@ class K8sProcessManager(ProcessManager):
         t.start()
         self.watchers.append(t)
 
-    def notify_termination(self, uuid, exit_code, reason):
-        if uuid not in self.boot_request:
-            self.log.debug(f"Received termination for already-removed UUID {uuid}")
-            return
+    def notify_termination(self, uuid, exit_code, reason, session):
+        if uuid in self.boot_request:
+            meta = self.boot_request[uuid].process_description.metadata
+            end_str = f"Pod '{meta.name}' (session: '{session}', user: '{meta.user}', uuid: {uuid}) terminated with exit code {exit_code}. Reason: {reason}"
+            self.log.info(end_str)
+            self.broadcast(end_str, BroadcastType.SUBPROCESS_STATUS_UPDATE)
+        else:
+            self.log.debug(f"Received termination for already-removed UUID {uuid}, checking session '{session}' for cleanup.")
 
-        meta = self.boot_request[uuid].process_description.metadata
-        end_str = f"Pod '{meta.name}' (session: '{meta.session}', user: '{meta.user}', uuid: {uuid}) terminated with exit code {exit_code}. Reason: {reason}"
-        self.log.info(end_str)
-        self.broadcast(end_str, BroadcastType.SUBPROCESS_STATUS_UPDATE)
-
-        # Automatically flush the record of the dead process
-        del self.boot_request[uuid]
+        self._kill_if_empty_session(session)
 
     def is_alive(self, podname, session):
         try:
@@ -161,6 +161,10 @@ class K8sProcessManager(ProcessManager):
         return f"creator.{self.drunc_label}={self.__class__.__name__}"
 
     def _create_namespace(self, session):
+
+        if session in self.sessions_pending_deletion:
+            self.sessions_pending_deletion.remove(session)
+
         try:
             self._core_v1_api.read_namespace(name=session)
         except self._api_error_v1_api as e:
@@ -397,24 +401,32 @@ class K8sProcessManager(ProcessManager):
 
     def _kill_pod(self, podname, session):
         try:
-            self._core_v1_api.delete_namespaced_pod(podname, session, grace_period_seconds=0)
+            self._core_v1_api.delete_namespaced_pod(podname, session)
         except self._api_error_v1_api as e:
             if e.status != 404: raise e
 
     def _kill_if_empty_session(self, session):
+        # If we have already started deleting this session, do nothing.
+        if session in self.sessions_pending_deletion:
+            return
+
         try:
             pods = self._core_v1_api.list_namespaced_pod(
                 session, label_selector=self._get_creator_label_selector()
             )
             if not pods.items:
+                # Mark this session for deletion BEFORE we send the request.
+                self.sessions_pending_deletion.add(session)
                 self.log.info(f'Session "{session}" is empty, deleting namespace.')
                 self._core_v1_api.delete_namespace(session)
         except self._api_error_v1_api as e:
-            if e.status != 404:
+            if e.status == 404:
+                self.sessions_pending_deletion.add(session)
+            else:
                 self.log.warning(f"Failed to check/delete empty session {session}: {e}")
 
     def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
-        ret, sessions_affected = [], set()
+        ret = []
         uuids_to_kill = self._get_process_uid(query)
         
         for proc_uuid in uuids_to_kill:
@@ -422,7 +434,6 @@ class K8sProcessManager(ProcessManager):
 
             pd = self.boot_request[proc_uuid].process_description
             podname, session = pd.metadata.name, pd.metadata.session
-            sessions_affected.add(session)
             self.log.info(f'Killing pod "{session}/{podname}" (UUID {proc_uuid})')
             
             try:
@@ -439,10 +450,9 @@ class K8sProcessManager(ProcessManager):
                 process_description=pd_copy, process_restriction=pr_copy,
                 status_code=ProcessInstance.StatusCode.DEAD, uuid=pu_copy,
             ))
+            del self.boot_request[proc_uuid]
 
-        for session in sessions_affected:
-            self._kill_if_empty_session(session)
-
+        # The check for empty sessions is no longer done here
         return ProcessInstanceList(values=ret)
 
     def _terminate_impl(self) -> ProcessInstanceList:

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -3,28 +3,12 @@ import getpass
 import os
 import re
 import signal
-import socket
 import subprocess
-import tempfile
 import threading
 import uuid
 from time import sleep, time
-from collections import deque
 
-# Third-Party Imports
-from grpc import ServicerContext
-from kubernetes import client, config, watch
-
-# Local Application Imports
-from drunc.authoriser.decorators import authentified_and_authorised
-from drunc.broadcast.server.decorators import broadcasted
-from drunc.exceptions import DruncCommandException, DruncException
-from drunc.process_manager.process_manager import ProcessManager, BadQuery
-from drunc.utils.grpc_utils import pack_to_any, unpack_any, unpack_error_response
-from drunc.utils.utils import get_logger
-from druncschema.authoriser_pb2 import ActionType, SystemType
 from druncschema.broadcast_pb2 import BroadcastType
-from druncschema.description_pb2 import CommandDescription, OldDescription
 from druncschema.process_manager_pb2 import (
     BootRequest,
     LogLines,
@@ -36,7 +20,14 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
     ProcessUUID,
 )
-from druncschema.request_response_pb2 import Request, Response, ResponseFlag
+
+# Third-Party Imports
+from kubernetes import client, config, watch
+
+# Local Application Imports
+from drunc.exceptions import DruncCommandException, DruncException
+from drunc.process_manager.process_manager import ProcessManager
+from drunc.utils.utils import get_logger
 
 
 class K8sPodWatcherThread(threading.Thread):
@@ -359,10 +350,10 @@ class K8sProcessManager(ProcessManager):
         self.log.debug("Sorting processes in leaf-first order using tree_id.")
 
         procs_to_sort = []
-        for uuid in initial_match:
-            if uuid in self.boot_request:
-                tree_id = self.boot_request[uuid].process_description.metadata.tree_id
-                procs_to_sort.append((uuid, tree_id))
+        for a_uuid in initial_match:
+            if a_uuid in self.boot_request:
+                tree_id = self.boot_request[a_uuid].process_description.metadata.tree_id
+                procs_to_sort.append((a_uuid, tree_id))
 
         procs_to_sort.sort(key=lambda p: (-len(p[1]), p[1]))
 
@@ -444,7 +435,7 @@ class K8sProcessManager(ProcessManager):
             command_parts.append(f"kubectl port-forward -n {session} pod/{podname} {self.connection_server_port}:{self.connection_server_port}")
             command = "; ".join(command_parts)
 
-            self.log.info(f"Starting port-forward for orchestrator. Executing shell command...")
+            self.log.info("Starting port-forward for orchestrator. Executing shell command...")
             try:
                 # preexec_fn=os.setsid creates a new process group, allowing us to kill the shell and all its children.
                 proc = subprocess.Popen(

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -331,6 +331,7 @@ class K8sProcessManager(ProcessManager):
         all_pods = self._core_v1_api.list_pod_for_all_namespaces(
             label_selector=self._get_creator_label_selector()
         )
+
         uuid_to_pod = {p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in all_pods.items}
         
         ret = []
@@ -424,5 +425,9 @@ class K8sProcessManager(ProcessManager):
         if not self.boot_request:
             self.log.info("No processes to terminate.")
             return ProcessInstanceList()
-        return self._kill_impl(ProcessQuery(names=[".*"]))
+        
+        # This correctly creates a query to kill all processes known to this manager,
+        # identical to the SSHProcessManager's behavior.
+        all_processes_query = ProcessQuery(names=[".*"])
+        return self._kill_impl(all_processes_query)
     

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -2,18 +2,18 @@
 import getpass
 import os
 import re
+import signal
 import socket
+import subprocess
 import tempfile
 import threading
 import uuid
 from time import sleep, time
 from collections import deque
-from urllib.parse import urlparse
 
 # Third-Party Imports
 from grpc import ServicerContext
 from kubernetes import client, config, watch
-from kubernetes.stream import portforward
 
 # Local Application Imports
 from drunc.authoriser.decorators import authentified_and_authorised
@@ -81,6 +81,15 @@ class K8sPodWatcherThread(threading.Thread):
 
 class K8sProcessManager(ProcessManager):
     def __init__(self, configuration, **kwargs):
+        """
+        Manages processes as Kubernetes Pods.
+
+        This ProcessManager interfaces with the Kubernetes API to start, stop, and monitor
+        applications running in Pods. It includes special handling for a local connectivity
+        service, which involves:
+        1.  Automating a `kubectl port-forward` in a background shell process for the orchestrator.
+        2.  Injecting a proxy sidecar container into other pods for transparent service discovery.
+        """
         self.session = getpass.getuser()
         super().__init__(configuration=configuration, session=self.session, **kwargs)
         self.log = get_logger("process_manager.k8s-process-manager")
@@ -97,18 +106,22 @@ class K8sProcessManager(ProcessManager):
         self.watchers = []
         self._start_watcher()
         self.sessions_pending_deletion = set()
+        self.port_forwards = {}
+        self.local_connection_server_is_booted = False
 
-        self.connection_server_name = "local-connection-server"
-        self.connection_server_port = 5000
-        self.local_connection_server_is_booted = False # Flag to track if the local server is in use
+        # Safely get settings from the configuration object
+        settings = {}
+        if hasattr(self.configuration.data, 'settings') and self.configuration.data.settings is not None:
+            settings = self.configuration.data.settings
 
-        try:
-            timeout_val = self.configuration.data.kill_timeout
-            self.kill_timeout = timeout_val if timeout_val is not None else 10
-        except AttributeError:
-            self.kill_timeout = 10
+        self.connection_server_name = settings.get("connection_server_name", "local-connection-server")
+        self.connection_server_port = settings.get("connection_server_port", 5000)
+        self.sidecar_image = settings.get("sidecar_image", "alpine/socat")
+        self.pod_ready_timeout = settings.get("pod_ready_timeout", 60)
+        self.port_forward_timeout = settings.get("port_forward_timeout", 15)
+        self.kill_timeout = settings.get("kill_timeout", 10)
+
         self.log.debug(f'Using kill_timeout of {self.kill_timeout} seconds.')
-
 
         namespaces = self._core_v1_api.list_namespace(
             label_selector=f"creator.{self.drunc_label}={self.__class__.__name__}"
@@ -122,12 +135,14 @@ class K8sProcessManager(ProcessManager):
             self.log.info("No active namespace created by drunc")
 
     def _start_watcher(self):
+        """Starts the background thread that watches for Pod status changes."""
         self.log.debug("Starting K8s pod watcher thread")
         t = K8sPodWatcherThread(pm=self)
         t.start()
         self.watchers.append(t)
 
     def notify_termination(self, uuid, exit_code, reason, session):
+        """Callback for when a pod terminates."""
         if uuid in self.boot_request:
             meta = self.boot_request[uuid].process_description.metadata
             end_str = f"Pod '{meta.name}' (session: '{session}', user: '{meta.user}', uuid: {uuid}) terminated with exit code {exit_code}. Reason: {reason}"
@@ -139,6 +154,7 @@ class K8sProcessManager(ProcessManager):
         self._kill_if_empty_session(session)
 
     def is_alive(self, podname, session):
+        """Checks if a pod is currently in the 'Running' phase."""
         try:
             pod_status = self._core_v1_api.read_namespaced_pod_status(podname, session)
             return pod_status.status.phase == "Running"
@@ -148,6 +164,7 @@ class K8sProcessManager(ProcessManager):
             return False
 
     def _add_label(self, obj_name, obj_type, key, label, session=None):
+        """Adds a label to a Kubernetes object (Pod or Namespace)."""
         body = {"metadata": {"labels": {f"{key}.{self.drunc_label}": label}}}
 
         if obj_type == "pod":
@@ -167,12 +184,15 @@ class K8sProcessManager(ProcessManager):
             raise DruncException(f"Cannot add label to object type: {obj_type}")
 
     def _add_creator_label(self, obj_name, obj_type):
+        """Adds a 'creator' label to a Kubernetes object."""
         self._add_label(obj_name, obj_type, "creator", self.__class__.__name__)
 
     def _get_creator_label_selector(self):
+        """Returns the label selector for objects created by this class."""
         return f"creator.{self.drunc_label}={self.__class__.__name__}"
 
     def _create_namespace(self, session):
+        """Creates a Kubernetes namespace if it doesn't already exist."""
         if session in self.sessions_pending_deletion: self.sessions_pending_deletion.remove(session)
         try:
             self._core_v1_api.read_namespace(name=session)
@@ -189,6 +209,7 @@ class K8sProcessManager(ProcessManager):
                 raise e
 
     def _create_headless_service(self, podname, session, pod_uid):
+        """Creates a headless service for a pod."""
         service_manifest = client.V1Service(
             api_version="v1", kind="Service",
             metadata=self._meta_v1_api(
@@ -211,6 +232,7 @@ class K8sProcessManager(ProcessManager):
             if e.status != 409: self.log.error(f"Failed to create headless service for {podname}: {e}")
 
     def _create_clusterip_service(self, podname, session, pod_uid):
+        """Creates a standard ClusterIP service for the connection server."""
         service_manifest = client.V1Service(
             api_version="v1", kind="Service",
             metadata=self._meta_v1_api(
@@ -237,6 +259,7 @@ class K8sProcessManager(ProcessManager):
             if e.status != 409: self.log.error(f"Failed to create ClusterIP service for {podname}: {e}")
 
     def _create_pod(self, podname, session, boot_request: BootRequest):
+        """Constructs and creates a Kubernetes Pod manifest."""
         pod_image = self.configuration.data.image
         exec_and_args_list = boot_request.process_description.executable_and_arguments
         main_command_str = "; ".join([" ".join([e_and_a.exec] + list(e_and_a.args)) for e_and_a in exec_and_args_list])
@@ -268,14 +291,14 @@ class K8sProcessManager(ProcessManager):
 
         all_containers = [main_container]
 
-        ### MODIFICATION ###: Only add the sidecar if the local connection server has been booted
+        # If the local connection server is active, inject a proxy sidecar into all other pods.
         if podname != self.connection_server_name and self.local_connection_server_is_booted:
             self.log.info(f"Adding proxy sidecar to pod '{podname}'")
             sidecar_container = client.V1Container(
                 name="proxy-sidecar",
-                image="alpine/socat",
+                image=self.sidecar_image,
                 args=[
-                    "TCP-LISTEN:5000,fork,reuseaddr",
+                    f"TCP-LISTEN:{self.connection_server_port},fork,reuseaddr",
                     f"TCP:{self.connection_server_name}.{session}:{self.connection_server_port}"
                 ]
             )
@@ -312,6 +335,12 @@ class K8sProcessManager(ProcessManager):
             raise e
 
     def _get_process_uid(self, query: ProcessQuery, order_by: str = None):
+        """
+        Finds process UUIDs matching a query.
+        
+        If order_by is "leaf_first", it sorts the UUIDs so that child processes
+        (which have a longer tree_id) come before their parents.
+        """
         initial_match = set()
         for proc_uuid, boot_req in self.boot_request.items():
             meta = boot_req.process_description.metadata
@@ -342,6 +371,7 @@ class K8sProcessManager(ProcessManager):
         return sorted_uuids
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
+        """Handles the 'logs' command."""
         uuids = self._get_process_uid(log_request.query)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
         podname = self.boot_request[uuid].process_description.metadata.name
@@ -355,12 +385,18 @@ class K8sProcessManager(ProcessManager):
             return LogLines(uuid=ProcessUUID(uuid=uuid), lines=[f"Could not retrieve logs: {e.reason}"])
 
     def _boot_impl(self, boot_request: BootRequest) -> ProcessInstanceList:
+        """Handles the 'boot' command from the gRPC interface."""
         self.log.debug(f"{self.name} running boot command")
         this_uuid = str(uuid.uuid4())
         process = self.__boot(boot_request, this_uuid)
         return ProcessInstanceList(values=[process])
 
     def __boot(self, boot_request: BootRequest, uuid: str) -> ProcessInstance:
+        """
+        Internal boot method. Handles pod creation and special logic for the connection server.
+        - For the connection server: Boot is BLOCKING, and a port-forward is automated.
+        - For all other pods: Boot is NON-BLOCKING.
+        """
         session = boot_request.process_description.metadata.session
         podname = boot_request.process_description.metadata.name
 
@@ -375,33 +411,76 @@ class K8sProcessManager(ProcessManager):
         self._add_label(podname, "pod", "uuid", uuid, session=session)
         self.log.info(f'"{session}.{podname}":{uuid} boot request sent.')
 
-        ### MODIFICATION ###: Only block and prompt for the connection server
+        # Special handling only for the connection server
         if podname == self.connection_server_name:
+            # Step 1: Block and wait for the server pod to be fully ready
             self.log.info(f"Waiting for '{podname}' to become ready...")
             start_time = time()
-            timeout = 60
-            while time() - start_time < timeout:
+            while time() - start_time < self.pod_ready_timeout:
                 try:
                     pod_status = self._core_v1_api.read_namespaced_pod_status(podname, session)
                     if pod_status.status.phase == 'Running' and pod_status.status.pod_ip:
                         self.log.info(f"'{podname}' is ready with IP {pod_status.status.pod_ip}.")
-                        self.local_connection_server_is_booted = True # Set the flag for sidecars
+                        self.local_connection_server_is_booted = True
                         break
                 except self._api_error_v1_api as e:
-                    if e.status == 404:
-                        pass
-                    else:
-                        raise e
+                    if e.status == 404: pass # Not created yet, wait
+                    else: raise e
                 sleep(1)
-            else:
-                raise DruncException(f"'{podname}' did not become ready in {timeout} seconds.")
+            else: # Only runs if the while loop finishes without a break
+                raise DruncException(f"'{podname}' did not become ready in {self.pod_ready_timeout} seconds.")
 
-            self.log.info("--- MANUAL STEP REQUIRED ---")
-            self.log.info("The orchestrator needs a port-forward tunnel to connect to the server.")
-            self.log.info("Please run this command in a NEW terminal (after setting KUBECONFIG):")
-            self.log.info(f"kubectl port-forward -n {session} pod/{podname} {self.connection_server_port}:{self.connection_server_port}")
-            input("Press Enter here after the port-forward is running in the other terminal...")
-            self.log.info("Resuming...")
+            # Step 2: Automate the port-forward for the orchestrator by running it in a shell
+            kubeconfig_path = os.environ.get('KUBECONFIG')
+            proxy_unset_script = "~np04daq/bin/web_proxy.sh -u"
+
+            command_parts = []
+            if kubeconfig_path:
+                command_parts.append(f"export KUBECONFIG='{kubeconfig_path}'")
+            else:
+                self.log.warning("KUBECONFIG env var not set; assuming kubectl is configured.")
+            
+            command_parts.append(f"source {proxy_unset_script}")
+            command_parts.append(f"kubectl port-forward -n {session} pod/{podname} {self.connection_server_port}:{self.connection_server_port}")
+            command = "; ".join(command_parts)
+
+            self.log.info(f"Starting port-forward for orchestrator. Executing shell command...")
+            try:
+                # preexec_fn=os.setsid creates a new process group, allowing us to kill the shell and all its children.
+                proc = subprocess.Popen(
+                    command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                    text=True, preexec_fn=os.setsid
+                )
+                self.port_forwards[uuid] = proc
+                self.log.info(f"Port-forward process for '{podname}' started with PID {proc.pid}. Waiting for tunnel...")
+
+                # Wait for kubectl to confirm the tunnel is up to prevent a race condition
+                output = {}
+                def read_output(pipe, storage):
+                    storage['line'] = pipe.readline()
+
+                thread = threading.Thread(target=read_output, args=(proc.stdout, output))
+                thread.start()
+                thread.join(timeout=self.port_forward_timeout)
+
+                if thread.is_alive():
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                    raise DruncException(f"Port-forward for '{podname}' did not become ready in {self.port_forward_timeout} seconds.")
+
+                line = output.get('line', '').strip()
+                if "Forwarding from" in line:
+                    self.log.info(f"Port-forward is active: {line}")
+                else:
+                    error_output = proc.stderr.read()
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                    raise DruncException(f"Port-forward for '{podname}' failed. Stdout: '{line}'. Stderr: '{error_output}'")
+
+            except Exception as e:
+                self.log.error(f"Failed to start or validate port-forwarding for '{podname}': {e}")
+                if uuid in self.port_forwards:
+                    os.killpg(os.getpgid(self.port_forwards[uuid].pid), signal.SIGTERM)
+                    del self.port_forwards[uuid]
+                raise
 
         pd, pr, pu = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=uuid)
         pd.CopyFrom(self.boot_request[uuid].process_description)
@@ -413,6 +492,7 @@ class K8sProcessManager(ProcessManager):
         )
 
     def _ps_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+        """Handles the 'ps' command."""
         queried_uuids = self._get_process_uid(query)
         if not queried_uuids: return ProcessInstanceList(values=[])
         all_pods = self._core_v1_api.list_pod_for_all_namespaces(
@@ -441,6 +521,7 @@ class K8sProcessManager(ProcessManager):
         return ProcessInstanceList(values=ret)
 
     def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+        """Handles the 'restart' command."""
         uuids = self._get_process_uid(query)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
 
@@ -458,6 +539,7 @@ class K8sProcessManager(ProcessManager):
         return ProcessInstanceList(values=[restarted_process])
 
     def _kill_pod(self, podname, session, grace_period=None):
+        """Deletes a specific pod from a namespace."""
         try:
             self._core_v1_api.delete_namespaced_pod(
                 podname,
@@ -469,6 +551,7 @@ class K8sProcessManager(ProcessManager):
                 raise e
 
     def _kill_if_empty_session(self, session):
+        """Deletes a namespace if it contains no more pods managed by this process manager."""
         if session in self.sessions_pending_deletion: return
         try:
             pods = self._core_v1_api.list_namespaced_pod(
@@ -483,6 +566,7 @@ class K8sProcessManager(ProcessManager):
             else: self.log.warning(f"Failed to check/delete empty session {session}: {e}")
 
     def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+        """Handles the 'kill' command."""
         ret = []
         uuids_to_kill = self._get_process_uid(query, order_by="leaf_first")
 
@@ -491,6 +575,15 @@ class K8sProcessManager(ProcessManager):
             pd = self.boot_request[proc_uuid].process_description
             podname, session = pd.metadata.name, pd.metadata.session
             
+            # If this pod has a port-forward process, terminate it.
+            if proc_uuid in self.port_forwards:
+                self.log.info(f"Terminating port-forward process for '{podname}'")
+                proc = self.port_forwards.pop(proc_uuid)
+                # Kill the entire process group started by shell=True
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                proc.wait()
+                self.log.info(f"Port-forward process for '{podname}' terminated.")
+
             self.log.info(f'Killing pod "{session}/{podname}" (UUID {proc_uuid})')
             try:
                 self._kill_pod(podname, session, grace_period=self.kill_timeout)
@@ -510,6 +603,7 @@ class K8sProcessManager(ProcessManager):
         return ProcessInstanceList(values=ret)
 
     def _terminate_impl(self) -> ProcessInstanceList:
+        """Handles the 'terminate' command, killing all known processes."""
         self.log.info("Terminating all known K8s processes.")
         if not self.boot_request:
             self.log.info("No processes to terminate.")
@@ -518,6 +612,7 @@ class K8sProcessManager(ProcessManager):
         return self._kill_impl(all_processes_query)
 
     def _flush_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+        """Handles the 'flush' command (no-op for Kubernetes)."""
         self.log.info(
             "The 'flush' command is not needed for the K8sProcessManager. "
             "Cleanup of dead processes is handled automatically in real-time."

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -1,3 +1,4 @@
+# Standard Library Imports
 import getpass
 import os
 import re
@@ -6,6 +7,15 @@ import threading
 import uuid
 from time import sleep
 
+# Third-Party Imports
+from kubernetes import client, config, watch
+
+# Local Application Imports
+from drunc.exceptions import DruncCommandException, DruncException
+from drunc.k8s_exceptions import DruncK8sNamespaceAlreadyExists
+from drunc.process_manager.process_manager import ProcessManager
+from drunc.utils.grpc_utils import pack_to_any
+from drunc.utils.utils import get_logger
 from druncschema.broadcast_pb2 import BroadcastType
 from druncschema.process_manager_pb2 import (
     BootRequest,
@@ -18,12 +28,7 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
     ProcessUUID,
 )
-from kubernetes import client, config, watch
-
-from drunc.exceptions import DruncCommandException, DruncException
-from drunc.k8s_exceptions import DruncK8sNamespaceAlreadyExists
-from drunc.process_manager.process_manager import ProcessManager
-from drunc.utils.utils import get_logger
+from druncschema.request_response_pb2 import Response, ResponseFlag
 
 
 class K8sPodWatcherThread(threading.Thread):
@@ -109,6 +114,9 @@ class K8sProcessManager(ProcessManager):
         end_str = f"Pod '{meta.name}' (session: '{meta.session}', user: '{meta.user}', uuid: {uuid}) terminated with exit code {exit_code}. Reason: {reason}"
         self.log.info(end_str)
         self.broadcast(end_str, BroadcastType.SUBPROCESS_STATUS_UPDATE)
+
+        # Automatically flush the record of the dead process
+        del self.boot_request[uuid]
 
     def is_alive(self, podname, session):
         try:
@@ -213,7 +221,7 @@ class K8sProcessManager(ProcessManager):
         ])
         
         init_containers = []
-        # Check if the boot request follows the pattern: 1. source script, 2. run command
+
         if len(exec_and_args_list) > 1 and exec_and_args_list[0].exec == "source":
             env_script_path = exec_and_args_list[0].args[0]
             main_app_name = exec_and_args_list[1].exec
@@ -244,12 +252,12 @@ class K8sProcessManager(ProcessManager):
                 labels={"app": podname, f"creator.{self.drunc_label}": self.__class__.__name__}
             ),
             spec=self._pod_spec_v1_api(
-                init_containers=init_containers, # Add the init container to the spec
+                init_containers=init_containers,
                 restart_policy="Never",
                 containers=[
                     client.V1Container(
                         name=podname, image=pod_image, command=["sh", "-c"],
-                        args=[main_command_str], # The main container now runs the original command without a wait loop
+                        args=[main_command_str],
                         env=env_vars,
                         volume_mounts=[
                             client.V1VolumeMount(name="nfs", mount_path="/nfs"),
@@ -293,7 +301,9 @@ class K8sProcessManager(ProcessManager):
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         uuids = self._get_process_uid(log_request.query)
-        uuid = self._ensure_one_process(uuids)
+        # Add in_boot_request=True to check the correct dictionary
+        uuid = self._ensure_one_process(uuids, in_boot_request=True)
+        
         podname = self.boot_request[uuid].process_description.metadata.name
         session = self.boot_request[uuid].process_description.metadata.session
         try:
@@ -364,16 +374,26 @@ class K8sProcessManager(ProcessManager):
             ))
         return ProcessInstanceList(values=ret)
 
-    def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+    def _restart_impl(self, query: ProcessQuery) -> ProcessInstance: # Corrected the return type hint
         uuids = self._get_process_uid(query)
-        uuid = self._ensure_one_process(uuids)
-        
+        uuid = self._ensure_one_process(uuids, in_boot_request=True)
+
+        if uuid not in self.boot_request:
+            raise DruncCommandException(f"Cannot restart process with UUID {uuid}: Not found.")
+
         br_copy = BootRequest()
         br_copy.CopyFrom(self.boot_request[uuid])
-        
-        self._kill_impl(ProcessQuery(uuids=[ProcessUUID(uuid=uuid)]))
+
+        pd = self.boot_request[uuid].process_description
+        podname, session = pd.metadata.name, pd.metadata.session
+        self.log.info(f"Restarting pod '{session}/{podname}'. First, killing the old one.")
+        self._kill_pod(podname, session)
+        self._kill_if_empty_session(session)
+
+        del self.boot_request[uuid]
+
         ret = self.__boot(br_copy, uuid)
-        return ProcessInstanceList(values=[ret])
+        return ret
 
     def _kill_pod(self, podname, session):
         try:
@@ -419,7 +439,6 @@ class K8sProcessManager(ProcessManager):
                 process_description=pd_copy, process_restriction=pr_copy,
                 status_code=ProcessInstance.StatusCode.DEAD, uuid=pu_copy,
             ))
-            del self.boot_request[proc_uuid]
 
         for session in sessions_affected:
             self._kill_if_empty_session(session)
@@ -436,4 +455,19 @@ class K8sProcessManager(ProcessManager):
         # identical to the SSHProcessManager's behavior.
         all_processes_query = ProcessQuery(names=[".*"])
         return self._kill_impl(all_processes_query)
+    
+    def flush(self, request: 'Request', context: 'ServicerContext') -> Response:
+        self.log.info(
+            "The 'flush' command is not needed for the K8sProcessManager. "
+            "Cleanup of dead processes is handled automatically in real-time."
+        )
+        # We must return a valid, empty ProcessInstanceList inside a Response object.
+        pil = ProcessInstanceList(values=[])
+        return Response(
+            name=self.name,
+            token=None,
+            data=pack_to_any(pil),
+            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+            children=[],
+        )
     

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -2,11 +2,27 @@
 import getpass
 import os
 import re
+import socket
+import subprocess
+import tempfile
 import threading
 import uuid
 from time import sleep
 
+# Third-Party Imports
+from grpc import ServicerContext
+from kubernetes import client, config, watch
+
+# Local Application Imports
+from drunc.authoriser.decorators import authentified_and_authorised
+from drunc.broadcast.server.decorators import broadcasted
+from drunc.exceptions import DruncCommandException, DruncException
+from drunc.process_manager.process_manager import ProcessManager, BadQuery
+from drunc.utils.grpc_utils import pack_to_any, unpack_any, unpack_error_response
+from drunc.utils.utils import get_logger
+from druncschema.authoriser_pb2 import ActionType, SystemType
 from druncschema.broadcast_pb2 import BroadcastType
+from druncschema.description_pb2 import CommandDescription, OldDescription
 from druncschema.process_manager_pb2 import (
     BootRequest,
     LogLines,
@@ -19,16 +35,6 @@ from druncschema.process_manager_pb2 import (
     ProcessUUID,
 )
 from druncschema.request_response_pb2 import Request, Response, ResponseFlag
-
-# Third-Party Imports
-from grpc import ServicerContext
-from kubernetes import client, config, watch
-
-# Local Application Imports
-from drunc.exceptions import DruncCommandException, DruncException
-from drunc.process_manager.process_manager import ProcessManager
-from drunc.utils.grpc_utils import pack_to_any
-from drunc.utils.utils import get_logger
 
 
 class K8sPodWatcherThread(threading.Thread):
@@ -51,26 +57,17 @@ class K8sPodWatcherThread(threading.Thread):
                     metadata = pod.metadata
                     status = pod.status
                     phase = status.phase
-
                     uuid = metadata.labels.get(f"uuid.{self.pm.drunc_label}")
                     session = metadata.namespace
 
                     if not uuid:
                         continue
 
-                    if event["type"] in ["MODIFIED", "DELETED"] and phase in [
-                        "Succeeded",
-                        "Failed",
-                    ]:
+                    if event["type"] in ["MODIFIED", "DELETED"] and phase in ["Succeeded", "Failed"]:
                         exit_code = -1
                         reason = "Unknown"
-                        if (
-                            status.container_statuses
-                            and status.container_statuses[0].state.terminated
-                        ):
-                            terminated_state = status.container_statuses[
-                                0
-                            ].state.terminated
+                        if status.container_statuses and status.container_statuses[0].state.terminated:
+                            terminated_state = status.container_statuses[0].state.terminated
                             exit_code = terminated_state.exit_code
                             reason = terminated_state.reason
                         self.pm.notify_termination(uuid, exit_code, reason, session)
@@ -85,7 +82,8 @@ class K8sProcessManager(ProcessManager):
         self.session = getpass.getuser()
         super().__init__(configuration=configuration, session=self.session, **kwargs)
         self.log = get_logger("process_manager.k8s-process-manager")
-        config.load_kube_config()
+        
+        config.load_kube_config() 
 
         self._k8s_client = client
         self._core_v1_api = client.CoreV1Api()
@@ -97,6 +95,7 @@ class K8sProcessManager(ProcessManager):
         self.watchers = []
         self._start_watcher()
         self.sessions_pending_deletion = set()
+        self.port_forwards = {}
 
         namespaces = self._core_v1_api.list_namespace(
             label_selector=f"creator.{self.drunc_label}={self.__class__.__name__}"
@@ -105,9 +104,7 @@ class K8sProcessManager(ProcessManager):
         namespace_list_str = "\n - ".join(namespace_names)
 
         if namespace_list_str:
-            self.log.info(
-                f"Active namespaces created by drunc:\n - {namespace_list_str}"
-            )
+            self.log.info(f"Active namespaces created by drunc:\n - {namespace_list_str}")
         else:
             self.log.info("No active namespace created by drunc")
 
@@ -124,9 +121,7 @@ class K8sProcessManager(ProcessManager):
             self.log.info(end_str)
             self.broadcast(end_str, BroadcastType.SUBPROCESS_STATUS_UPDATE)
         else:
-            self.log.debug(
-                f"Received termination for already-removed UUID {uuid}, checking session '{session}' for cleanup."
-            )
+            self.log.debug(f"Received termination for already-removed UUID {uuid}, checking session '{session}' for cleanup.")
 
         self._kill_if_empty_session(session)
 
@@ -135,40 +130,24 @@ class K8sProcessManager(ProcessManager):
             pod_status = self._core_v1_api.read_namespaced_pod_status(podname, session)
             return pod_status.status.phase == "Running"
         except self._api_error_v1_api as e:
-            if e.status == 404:
-                return False
-            else:
-                self.log.error(
-                    f"Error checking status for pod {session}.{podname}: {e}"
-                )
-                return False
+            if e.status == 404: return False
+            self.log.error(f"Error checking status for pod {session}.{podname}: {e}")
+            return False
 
     def _add_label(self, obj_name, obj_type, key, label, session=None):
         body = {"metadata": {"labels": {f"{key}.{self.drunc_label}": label}}}
-
+        
         if obj_type == "pod":
-            if not session:
-                raise DruncException(
-                    "Session (namespace) must be provided to label a pod."
-                )
+            if not session: raise DruncException("Session (namespace) must be provided to label a pod.")
             try:
-                self._core_v1_api.patch_namespaced_pod(
-                    name=obj_name, namespace=session, body=body
-                )
-                self.log.info(
-                    f'Added label "{key}.{self.drunc_label}:{label}" to pod "{session}.{obj_name}"'
-                )
+                self._core_v1_api.patch_namespaced_pod(name=obj_name, namespace=session, body=body)
+                self.log.info(f'Added label "{key}.{self.drunc_label}:{label}" to pod "{session}.{obj_name}"')
             except self._api_error_v1_api as e:
-                self.log.error(
-                    f"Failed to apply label to pod {session}/{obj_name}: {e}"
-                )
-
+                self.log.error(f"Failed to apply label to pod {session}/{obj_name}: {e}")
         elif obj_type == "namespace":
             try:
                 self._core_v1_api.patch_namespace(name=obj_name, body=body)
-                self.log.info(
-                    f'Added label "{key}.{self.drunc_label}:{label}" to namespace "{obj_name}"'
-                )
+                self.log.info(f'Added label "{key}.{self.drunc_label}:{label}" to namespace "{obj_name}"')
             except self._api_error_v1_api as e:
                 self.log.error(f"Failed to apply label to namespace {obj_name}: {e}")
         else:
@@ -181,21 +160,15 @@ class K8sProcessManager(ProcessManager):
         return f"creator.{self.drunc_label}={self.__class__.__name__}"
 
     def _create_namespace(self, session):
-        if session in self.sessions_pending_deletion:
-            self.sessions_pending_deletion.remove(session)
-
+        if session in self.sessions_pending_deletion: self.sessions_pending_deletion.remove(session)
         try:
             self._core_v1_api.read_namespace(name=session)
         except self._api_error_v1_api as e:
             if e.status == 404:
                 self.log.info(f'Creating "{session}" session')
                 namespace_manifest = client.V1Namespace(
-                    api_version="v1",
-                    kind="Namespace",
-                    metadata=self._meta_v1_api(
-                        name=session,
-                        labels={"pod-security.kubernetes.io/enforce": "privileged"},
-                    ),
+                    api_version="v1", kind="Namespace",
+                    metadata=self._meta_v1_api(name=session, labels={"pod-security.kubernetes.io/enforce": "privileged"})
                 )
                 self._core_v1_api.create_namespace(body=namespace_manifest)
                 self._add_creator_label(session, "namespace")
@@ -204,114 +177,66 @@ class K8sProcessManager(ProcessManager):
 
     def _create_headless_service(self, podname, session, pod_uid):
         service_manifest = client.V1Service(
-            api_version="v1",
-            kind="Service",
+            api_version="v1", kind="Service",
             metadata=self._meta_v1_api(
-                name=podname,
-                namespace=session,
+                name=podname, namespace=session,
                 labels={f"creator.{self.drunc_label}": self.__class__.__name__},
-                owner_references=[
-                    client.V1OwnerReference(
-                        api_version="v1",
-                        kind="Pod",
-                        name=podname,
-                        uid=pod_uid,
-                        controller=True,
-                        block_owner_deletion=True,
-                    )
-                ],
+                owner_references=[client.V1OwnerReference(
+                    api_version="v1", kind="Pod", name=podname, uid=pod_uid,
+                    controller=True, block_owner_deletion=True
+                )]
             ),
             spec=client.V1ServiceSpec(
-                cluster_ip="None",
-                selector={"app": podname},
+                cluster_ip="None", selector={"app": podname},
                 ports=[client.V1ServicePort(port=80, target_port=80)],
             ),
         )
         try:
-            self._core_v1_api.create_namespaced_service(
-                namespace=session, body=service_manifest
-            )
+            self._core_v1_api.create_namespaced_service(namespace=session, body=service_manifest)
             self.log.info(f'Created headless service "{session}.{podname}"')
         except self._api_error_v1_api as e:
-            if e.status != 409:  # Ignore if it already exists
-                self.log.error(f"Failed to create headless service for {podname}: {e}")
+            if e.status != 409: self.log.error(f"Failed to create headless service for {podname}: {e}")
 
     def _create_pod(self, podname, session, boot_request: BootRequest):
         pod_image = self.configuration.data.image
-
         exec_and_args_list = boot_request.process_description.executable_and_arguments
-        main_command_str = "; ".join(
-            [
-                " ".join([e_and_a.exec] + list(e_and_a.args))
-                for e_and_a in exec_and_args_list
-            ]
-        )
-
+        main_command_str = "; ".join([" ".join([e_and_a.exec] + list(e_and_a.args)) for e_and_a in exec_and_args_list])
         init_containers = []
-
         if len(exec_and_args_list) > 1 and exec_and_args_list[0].exec == "source":
             env_script_path = exec_and_args_list[0].args[0]
             main_app_name = exec_and_args_list[1].exec
-
-            # This command will loop until the environment script can be sourced AND the main application command is found in the PATH.
-            init_command_str = f"until source {env_script_path} && command -v {main_app_name} >/dev/null 2>&1; do echo 'Waiting for environment of {main_app_name} to be ready...'; sleep 1; done"
-
-            init_container = client.V1Container(
-                name="init-environment",
-                image=pod_image,
-                command=["sh", "-c"],
-                args=[init_command_str],
+            init_command_str = f"until source {env_script_path} && command -v {main_app_name} >/dev/null 2>&1; do echo 'Waiting for env for {main_app_name}...'; sleep 1; done"
+            init_containers.append(client.V1Container(
+                name="init-environment", image=pod_image, command=["sh", "-c"], args=[init_command_str],
                 volume_mounts=[
                     client.V1VolumeMount(name="nfs", mount_path="/nfs"),
                     client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
-                ],
-            )
-            init_containers.append(init_container)
-
-        env_vars = [
-            client.V1EnvVar(name=k, value=v)
-            for k, v in boot_request.process_description.env.items()
-        ]
-
+                ]
+            ))
         pod_manifest = client.V1Pod(
-            api_version="v1",
-            kind="Pod",
+            api_version="v1", kind="Pod",
             metadata=self._meta_v1_api(
-                name=podname,
-                namespace=session,
-                labels={
-                    "app": podname,
-                    f"creator.{self.drunc_label}": self.__class__.__name__,
-                },
+                name=podname, namespace=session,
+                labels={"app": podname, f"creator.{self.drunc_label}": self.__class__.__name__}
             ),
             spec=self._pod_spec_v1_api(
                 init_containers=init_containers,
                 restart_policy="Never",
-                containers=[
-                    client.V1Container(
-                        name=podname,
-                        image=pod_image,
-                        command=["sh", "-c"],
-                        args=[main_command_str],
-                        env=env_vars,
-                        volume_mounts=[
-                            client.V1VolumeMount(name="nfs", mount_path="/nfs"),
-                            client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
-                        ],
-                        working_dir=boot_request.process_description.process_execution_directory,
-                        security_context=client.V1SecurityContext(
-                            run_as_user=os.getuid(), run_as_group=os.getgid()
-                        ),
-                    )
-                ],
+                containers=[client.V1Container(
+                    name=podname, image=pod_image, command=["sh", "-c"],
+                    args=[main_command_str],
+                    env=[client.V1EnvVar(name=k, value=v) for k, v in boot_request.process_description.env.items()],
+                    ports=[client.V1ContainerPort(container_port=50051)], # <<< THIS IS THE NEW LINE
+                    volume_mounts=[
+                        client.V1VolumeMount(name="nfs", mount_path="/nfs"),
+                        client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
+                    ],
+                    working_dir=boot_request.process_description.process_execution_directory,
+                    security_context=client.V1SecurityContext(run_as_user=os.getuid(), run_as_group=os.getgid()),
+                )],
                 volumes=[
-                    client.V1Volume(
-                        name="nfs", host_path=client.V1HostPathVolumeSource(path="/nfs")
-                    ),
-                    client.V1Volume(
-                        name="cvmfs",
-                        host_path=client.V1HostPathVolumeSource(path="/cvmfs"),
-                    ),
+                    client.V1Volume(name="nfs", host_path=client.V1HostPathVolumeSource(path="/nfs")),
+                    client.V1Volume(name="cvmfs", host_path=client.V1HostPathVolumeSource(path="/cvmfs")),
                 ],
             ),
         )
@@ -327,47 +252,40 @@ class K8sProcessManager(ProcessManager):
     def _get_process_uid(self, query: ProcessQuery):
         if not any([query.uuids, query.names, query.session, query.user]):
             return list(self.boot_request.keys())
-
         matched_uuids = set()
         for proc_uuid, boot_req in self.boot_request.items():
             meta = boot_req.process_description.metadata
-            if any(uid.uuid == proc_uuid for uid in query.uuids):
-                matched_uuids.add(proc_uuid)
-            if query.session and query.session == meta.session:
-                matched_uuids.add(proc_uuid)
-            if query.user and query.user == meta.user:
-                matched_uuids.add(proc_uuid)
-            if any(re.search(name_reg, meta.name) for name_reg in query.names):
-                matched_uuids.add(proc_uuid)
+            if any(uid.uuid == proc_uuid for uid in query.uuids): matched_uuids.add(proc_uuid)
+            if query.session and query.session == meta.session: matched_uuids.add(proc_uuid)
+            if query.user and query.user == meta.user: matched_uuids.add(proc_uuid)
+            if any(re.search(name_reg, meta.name) for name_reg in query.names): matched_uuids.add(proc_uuid)
         return list(matched_uuids)
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         uuids = self._get_process_uid(log_request.query)
-        # Add in_boot_request=True to check the correct dictionary
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
-
         podname = self.boot_request[uuid].process_description.metadata.name
         session = self.boot_request[uuid].process_description.metadata.session
         try:
             logs = self._core_v1_api.read_namespaced_pod_log(
                 podname, session, tail_lines=log_request.how_far or 100
             )
-            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=logs.split("\n"))
+            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=logs.split('\n'))
         except self._api_error_v1_api as e:
-            return LogLines(
-                uuid=ProcessUUID(uuid=uuid),
-                lines=[f"Could not retrieve logs: {e.reason}"],
-            )
+            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=[f"Could not retrieve logs: {e.reason}"])
 
-    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
-        return self.__boot(boot_request, str(uuid.uuid4()))
+    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstanceList:
+        self.log.debug(f"{self.name} running boot command")
+        this_uuid = str(uuid.uuid4())
+        process = self.__boot(boot_request, this_uuid)
+        return ProcessInstanceList(values=[process])
 
     def __boot(self, boot_request: BootRequest, uuid: str) -> ProcessInstance:
         session = boot_request.process_description.metadata.session
         podname = boot_request.process_description.metadata.name
         if uuid in self.boot_request:
             raise DruncCommandException(f'"{session}.{podname}":{uuid} already exists!')
-
+        
         self.boot_request[uuid] = BootRequest()
         self.boot_request[uuid].CopyFrom(boot_request)
 
@@ -381,89 +299,57 @@ class K8sProcessManager(ProcessManager):
         pr.CopyFrom(self.boot_request[uuid].process_restriction)
 
         return ProcessInstance(
-            process_description=pd,
-            process_restriction=pr,
-            status_code=ProcessInstance.StatusCode.RUNNING,
-            uuid=pu,
+            process_description=pd, process_restriction=pr,
+            status_code=ProcessInstance.StatusCode.RUNNING, uuid=pu,
         )
 
     def _ps_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         queried_uuids = self._get_process_uid(query)
-        if not queried_uuids:
-            return ProcessInstanceList()
-
+        if not queried_uuids: return ProcessInstanceList(values=[])
         all_pods = self._core_v1_api.list_pod_for_all_namespaces(
             label_selector=self._get_creator_label_selector()
         )
-        uuid_to_pod = {
-            p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in all_pods.items
-        }
-
+        uuid_to_pod = {p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in all_pods.items}
         ret = []
-        for proc_uuid in queried_uuids:  # Renamed 'uuid' to 'proc_uuid'
-            if proc_uuid not in self.boot_request:
-                continue
-
+        for proc_uuid in queried_uuids:
+            if proc_uuid not in self.boot_request: continue
             pod = uuid_to_pod.get(proc_uuid)
             status_code = ProcessInstance.StatusCode.DEAD
             return_code = None
             if pod:
-                if pod.status.phase == "Running":
+                if pod.status.phase == 'Running':
                     status_code = ProcessInstance.StatusCode.RUNNING
-                elif pod.status.phase in ["Succeeded", "Failed"]:
-                    if (
-                        pod.status.container_statuses
-                        and pod.status.container_statuses[0].state.terminated
-                    ):
-                        return_code = pod.status.container_statuses[
-                            0
-                        ].state.terminated.exit_code
-
-            pd, pr, pu = (
-                ProcessDescription(),
-                ProcessRestriction(),
-                ProcessUUID(uuid=proc_uuid),
-            )
+                elif pod.status.phase in ['Succeeded', 'Failed']:
+                    if pod.status.container_statuses and pod.status.container_statuses[0].state.terminated:
+                        return_code = pod.status.container_statuses[0].state.terminated.exit_code
+            pd, pr, pu = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=proc_uuid)
             pd.CopyFrom(self.boot_request[proc_uuid].process_description)
             pr.CopyFrom(self.boot_request[proc_uuid].process_restriction)
-
-            ret.append(
-                ProcessInstance(
-                    process_description=pd,
-                    process_restriction=pr,
-                    status_code=status_code,
-                    return_code=return_code,
-                    uuid=pu,
-                )
-            )
+            ret.append(ProcessInstance(
+                process_description=pd, process_restriction=pr,
+                status_code=status_code, return_code=return_code, uuid=pu,
+            ))
         return ProcessInstanceList(values=ret)
-
-    def _restart_impl(
-        self, query: ProcessQuery
-    ) -> ProcessInstance:  # Corrected the return type hint
+        
+    def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         uuids = self._get_process_uid(query)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
 
         if uuid not in self.boot_request:
-            raise DruncCommandException(
-                f"Cannot restart process with UUID {uuid}: Not found."
-            )
+            raise DruncCommandException(f"Cannot restart process with UUID {uuid}: Not found.")
 
+        # Store the original boot request before we kill the process
         br_copy = BootRequest()
         br_copy.CopyFrom(self.boot_request[uuid])
 
-        pd = self.boot_request[uuid].process_description
-        podname, session = pd.metadata.name, pd.metadata.session
-        self.log.info(
-            f"Restarting pod '{session}/{podname}'. First, killing the old one."
-        )
-        self._kill_pod(podname, session)
-        self._kill_if_empty_session(session)
+        # Use the full kill implementation to ensure a complete cleanup
+        kill_query = ProcessQuery(uuids=[ProcessUUID(uuid=uuid)])
+        self._kill_impl(kill_query)
 
-        del self.boot_request[uuid]
-
-        ret = self.__boot(br_copy, uuid)
-        return ret
+        # Now, boot the new instance with the same config and UUID
+        restarted_process = self.__boot(br_copy, uuid)
+        
+        return ProcessInstanceList(values=[restarted_process])   
 
     def _kill_pod(self, podname, session):
         try:
@@ -473,86 +359,57 @@ class K8sProcessManager(ProcessManager):
                 raise e
 
     def _kill_if_empty_session(self, session):
-        # If we have already started deleting this session, do nothing.
-        if session in self.sessions_pending_deletion:
-            return
-
+        if session in self.sessions_pending_deletion: return
         try:
             pods = self._core_v1_api.list_namespaced_pod(
                 session, label_selector=self._get_creator_label_selector()
             )
             if not pods.items:
-                # Mark this session for deletion BEFORE we send the request.
                 self.sessions_pending_deletion.add(session)
                 self.log.info(f'Session "{session}" is empty, deleting namespace.')
                 self._core_v1_api.delete_namespace(session)
         except self._api_error_v1_api as e:
-            if e.status == 404:
-                self.sessions_pending_deletion.add(session)
-            else:
-                self.log.warning(f"Failed to check/delete empty session {session}: {e}")
+            if e.status == 404: self.sessions_pending_deletion.add(session)
+            else: self.log.warning(f"Failed to check/delete empty session {session}: {e}")
 
     def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         ret = []
         uuids_to_kill = self._get_process_uid(query)
-
         for proc_uuid in uuids_to_kill:
-            if proc_uuid not in self.boot_request:
-                continue
-
+            if proc_uuid not in self.boot_request: continue
             pd = self.boot_request[proc_uuid].process_description
             podname, session = pd.metadata.name, pd.metadata.session
             self.log.info(f'Killing pod "{session}/{podname}" (UUID {proc_uuid})')
-
             try:
                 self._kill_pod(podname, session)
             except Exception as e:
                 self.log.error(f"Failed to issue kill for pod {podname}: {e}")
                 continue
-
-            pd_copy, pr_copy, pu_copy = (
-                ProcessDescription(),
-                ProcessRestriction(),
-                ProcessUUID(uuid=proc_uuid),
-            )
+            pd_copy, pr_copy, pu_copy = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=proc_uuid)
             pd_copy.CopyFrom(self.boot_request[proc_uuid].process_description)
             pr_copy.CopyFrom(self.boot_request[proc_uuid].process_restriction)
-
             ret.append(
                 ProcessInstance(
-                    process_description=pd_copy,
-                    process_restriction=pr_copy,
-                    status_code=ProcessInstance.StatusCode.DEAD,
-                    uuid=pu_copy,
+                    process_description=pd_copy, process_restriction=pr_copy,
+                    status_code=ProcessInstance.StatusCode.DEAD, uuid=pu_copy,
                 )
             )
             del self.boot_request[proc_uuid]
-
-        # The check for empty sessions is no longer done here
         return ProcessInstanceList(values=ret)
 
     def _terminate_impl(self) -> ProcessInstanceList:
         self.log.info("Terminating all known K8s processes.")
         if not self.boot_request:
             self.log.info("No processes to terminate.")
-            return ProcessInstanceList()
-
-        # This correctly creates a query to kill all processes known to this manager,
-        # identical to the SSHProcessManager's behavior.
+            return ProcessInstanceList(values=[])
         all_processes_query = ProcessQuery(names=[".*"])
         return self._kill_impl(all_processes_query)
 
-    def flush(self, request: "Request", context: "ServicerContext") -> Response:
+    def _flush_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+        # This implementation is a safe no-op for now.
         self.log.info(
             "The 'flush' command is not needed for the K8sProcessManager. "
             "Cleanup of dead processes is handled automatically in real-time."
         )
-        # We must return a valid, empty ProcessInstanceList inside a Response object.
-        pil = ProcessInstanceList(values=[])
-        return Response(
-            name=self.name,
-            token=None,
-            data=pack_to_any(pil),
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-            children=[],
-        )
+        return ProcessInstanceList(values=[])
+

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -198,25 +198,35 @@ class K8sProcessManager(ProcessManager):
                 self.log.error(f"Failed to create headless service for {podname}: {e}")
 
     def _create_pod(self, podname, session, boot_request: BootRequest):
-        pod_image = "ghcr.io/dune-daq/alma9:latest"
+        pod_image = self.configuration.data.image
         
-        original_exec_and_args = "; ".join([
+        exec_and_args_list = boot_request.process_description.executable_and_arguments
+        main_command_str = "; ".join([
             " ".join([e_and_a.exec] + list(e_and_a.args))
-            for e_and_a in boot_request.process_description.executable_and_arguments
+            for e_and_a in exec_and_args_list
         ])
-
-        wait_command = ""
-        if boot_request.process_description.executable_and_arguments:
-            first_e_and_a = boot_request.process_description.executable_and_arguments[0]
-            file_to_wait_for = ""
-            if first_e_and_a.exec == "source" and first_e_and_a.args:
-                file_to_wait_for = first_e_and_a.args[0]
-            else:
-                file_to_wait_for = first_e_and_a.exec
-            if file_to_wait_for:
-                wait_command = f"while [ ! -f {file_to_wait_for} ]; do echo 'Waiting for {file_to_wait_for} to be available...'; sleep 0.5; done;"
         
-        final_exec_and_args = f"{wait_command} {original_exec_and_args}"
+        init_containers = []
+        # Check if the boot request follows the pattern: 1. source script, 2. run command
+        if len(exec_and_args_list) > 1 and exec_and_args_list[0].exec == "source":
+            env_script_path = exec_and_args_list[0].args[0]
+            main_app_name = exec_and_args_list[1].exec
+
+            # This command will loop until the environment script can be sourced AND the main application command is found in the PATH.
+            init_command_str = f"until source {env_script_path} && command -v {main_app_name} >/dev/null 2>&1; do echo 'Waiting for environment of {main_app_name} to be ready...'; sleep 1; done"
+            
+            init_container = client.V1Container(
+                name="init-environment",
+                image=pod_image,
+                command=["sh", "-c"],
+                args=[init_command_str],
+                volume_mounts=[
+                    client.V1VolumeMount(name="nfs", mount_path="/nfs"),
+                    client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
+                ]
+            )
+            init_containers.append(init_container)
+
         env_vars = [client.V1EnvVar(name=k, value=v) for k, v in boot_request.process_description.env.items()]
 
         pod_manifest = client.V1Pod(
@@ -228,11 +238,13 @@ class K8sProcessManager(ProcessManager):
                 labels={"app": podname, f"creator.{self.drunc_label}": self.__class__.__name__}
             ),
             spec=self._pod_spec_v1_api(
+                init_containers=init_containers, # Add the init container to the spec
                 restart_policy="Never",
                 containers=[
                     client.V1Container(
                         name=podname, image=pod_image, command=["sh", "-c"],
-                        args=[final_exec_and_args], env=env_vars,
+                        args=[main_command_str], # The main container now runs the original command without a wait loop
+                        env=env_vars,
                         volume_mounts=[
                             client.V1VolumeMount(name="nfs", mount_path="/nfs"),
                             client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -8,6 +8,7 @@ import tempfile
 import threading
 import uuid
 from time import sleep
+from collections import deque
 
 # Third-Party Imports
 from grpc import ServicerContext
@@ -82,8 +83,8 @@ class K8sProcessManager(ProcessManager):
         self.session = getpass.getuser()
         super().__init__(configuration=configuration, session=self.session, **kwargs)
         self.log = get_logger("process_manager.k8s-process-manager")
-        
-        config.load_kube_config() 
+
+        config.load_kube_config()
 
         self._k8s_client = client
         self._core_v1_api = client.CoreV1Api()
@@ -96,6 +97,14 @@ class K8sProcessManager(ProcessManager):
         self._start_watcher()
         self.sessions_pending_deletion = set()
         self.port_forwards = {}
+
+        try:
+            timeout_val = self.configuration.data.kill_timeout
+            self.kill_timeout = timeout_val if timeout_val is not None else 10
+        except AttributeError:
+            self.kill_timeout = 10
+        self.log.debug(f'Using kill_timeout of {self.kill_timeout} seconds.')
+
 
         namespaces = self._core_v1_api.list_namespace(
             label_selector=f"creator.{self.drunc_label}={self.__class__.__name__}"
@@ -136,7 +145,7 @@ class K8sProcessManager(ProcessManager):
 
     def _add_label(self, obj_name, obj_type, key, label, session=None):
         body = {"metadata": {"labels": {f"{key}.{self.drunc_label}": label}}}
-        
+
         if obj_type == "pod":
             if not session: raise DruncException("Session (namespace) must be provided to label a pod.")
             try:
@@ -226,7 +235,7 @@ class K8sProcessManager(ProcessManager):
                     name=podname, image=pod_image, command=["sh", "-c"],
                     args=[main_command_str],
                     env=[client.V1EnvVar(name=k, value=v) for k, v in boot_request.process_description.env.items()],
-                    ports=[client.V1ContainerPort(container_port=50051)], # <<< THIS IS THE NEW LINE
+                    ports=[client.V1ContainerPort(container_port=50051)],
                     volume_mounts=[
                         client.V1VolumeMount(name="nfs", mount_path="/nfs"),
                         client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
@@ -249,17 +258,43 @@ class K8sProcessManager(ProcessManager):
             self.log.error(f'Couldn\'t create pod "{session}.{podname}": {e}')
             raise e
 
-    def _get_process_uid(self, query: ProcessQuery):
-        if not any([query.uuids, query.names, query.session, query.user]):
-            return list(self.boot_request.keys())
-        matched_uuids = set()
+    def _get_process_uid(self, query: ProcessQuery, order_by: str = None):
+        # First, find all processes that match the query
+        initial_match = set()
         for proc_uuid, boot_req in self.boot_request.items():
             meta = boot_req.process_description.metadata
-            if any(uid.uuid == proc_uuid for uid in query.uuids): matched_uuids.add(proc_uuid)
-            if query.session and query.session == meta.session: matched_uuids.add(proc_uuid)
-            if query.user and query.user == meta.user: matched_uuids.add(proc_uuid)
-            if any(re.search(name_reg, meta.name) for name_reg in query.names): matched_uuids.add(proc_uuid)
-        return list(matched_uuids)
+            query_is_empty = not any([query.uuids, query.names, query.session, query.user])
+
+            if query_is_empty or \
+               any(uid.uuid == proc_uuid for uid in query.uuids) or \
+               (query.session and query.session == meta.session) or \
+               (query.user and query.user == meta.user) or \
+               any(re.search(name_reg, meta.name) for name_reg in query.names):
+                initial_match.add(proc_uuid)
+
+        # If no ordering is required, return the matched list
+        if order_by != "leaf_first":
+            return list(initial_match)
+
+        self.log.debug("Sorting processes in leaf-first order using tree_id.")
+
+        # Create a list of tuples (uuid, tree_id) for the matched processes.
+        procs_to_sort = []
+        for uuid in initial_match:
+            if uuid in self.boot_request:
+                tree_id = self.boot_request[uuid].process_description.metadata.tree_id
+                procs_to_sort.append((uuid, tree_id))
+
+        # Sort the list. The key is a tuple: (-len(tree_id), tree_id).
+        # -len sorts by length in descending order (longest ID string is a leaf).
+        # tree_id is the secondary key for stable sorting of nodes at the same depth.
+        procs_to_sort.sort(key=lambda p: (-len(p[1]), p[1]))
+
+        # Extract just the UUIDs from the now-sorted list.
+        sorted_uuids = [uuid for uuid, tree_id in procs_to_sort]
+
+        return sorted_uuids
+
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
         uuids = self._get_process_uid(log_request.query)
@@ -285,7 +320,7 @@ class K8sProcessManager(ProcessManager):
         podname = boot_request.process_description.metadata.name
         if uuid in self.boot_request:
             raise DruncCommandException(f'"{session}.{podname}":{uuid} already exists!')
-        
+
         self.boot_request[uuid] = BootRequest()
         self.boot_request[uuid].CopyFrom(boot_request)
 
@@ -330,7 +365,7 @@ class K8sProcessManager(ProcessManager):
                 status_code=status_code, return_code=return_code, uuid=pu,
             ))
         return ProcessInstanceList(values=ret)
-        
+
     def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         uuids = self._get_process_uid(query)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
@@ -348,12 +383,16 @@ class K8sProcessManager(ProcessManager):
 
         # Now, boot the new instance with the same config and UUID
         restarted_process = self.__boot(br_copy, uuid)
-        
-        return ProcessInstanceList(values=[restarted_process])   
 
-    def _kill_pod(self, podname, session):
+        return ProcessInstanceList(values=[restarted_process])
+
+    def _kill_pod(self, podname, session, grace_period=None):
         try:
-            self._core_v1_api.delete_namespaced_pod(podname, session)
+            self._core_v1_api.delete_namespaced_pod(
+                podname,
+                session,
+                grace_period_seconds=grace_period
+            )
         except self._api_error_v1_api as e:
             if e.status != 404:
                 raise e
@@ -374,14 +413,15 @@ class K8sProcessManager(ProcessManager):
 
     def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         ret = []
-        uuids_to_kill = self._get_process_uid(query)
+        uuids_to_kill = self._get_process_uid(query, order_by="leaf_first")
+
         for proc_uuid in uuids_to_kill:
             if proc_uuid not in self.boot_request: continue
             pd = self.boot_request[proc_uuid].process_description
             podname, session = pd.metadata.name, pd.metadata.session
             self.log.info(f'Killing pod "{session}/{podname}" (UUID {proc_uuid})')
             try:
-                self._kill_pod(podname, session)
+                self._kill_pod(podname, session, grace_period=self.kill_timeout)
             except Exception as e:
                 self.log.error(f"Failed to issue kill for pod {podname}: {e}")
                 continue

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -2,9 +2,11 @@ import getpass
 import os
 import re
 import socket
+import threading
 import uuid
 from time import sleep
 
+from druncschema.broadcast_pb2 import BroadcastType
 from druncschema.process_manager_pb2 import (
     BootRequest,
     LogLines,
@@ -16,8 +18,7 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
     ProcessUUID,
 )
-from druncschema.request_response_pb2 import ResponseFlag
-from kubernetes import client, config
+from kubernetes import client, config, watch
 
 from drunc.exceptions import DruncCommandException, DruncException
 from drunc.k8s_exceptions import DruncK8sNamespaceAlreadyExists
@@ -25,138 +26,147 @@ from drunc.process_manager.process_manager import ProcessManager
 from drunc.utils.utils import get_logger
 
 
+class K8sPodWatcherThread(threading.Thread):
+    def __init__(self, pm):
+        threading.Thread.__init__(self)
+        self.pm = pm
+        self.daemon = True
+
+    def run(self):
+        self.pm.log.info("K8sPodWatcherThread started")
+        while True:
+            try:
+                w = watch.Watch()
+                stream = w.stream(
+                    self.pm._core_v1_api.list_pod_for_all_namespaces,
+                    label_selector=self.pm._get_creator_label_selector(),
+                )
+                for event in stream:
+                    pod = event["object"]
+                    event_type = event["type"]
+                    metadata = pod.metadata
+                    status = pod.status
+                    phase = status.phase
+                    uuid = metadata.labels.get(f"uuid.{self.pm.drunc_label}")
+
+                    if not uuid:
+                        continue
+
+                    if event_type in ["MODIFIED", "DELETED"] and phase in ["Succeeded", "Failed"]:
+                        exit_code = -1
+                        reason = "Unknown"
+                        if status.container_statuses and status.container_statuses[0].state.terminated:
+                            terminated_state = status.container_statuses[0].state.terminated
+                            exit_code = terminated_state.exit_code
+                            reason = terminated_state.reason
+                        self.pm.notify_termination(uuid, exit_code, reason)
+
+            except Exception as e:
+                self.pm.log.error(f"K8s watcher thread error: {e}. Restarting watch.")
+                sleep(5)
+
+
 class K8sProcessManager(ProcessManager):
     def __init__(self, configuration, **kwargs):
-        self.session = getpass.getuser()  # unfortunate
+        self.session = getpass.getuser()
         super().__init__(configuration=configuration, session=self.session, **kwargs)
         self.log = get_logger("process_manager.k8s-process-manager")
         config.load_kube_config()
 
         self._k8s_client = client
         self._core_v1_api = client.CoreV1Api()
-
-        self._ns_v1_api = client.V1Namespace
         self._meta_v1_api = client.V1ObjectMeta
-        self._container_v1_api = client.V1Container
-        self._api_error_v1_api = client.rest.ApiException
-        self._pod_v1_api = client.V1Pod
         self._pod_spec_v1_api = client.V1PodSpec
-        self._pod_security_context_v1_api = client.V1PodSecurityContext
-        self._security_context_v1_api = client.V1SecurityContext
-        self._capabilities_v1_api = client.V1Capabilities
+        self._api_error_v1_api = client.rest.ApiException
 
         self.drunc_label = "drunc.daq"
+        self.watchers = []
+        self._start_watcher()
 
         namespaces = self._core_v1_api.list_namespace(
             label_selector=f"creator.{self.drunc_label}={self.__class__.__name__}"
         )
-
         namespace_names = [ns.metadata.name for ns in namespaces.items]
         namespace_list_str = "\n - ".join(namespace_names)
 
         if namespace_list_str:
-            namespace_list_str = "\n - " + namespace_list_str
-            self.log.info(f"Active namespaces created by drunc:{namespace_list_str}")
-
+            self.log.info(f"Active namespaces created by drunc:\n - {namespace_list_str}")
         else:
             self.log.info("No active namespace created by drunc")
 
+    def _start_watcher(self):
+        self.log.debug("Starting K8s pod watcher thread")
+        t = K8sPodWatcherThread(pm=self)
+        t.start()
+        self.watchers.append(t)
+
+    def notify_termination(self, uuid, exit_code, reason):
+        if uuid not in self.boot_request:
+            self.log.debug(f"Received termination for already-removed UUID {uuid}")
+            return
+
+        meta = self.boot_request[uuid].process_description.metadata
+        end_str = f"Pod '{meta.name}' (session: '{meta.session}', user: '{meta.user}', uuid: {uuid}) terminated with exit code {exit_code}. Reason: {reason}"
+        self.log.info(end_str)
+        self.broadcast(end_str, BroadcastType.SUBPROCESS_STATUS_UPDATE)
+
     def is_alive(self, podname, session):
-        pods = self._core_v1_api.list_namespaced_pod(session)
-        pod_names = [pod.metadata.name for pod in pods.items]
-        if podname in pod_names:
-            for _ in range(10):
-                s = self._core_v1_api.read_namespaced_pod_status(podname, session)
-                for cond in s.status.conditions:
-                    if cond.type == "Ready" and cond.status == "True":
-                        return True
-        else:
-            return False
+        try:
+            pod_status = self._core_v1_api.read_namespaced_pod_status(podname, session)
+            return pod_status.status.phase == "Running"
+        except self._api_error_v1_api as e:
+            if e.status == 404:
+                return False
+            else:
+                self.log.error(f"Error checking status for pod {session}.{podname}: {e}")
+                return False
 
-    def _add_label(self, obj_name, obj_type, key, label):
+    def _add_label(self, obj_name, obj_type, key, label, session=None):
         body = {"metadata": {"labels": {f"{key}.{self.drunc_label}": label}}}
+        
+        if obj_type == "pod":
+            if not session:
+                raise DruncException("Session (namespace) must be provided to label a pod.")
+            try:
+                self._core_v1_api.patch_namespaced_pod(name=obj_name, namespace=session, body=body)
+            except self._api_error_v1_api as e:
+                self.log.error(f"Failed to apply label to pod {session}/{obj_name}: {e}")
 
-        if obj_type == "namespace":
-            self._core_v1_api.patch_namespace(obj_name, body)
-            self.log.info(
-                f'Added label "{key}.{self.drunc_label}:{label}" to "{obj_name}" session'
-            )
-        elif obj_type == "pod":
-            session = self._get_pod_namespace(obj_name)
-            self._core_v1_api.patch_namespaced_pod(obj_name, session, body)
-            self.log.info(
-                f'Added label "{key}.{self.drunc_label}:{label}" to "{session}.{obj_name}"'
-            )
+        elif obj_type == "namespace":
+            try:
+                self._core_v1_api.patch_namespace(name=obj_name, body=body)
+            except self._api_error_v1_api as e:
+                self.log.error(f"Failed to apply label to namespace {obj_name}: {e}")
         else:
             raise DruncException(f"Cannot add label to object type: {obj_type}")
 
-    def _get_pod_namespace(self, podname):
-        pods = self._core_v1_api.list_pod_for_all_namespaces()
-        for pod in pods.items:
-            if pod.metadata.name == podname:
-                return pod.metadata.namespace
-
     def _add_creator_label(self, obj_name, obj_type):
-        return self._add_label(obj_name, obj_type, "creator", self.__class__.__name__)
+        self._add_label(obj_name, obj_type, "creator", self.__class__.__name__)
 
     def _get_creator_label_selector(self):
-        label = f"creator.{self.drunc_label}={self.__class__.__name__}"
-        return label
+        return f"creator.{self.drunc_label}={self.__class__.__name__}"
 
     def _create_namespace(self, session):
-        ns_list = self._core_v1_api.list_namespace(
-            label_selector=self._get_creator_label_selector(),
-        )
-        ns_names = [ns.metadata.name for ns in ns_list.items]
-
-        if session not in ns_names:
-            self.log.info(f'Creating "{session}" session')
-            namespace_manifest = {
-                "apiVersion": "v1",
-                "kind": "Namespace",
-                "metadata": {
-                    "name": session,
-                    "labels": {
-                        "pod-security.kubernetes.io/enforce": "privileged",
-                        "pod-security.kubernetes.io/enforce-version": "latest",
-                        "pod-security.kubernetes.io/warn": "privileged",
-                        "pod-security.kubernetes.io/warn-version": "latest",
-                        "pod-security.kubernetes.io/audit": "privileged",
-                        "pod-security.kubernetes.io/audit-version": "latest",
-                    },
-                },
-            }
-            self._core_v1_api.create_namespace(namespace_manifest)
-            self._add_creator_label(session, "namespace")
-        else:
-            return DruncK8sNamespaceAlreadyExists(f'"{session}" session already exists')
-
-    def _volume(self, name, host_path):
-        return self._k8s_client.V1Volume(
-            name=name, host_path=self._k8s_client.V1HostPathVolumeSource(path=host_path)
-        )
-
-    def _volume_mount(self, name, mount_path):
-        return self._k8s_client.V1VolumeMount(name=name, mount_path=mount_path)
-
-    def _env_vars(self, env_var):
-        env_vars_list = [
-            self._k8s_client.models.V1EnvVar(name=k, value=v)
-            for k, v in env_var.items()
-        ]
-        return env_vars_list
-
-    def _execs_and_args(self, executable_and_arguments=[]):
-        exec_and_args = []
-        for e_and_a in executable_and_arguments:
-            args = [a for a in e_and_a.args]
-            exec_and_args += [" ".join([e_and_a.exec] + args)]
-            # exec_and_args = ["source rte", "daq_application --something argument"]
-        exec_and_args = "; ".join(exec_and_args)
-        return exec_and_args
+        try:
+            self._core_v1_api.read_namespace(name=session)
+        except self._api_error_v1_api as e:
+            if e.status == 404:
+                self.log.info(f'Creating "{session}" session')
+                namespace_manifest = client.V1Namespace(
+                    api_version="v1",
+                    kind="Namespace",
+                    metadata=self._meta_v1_api(
+                        name=session,
+                        labels={"pod-security.kubernetes.io/enforce": "privileged"}
+                    )
+                )
+                self._core_v1_api.create_namespace(body=namespace_manifest)
+                self._add_creator_label(session, "namespace")
+            else:
+                raise e
 
     def _create_headless_service(self, podname, session, pod_uid):
-        service_manifest = self._k8s_client.V1Service(
+        service_manifest = client.V1Service(
             api_version="v1",
             kind="Service",
             metadata=self._meta_v1_api(
@@ -164,7 +174,7 @@ class K8sProcessManager(ProcessManager):
                 namespace=session,
                 labels={f"creator.{self.drunc_label}": self.__class__.__name__},
                 owner_references=[
-                    self._k8s_client.V1OwnerReference(
+                    client.V1OwnerReference(
                         api_version="v1",
                         kind="Pod",
                         name=podname,
@@ -174,429 +184,233 @@ class K8sProcessManager(ProcessManager):
                     )
                 ],
             ),
-            spec=self._k8s_client.V1ServiceSpec(
-                cluster_ip="None",  # Headless service
+            spec=client.V1ServiceSpec(
+                cluster_ip="None",
                 selector={"app": podname},
-                ports=[self._k8s_client.V1ServicePort(port=80, target_port=80)],
+                ports=[client.V1ServicePort(port=80, target_port=80)],
             ),
         )
-
         try:
             self._core_v1_api.create_namespaced_service(namespace=session, body=service_manifest)
             self.log.info(f'Created headless service "{session}.{podname}"')
         except self._api_error_v1_api as e:
-            self.log.error(f"Failed to create headless service for {podname}: {e}")
+            if e.status != 409: # Ignore if it already exists
+                self.log.error(f"Failed to create headless service for {podname}: {e}")
 
     def _create_pod(self, podname, session, boot_request: BootRequest):
-        # HACK
-        hostname = socket.gethostname()
-        # / HACK
+        pod_image = "ghcr.io/dune-daq/alma9:latest"
+        
+        original_exec_and_args = "; ".join([
+            " ".join([e_and_a.exec] + list(e_and_a.args))
+            for e_and_a in boot_request.process_description.executable_and_arguments
+        ])
 
-        pod_image = self.configuration.data.image
-        #pod_image = boot_request.process_description.metadata.pod_image or "ghcr.io/dune-daq/alma9:latest"
+        wait_command = ""
+        if boot_request.process_description.executable_and_arguments:
+            first_e_and_a = boot_request.process_description.executable_and_arguments[0]
+            file_to_wait_for = ""
+            if first_e_and_a.exec == "source" and first_e_and_a.args:
+                file_to_wait_for = first_e_and_a.args[0]
+            else:
+                file_to_wait_for = first_e_and_a.exec
+            if file_to_wait_for:
+                wait_command = f"while [ ! -f {file_to_wait_for} ]; do echo 'Waiting for {file_to_wait_for} to be available...'; sleep 0.5; done;"
+        
+        final_exec_and_args = f"{wait_command} {original_exec_and_args}"
+        env_vars = [client.V1EnvVar(name=k, value=v) for k, v in boot_request.process_description.env.items()]
 
-        # if not pod_image:
-        #     raise DruncException("No image specified in BootRequest")
-
-        pod = self._pod_v1_api(
+        pod_manifest = client.V1Pod(
             api_version="v1",
             kind="Pod",
-            metadata=self._meta_v1_api(name=podname, namespace=session, labels={"app": podname}),
+            metadata=self._meta_v1_api(
+                name=podname, 
+                namespace=session,
+                labels={"app": podname, f"creator.{self.drunc_label}": self.__class__.__name__}
+            ),
             spec=self._pod_spec_v1_api(
                 restart_policy="Never",
                 containers=[
-                    self._container_v1_api(
-                        name=podname,
-                        image=pod_image,
-                        command=["sh"],
-                        # args = ["-c", "exit 3"],
-                        args=[
-                            "-c",
-                            self._execs_and_args(
-                                boot_request.process_description.executable_and_arguments
-                            ),
-                        ],
-                        # args = ["-c", "sleep 3600"],
-                        env=self._env_vars(boot_request.process_description.env),
+                    client.V1Container(
+                        name=podname, image=pod_image, command=["sh", "-c"],
+                        args=[final_exec_and_args], env=env_vars,
                         volume_mounts=[
-                            #self._volume_mount("pwd", os.getcwd()),
-                            self._volume_mount("cvmfs", "/cvmfs/"),
-                            self._volume_mount("nfs", "/nfs/"),
+                            client.V1VolumeMount(name="nfs", mount_path="/nfs"),
+                            client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
                         ],
                         working_dir=boot_request.process_description.process_execution_directory,
-                        restart_policy="Never",
-                        security_context=self._security_context_v1_api(
-                            run_as_user=os.getuid(),
-                            run_as_group=os.getgid(),
-                            run_as_non_root=True,
-                            allow_privilege_escalation=False,
-                            capabilities=self._capabilities_v1_api(drop=["ALL"]),
-                            seccomp_profile=self._k8s_client.V1SeccompProfile(
-                                type="RuntimeDefault"
-                            ),
-                        ),
+                        security_context=client.V1SecurityContext(run_as_user=os.getuid(), run_as_group=os.getgid()),
                     )
                 ],
                 volumes=[
-                    #self._volume("pwd", os.getcwd()),
-                    self._volume("cvmfs", "/cvmfs/"),
-                    self._volume("nfs", "/nfs/"),
+                    client.V1Volume(name="nfs", host_path=client.V1HostPathVolumeSource(path="/nfs")),
+                    client.V1Volume(name="cvmfs", host_path=client.V1HostPathVolumeSource(path="/cvmfs")),
                 ],
-                # HACK
-                affinity=(
-                    self._k8s_client.V1Affinity(
-                        self._k8s_client.V1NodeAffinity(
-                            required_during_scheduling_ignored_during_execution=self._k8s_client.V1NodeSelector(
-                                node_selector_terms=[
-                                    self._k8s_client.V1NodeSelectorTerm(
-                                        match_expressions=[
-                                            {
-                                                "key": "kubernetes.io/hostname",
-                                                "operator": "In",
-                                                "values": [hostname],
-                                            }
-                                        ]
-                                    )
-                                ]
-                            )
-                        )
-                    )
-                    if hostname.startswith("np04")
-                    else None
-                ),
-                # / HACK
-                security_context=self._pod_security_context_v1_api(
-                    run_as_user=os.getuid(),
-                    run_as_group=os.getgid(),
-                    run_as_non_root=True,
-                ),
             ),
         )
         try:
-            pods = self._core_v1_api.list_namespaced_pod(session)
-            if any(p.metadata.name == podname for p in pods.items):
-                self.log.warning(f'Pod "{session}.{podname}" already exists. Deleting it...')
-                self._core_v1_api.delete_namespaced_pod(
-                    podname, session, grace_period_seconds=0
-                )
-                for _ in range(10):
-                    sleep(1)
-                    pods = self._core_v1_api.list_namespaced_pod(session)
-                    if all(p.metadata.name != podname for p in pods.items):
-                        break
-                else:
-                    raise DruncException(f'Timed out waiting for pod "{session}.{podname}" to be deleted')
-
-            created_pod = self._core_v1_api.create_namespaced_pod(session, pod)
-            self.log.info(f'Creating "{session}.{podname}"')
-            self._add_creator_label(podname, "pod")
-
-            # Pass pod UID to the service creation so ownerReferences are set
+            created_pod = self._core_v1_api.create_namespaced_pod(session, pod_manifest)
+            self.log.info(f'Creating pod "{session}.{podname}"')
             pod_uid = created_pod.metadata.uid
             self._create_headless_service(podname, session, pod_uid)
-
-        except Exception as e:
-            self.log.error(
-                f'Couldn\'t create pod with name: "{session}.{podname}": {e}'
-            )
+        except self._api_error_v1_api as e:
+            self.log.error(f'Couldn\'t create pod "{session}.{podname}": {e}')
             raise e
 
-    def _get_process_uid(self, query: ProcessQuery, in_boot_request: bool = False):
-        uuid_selector = []
-        name_selector = query.names
-        user_selector = query.user
-        session_selector = query.session
-        # relevant reading here: https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md
+    def _get_process_uid(self, query: ProcessQuery):
+        if not any([query.uuids, query.names, query.session, query.user]):
+            return list(self.boot_request.keys())
 
-        processes = []
-
-        all_the_uuids = self.boot_request.keys()
-
-        for uid in query.uuids:
-            uuid_selector += [uid.uuid]
-
-        all_pods = []
-        for proc_uuid in all_the_uuids:
-            podname = self.boot_request[proc_uuid].process_description.metadata.name
-            all_pods.append(podname)
-
-        for proc_uuid in self.boot_request.keys():
-            accepted = False
-            meta = self.boot_request[proc_uuid].process_description.metadata
-
-            if proc_uuid in uuid_selector:
-                accepted = True
-
-            for name_reg in name_selector:
-                if re.search(name_reg, meta.name):
-                    accepted = True
-
-            if session_selector == meta.session:
-                accepted = True
-
-            if user_selector == meta.user:
-                accepted = True
-
-            if accepted:
-                processes.append(proc_uuid)
-
-        return processes
-
-    def _get_pi(self, uuid, podname, session, return_code=None):
-        pd = ProcessDescription()
-        pd.CopyFrom(self.boot_request[uuid].process_description)
-        pr = ProcessRestriction()
-        pr.CopyFrom(self.boot_request[uuid].process_restriction)
-        pu = ProcessUUID(uuid=uuid)
-
-        pi = ProcessInstance(
-            process_description=pd,
-            process_restriction=pr,
-            status_code=(
-                ProcessInstance.StatusCode.RUNNING
-                if self.is_alive(podname, session)
-                else ProcessInstance.StatusCode.DEAD
-            ),
-            return_code=return_code,
-            uuid=pu,
-        )
-        return pi
-
-    def _kill_pod(self, podname, session):
-        pods = self._core_v1_api.list_namespaced_pod(session)
-        pod_names = [pod.metadata.name for pod in pods.items]
-        if podname in pod_names:
-            self._core_v1_api.delete_namespaced_pod(
-                podname, session, grace_period_seconds=0
-            )
-            while podname in pod_names:
-                sleep(1)
-                pods = self._core_v1_api.list_namespaced_pod(session)
-                pod_names = [pod.metadata.name for pod in pods.items]
-        else:
-            pass
-
-    def _kill_if_empty_session(self, session):
-        pods = self._core_v1_api.list_namespaced_pod(
-            session,
-            label_selector=self._get_creator_label_selector(),
-        )
-        deletion_timestamps = [pod.metadata.deletion_timestamp for pod in pods.items]
-        if not pods.items or all(
-            timestamp is not None for timestamp in deletion_timestamps
-        ):
-            self.log.info(f'Killing empty "{session}" session')
-            self._core_v1_api.delete_namespace(session)
-
-            ns_list = self._core_v1_api.list_namespace(
-                label_selector=self._get_creator_label_selector(),
-            )
-            namespaces = [ns.metadata.name for ns in ns_list.items]
-            while session in namespaces:
-                sleep(1)
-                ns_list = self._core_v1_api.list_namespace(
-                    label_selector=self._get_creator_label_selector(),
-                )
-                namespaces = [ns.metadata.name for ns in ns_list.items]
-            else:
-                self.log.info(f'"{session}" session has been killed')
-                pass
-        else:
-            pass
-
-    def _return_code(self, podname, session):
-        pods = self._core_v1_api.list_namespaced_pod(session)
-        pod_names = [pod.metadata.name for pod in pods.items]
-        if podname not in pod_names:
-            return_code = None
-        else:
-            if not self.is_alive(podname, session):
-                container_statuses = (
-                    self._core_v1_api.read_namespaced_pod_status(podname, session)
-                    .status.container_statuses
-                )
-
-                if container_statuses:
-                    state = container_statuses[0].state
-                    self.log.debug(f"{podname} state: {state}")
-                    if state and state.terminated:
-                        return_code = state.terminated.exit_code
-                    else:
-                        return_code = None
-                else:
-                    return_code = None
-            else:
-                return_code = None
-        return return_code
-
-    # --------------------------------------Commands--------------------------------------
-
-    def _terminate(self):
-        self.log.info("Terminating")
-
-    def _terminate_impl(self):
-        return self._terminate()
+        matched_uuids = set()
+        for proc_uuid, boot_req in self.boot_request.items():
+            meta = boot_req.process_description.metadata
+            if any(uid.uuid == proc_uuid for uid in query.uuids):
+                matched_uuids.add(proc_uuid)
+            if query.session and query.session == meta.session:
+                matched_uuids.add(proc_uuid)
+            if query.user and query.user == meta.user:
+                matched_uuids.add(proc_uuid)
+            if any(re.search(name_reg, meta.name) for name_reg in query.names):
+                matched_uuids.add(proc_uuid)
+        return list(matched_uuids)
 
     def _logs_impl(self, log_request: LogRequest) -> LogLines:
-        uuids = self._get_process_uid(log_request.query, in_boot_request=True)
-        uuid = self._ensure_one_process(uuids, in_boot_request=True)
-        for uuid in self._get_process_uid(log_request.query):
-            podname = self.boot_request[uuid].process_description.metadata.name
-            session = self.boot_request[uuid].process_description.metadata.session
-            
-            return LogLines(lines=[log for log in self._core_v1_api.read_namespaced_pod_log(
-                podname, session, tail_lines=log_request.how_far
-            ).split("\n")])
+        uuids = self._get_process_uid(log_request.query)
+        uuid = self._ensure_one_process(uuids)
+        podname = self.boot_request[uuid].process_description.metadata.name
+        session = self.boot_request[uuid].process_description.metadata.session
+        try:
+            logs = self._core_v1_api.read_namespaced_pod_log(
+                podname, session, tail_lines=log_request.how_far or 100
+            )
+            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=logs.split('\n'))
+        except self._api_error_v1_api as e:
+            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=[f"Could not retrieve logs: {e.reason}"])
 
-    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstanceList:
-        self.log.debug(f"{self.name} running boot command")
-        this_uuid = str(uuid.uuid4())
-        process = self.__boot(boot_request, this_uuid)
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=[process],
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-        )
+    def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
+        return self.__boot(boot_request, str(uuid.uuid4()))
 
     def __boot(self, boot_request: BootRequest, uuid: str) -> ProcessInstance:
         session = boot_request.process_description.metadata.session
-        podnames = boot_request.process_description.metadata.name
+        podname = boot_request.process_description.metadata.name
         if uuid in self.boot_request:
-            raise DruncCommandException(
-                f'"{session}.{podnames}":{uuid} already exists!'
-            )
+            raise DruncCommandException(f'"{session}.{podname}":{uuid} already exists!')
+        
         self.boot_request[uuid] = BootRequest()
         self.boot_request[uuid].CopyFrom(boot_request)
 
         self._create_namespace(session)
-        self._create_pod(podnames, session, boot_request)
-        self._add_label(podnames, "pod", "uuid", uuid)
-        self.log.info(f'"{session}.{podnames}":{uuid} booted')
+        self._create_pod(podname, session, boot_request)
+        self._add_label(podname, "pod", "uuid", uuid, session=session)
+        self.log.info(f'"{session}.{podname}":{uuid} boot request sent.')
 
-        pods = self._core_v1_api.list_namespaced_pod(session)
-        pod_names = [pod.metadata.name for pod in pods.items]
+        pd, pr, pu = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=uuid)
+        pd.CopyFrom(self.boot_request[uuid].process_description)
+        pr.CopyFrom(self.boot_request[uuid].process_restriction)
 
-        for _ in range(10):
-            if podnames not in pod_names:
-                sleep(1)
-            else:
-                break
-        else:
-            raise DruncException(f'Not able to boot "{session}.{podnames}":{uuid}')
-        
-        try:
-            pod_info = self._core_v1_api.read_namespaced_pod(podnames, session)
-            node_name = pod_info.spec.node_name
-            self.boot_request[uuid].process_description.metadata.hostname = node_name
-        except Exception as e:
-            self.log.warning(f"Could not retrieve node name for pod {session}.{podnames}: {e}")
-
-        return self._get_pi(uuid, podnames, session)
-
-    def _ps_impl(
-        self, query: ProcessQuery, in_boot_request: bool = False
-    ) -> ProcessInstanceList:
-        ret = []
-        for proc_uuid in self._get_process_uid(query):
-            podname = self.boot_request[proc_uuid].process_description.metadata.name
-            session = self.boot_request[proc_uuid].process_description.metadata.session
-
-            return_code = self._return_code(podname, session)
-
-            ret.append(self._get_pi(proc_uuid, podname, session, return_code))
-
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=ret,
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
+        return ProcessInstance(
+            process_description=pd, process_restriction=pr,
+            status_code=ProcessInstance.StatusCode.RUNNING, uuid=pu,
         )
+
+    def _ps_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+        queried_uuids = self._get_process_uid(query)
+        if not queried_uuids: return ProcessInstanceList()
+
+        all_pods = self._core_v1_api.list_pod_for_all_namespaces(
+            label_selector=self._get_creator_label_selector()
+        )
+        uuid_to_pod = {p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in all_pods.items}
+        
+        ret = []
+        for uuid in queried_uuids:
+            if uuid not in self.boot_request: continue
+            
+            pod = uuid_to_pod.get(uuid)
+            status_code = ProcessInstance.StatusCode.DEAD
+            return_code = None
+            if pod:
+                if pod.status.phase == 'Running':
+                    status_code = ProcessInstance.StatusCode.RUNNING
+                elif pod.status.phase in ['Succeeded', 'Failed']:
+                    if pod.status.container_statuses and pod.status.container_statuses[0].state.terminated:
+                        return_code = pod.status.container_statuses[0].state.terminated.exit_code
+
+            pd, pr, pu = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=uuid)
+            pd.CopyFrom(self.boot_request[uuid].process_description)
+            pr.CopyFrom(self.boot_request[uuid].process_restriction)
+
+            ret.append(ProcessInstance(
+                process_description=pd, process_restriction=pr,
+                status_code=status_code, return_code=return_code, uuid=pu,
+            ))
+        return ProcessInstanceList(values=ret)
 
     def _restart_impl(self, query: ProcessQuery) -> ProcessInstanceList:
-        ret = []
-        uuids = self._get_process_uid(query, in_boot_request=True)
-        uuid = self._ensure_one_process(uuids, in_boot_request=True)
-        for uuid in self._get_process_uid(query):
-            podname = self.boot_request[uuid].process_description.metadata.name
-            session = self.boot_request[uuid].process_description.metadata.session
-            self.log.info(f'Restarting "{session}.{podname}":{uuid}')
+        uuids = self._get_process_uid(query)
+        uuid = self._ensure_one_process(uuids)
+        
+        br_copy = BootRequest()
+        br_copy.CopyFrom(self.boot_request[uuid])
+        
+        self._kill_impl(ProcessQuery(uuids=[ProcessUUID(uuid=uuid)]))
+        ret = self.__boot(br_copy, uuid)
+        return ProcessInstanceList(values=[ret])
 
-            self._kill_pod(podname, session)
+    def _kill_pod(self, podname, session):
+        try:
+            self._core_v1_api.delete_namespaced_pod(podname, session, grace_period_seconds=0)
+        except self._api_error_v1_api as e:
+            if e.status != 404: raise e
 
-            same_uuid_br = BootRequest()
-            same_uuid_br.CopyFrom(self.boot_request[uuid])
-            same_uuid = uuid
+    def _kill_if_empty_session(self, session):
+        try:
+            pods = self._core_v1_api.list_namespaced_pod(
+                session, label_selector=self._get_creator_label_selector()
+            )
+            if not pods.items:
+                self.log.info(f'Session "{session}" is empty, deleting namespace.')
+                self._core_v1_api.delete_namespace(session)
+        except self._api_error_v1_api as e:
+            if e.status != 404:
+                self.log.warning(f"Failed to check/delete empty session {session}: {e}")
 
-            del self.boot_request[uuid]
-            del uuid
+    def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
+        ret, sessions_affected = [], set()
+        uuids_to_kill = self._get_process_uid(query)
+        
+        for proc_uuid in uuids_to_kill:
+            if proc_uuid not in self.boot_request: continue
 
-            ret = [self.__boot(same_uuid_br, same_uuid)]
-            # ret.append(self._get_pi(uuid, podname, session))
-
-            del same_uuid_br
-            del same_uuid
-
-        return ProcessInstanceList(
-            name=self.name,
-            token=None,
-            values=ret,
-            flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
-        )
-
-    # # ORDER MATTERS!
-    # @broadcasted  # outer most wrapper 1st step
-    # @authentified_and_authorised(
-    #     action=ActionType.DELETE, system=SystemType.PROCESS_MANAGER
-    # )  # 2nd step
-    # @pack_response  # 3rd step
-    # def flush(self, request:Request, context:grpc.ServicerContext) -> Response:
-    #     try:
-    #         data = unpack_any(request.data, ProcessQuery)
-    #     except UnpackingError as e:
-    #         return unpack_error_response(self.__class__.__name__, str(e), request.token)
-
-    #     self.log.info("Flushing dead processes")
-
-    #     ret = []
-    #     for proc_uuid in self._get_process_uid(data):
-    #         podname = self.boot_request[proc_uuid].process_description.metadata.name
-    #         session = self.boot_request[proc_uuid].process_description.metadata.session
-
-    #         if not self.is_alive(podname, session):
-    #             return_code = self._return_code(podname, session)
-    #             ret.append(self._get_pi(proc_uuid, podname, session, return_code))
-    #             self.log.info(f'Flushing "{session}.{podname}":{proc_uuid}')
-    #             del self.boot_request[proc_uuid]
-    #             self.log.info(f'"{session}.{podname}":{proc_uuid} flushed')
-    #             del proc_uuid
-    #             self._kill_pod(podname, session)
-
-    #         self._kill_if_empty_session(session)
-
-    #     return ProcessInstanceList(values=ret)
-
-    def _kill_impl(
-        self, query: ProcessQuery, in_boot_request: bool = False
-    ) -> ProcessInstanceList:
-        ret = []
-        for proc_uuid in self._get_process_uid(query):
-            podname = self.boot_request[proc_uuid].process_description.metadata.name
-            session = self.boot_request[proc_uuid].process_description.metadata.session
-
-            self.log.info(f'Killing "{session}.{podname}":{proc_uuid}')
-
-            self._kill_pod(podname, session)
-
-            self.log.info(f'"{session}.{podname}":{proc_uuid} killed')
-
-            return_code = self._return_code(podname, session)
-            ret.append(self._get_pi(proc_uuid, podname, session, return_code))
-
+            pd = self.boot_request[proc_uuid].process_description
+            podname, session = pd.metadata.name, pd.metadata.session
+            sessions_affected.add(session)
+            self.log.info(f'Killing pod "{session}/{podname}" (UUID {proc_uuid})')
+            
+            try:
+                self._kill_pod(podname, session)
+            except Exception as e:
+                self.log.error(f"Failed to issue kill for pod {podname}: {e}")
+                continue
+            
+            pd_copy, pr_copy, pu_copy = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=proc_uuid)
+            pd_copy.CopyFrom(self.boot_request[proc_uuid].process_description)
+            pr_copy.CopyFrom(self.boot_request[proc_uuid].process_restriction)
+            
+            ret.append(ProcessInstance(
+                process_description=pd_copy, process_restriction=pr_copy,
+                status_code=ProcessInstance.StatusCode.DEAD, uuid=pu_copy,
+            ))
             del self.boot_request[proc_uuid]
-            del proc_uuid
 
+        for session in sessions_affected:
             self._kill_if_empty_session(session)
 
-        pil = ProcessInstanceList(values=ret)
-        return pil
+        return ProcessInstanceList(values=ret)
+
+    def _terminate_impl(self) -> ProcessInstanceList:
+        self.log.info("Terminating all known K8s processes.")
+        if not self.boot_request:
+            self.log.info("No processes to terminate.")
+            return ProcessInstanceList()
+        return self._kill_impl(ProcessQuery(names=[".*"]))
+    

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -2,20 +2,10 @@
 import getpass
 import os
 import re
-import socket
 import threading
 import uuid
 from time import sleep
 
-# Third-Party Imports
-from kubernetes import client, config, watch
-
-# Local Application Imports
-from drunc.exceptions import DruncCommandException, DruncException
-from drunc.k8s_exceptions import DruncK8sNamespaceAlreadyExists
-from drunc.process_manager.process_manager import ProcessManager
-from drunc.utils.grpc_utils import pack_to_any
-from drunc.utils.utils import get_logger
 from druncschema.broadcast_pb2 import BroadcastType
 from druncschema.process_manager_pb2 import (
     BootRequest,
@@ -28,7 +18,17 @@ from druncschema.process_manager_pb2 import (
     ProcessRestriction,
     ProcessUUID,
 )
-from druncschema.request_response_pb2 import Response, ResponseFlag
+from druncschema.request_response_pb2 import Request, Response, ResponseFlag
+
+# Third-Party Imports
+from grpc import ServicerContext
+from kubernetes import client, config, watch
+
+# Local Application Imports
+from drunc.exceptions import DruncCommandException, DruncException
+from drunc.process_manager.process_manager import ProcessManager
+from drunc.utils.grpc_utils import pack_to_any
+from drunc.utils.utils import get_logger
 
 
 class K8sPodWatcherThread(threading.Thread):
@@ -51,18 +51,26 @@ class K8sPodWatcherThread(threading.Thread):
                     metadata = pod.metadata
                     status = pod.status
                     phase = status.phase
-                    
+
                     uuid = metadata.labels.get(f"uuid.{self.pm.drunc_label}")
                     session = metadata.namespace
 
                     if not uuid:
                         continue
 
-                    if event["type"] in ["MODIFIED", "DELETED"] and phase in ["Succeeded", "Failed"]:
+                    if event["type"] in ["MODIFIED", "DELETED"] and phase in [
+                        "Succeeded",
+                        "Failed",
+                    ]:
                         exit_code = -1
                         reason = "Unknown"
-                        if status.container_statuses and status.container_statuses[0].state.terminated:
-                            terminated_state = status.container_statuses[0].state.terminated
+                        if (
+                            status.container_statuses
+                            and status.container_statuses[0].state.terminated
+                        ):
+                            terminated_state = status.container_statuses[
+                                0
+                            ].state.terminated
                             exit_code = terminated_state.exit_code
                             reason = terminated_state.reason
                         self.pm.notify_termination(uuid, exit_code, reason, session)
@@ -97,7 +105,9 @@ class K8sProcessManager(ProcessManager):
         namespace_list_str = "\n - ".join(namespace_names)
 
         if namespace_list_str:
-            self.log.info(f"Active namespaces created by drunc:\n - {namespace_list_str}")
+            self.log.info(
+                f"Active namespaces created by drunc:\n - {namespace_list_str}"
+            )
         else:
             self.log.info("No active namespace created by drunc")
 
@@ -114,7 +124,9 @@ class K8sProcessManager(ProcessManager):
             self.log.info(end_str)
             self.broadcast(end_str, BroadcastType.SUBPROCESS_STATUS_UPDATE)
         else:
-            self.log.debug(f"Received termination for already-removed UUID {uuid}, checking session '{session}' for cleanup.")
+            self.log.debug(
+                f"Received termination for already-removed UUID {uuid}, checking session '{session}' for cleanup."
+            )
 
         self._kill_if_empty_session(session)
 
@@ -126,22 +138,30 @@ class K8sProcessManager(ProcessManager):
             if e.status == 404:
                 return False
             else:
-                self.log.error(f"Error checking status for pod {session}.{podname}: {e}")
+                self.log.error(
+                    f"Error checking status for pod {session}.{podname}: {e}"
+                )
                 return False
 
     def _add_label(self, obj_name, obj_type, key, label, session=None):
         body = {"metadata": {"labels": {f"{key}.{self.drunc_label}": label}}}
-        
+
         if obj_type == "pod":
             if not session:
-                raise DruncException("Session (namespace) must be provided to label a pod.")
+                raise DruncException(
+                    "Session (namespace) must be provided to label a pod."
+                )
             try:
-                self._core_v1_api.patch_namespaced_pod(name=obj_name, namespace=session, body=body)
+                self._core_v1_api.patch_namespaced_pod(
+                    name=obj_name, namespace=session, body=body
+                )
                 self.log.info(
                     f'Added label "{key}.{self.drunc_label}:{label}" to pod "{session}.{obj_name}"'
                 )
             except self._api_error_v1_api as e:
-                self.log.error(f"Failed to apply label to pod {session}/{obj_name}: {e}")
+                self.log.error(
+                    f"Failed to apply label to pod {session}/{obj_name}: {e}"
+                )
 
         elif obj_type == "namespace":
             try:
@@ -161,7 +181,6 @@ class K8sProcessManager(ProcessManager):
         return f"creator.{self.drunc_label}={self.__class__.__name__}"
 
     def _create_namespace(self, session):
-
         if session in self.sessions_pending_deletion:
             self.sessions_pending_deletion.remove(session)
 
@@ -175,8 +194,8 @@ class K8sProcessManager(ProcessManager):
                     kind="Namespace",
                     metadata=self._meta_v1_api(
                         name=session,
-                        labels={"pod-security.kubernetes.io/enforce": "privileged"}
-                    )
+                        labels={"pod-security.kubernetes.io/enforce": "privileged"},
+                    ),
                 )
                 self._core_v1_api.create_namespace(body=namespace_manifest)
                 self._add_creator_label(session, "namespace")
@@ -209,21 +228,25 @@ class K8sProcessManager(ProcessManager):
             ),
         )
         try:
-            self._core_v1_api.create_namespaced_service(namespace=session, body=service_manifest)
+            self._core_v1_api.create_namespaced_service(
+                namespace=session, body=service_manifest
+            )
             self.log.info(f'Created headless service "{session}.{podname}"')
         except self._api_error_v1_api as e:
-            if e.status != 409: # Ignore if it already exists
+            if e.status != 409:  # Ignore if it already exists
                 self.log.error(f"Failed to create headless service for {podname}: {e}")
 
     def _create_pod(self, podname, session, boot_request: BootRequest):
         pod_image = self.configuration.data.image
-        
+
         exec_and_args_list = boot_request.process_description.executable_and_arguments
-        main_command_str = "; ".join([
-            " ".join([e_and_a.exec] + list(e_and_a.args))
-            for e_and_a in exec_and_args_list
-        ])
-        
+        main_command_str = "; ".join(
+            [
+                " ".join([e_and_a.exec] + list(e_and_a.args))
+                for e_and_a in exec_and_args_list
+            ]
+        )
+
         init_containers = []
 
         if len(exec_and_args_list) > 1 and exec_and_args_list[0].exec == "source":
@@ -232,7 +255,7 @@ class K8sProcessManager(ProcessManager):
 
             # This command will loop until the environment script can be sourced AND the main application command is found in the PATH.
             init_command_str = f"until source {env_script_path} && command -v {main_app_name} >/dev/null 2>&1; do echo 'Waiting for environment of {main_app_name} to be ready...'; sleep 1; done"
-            
+
             init_container = client.V1Container(
                 name="init-environment",
                 image=pod_image,
@@ -241,26 +264,34 @@ class K8sProcessManager(ProcessManager):
                 volume_mounts=[
                     client.V1VolumeMount(name="nfs", mount_path="/nfs"),
                     client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
-                ]
+                ],
             )
             init_containers.append(init_container)
 
-        env_vars = [client.V1EnvVar(name=k, value=v) for k, v in boot_request.process_description.env.items()]
+        env_vars = [
+            client.V1EnvVar(name=k, value=v)
+            for k, v in boot_request.process_description.env.items()
+        ]
 
         pod_manifest = client.V1Pod(
             api_version="v1",
             kind="Pod",
             metadata=self._meta_v1_api(
-                name=podname, 
+                name=podname,
                 namespace=session,
-                labels={"app": podname, f"creator.{self.drunc_label}": self.__class__.__name__}
+                labels={
+                    "app": podname,
+                    f"creator.{self.drunc_label}": self.__class__.__name__,
+                },
             ),
             spec=self._pod_spec_v1_api(
                 init_containers=init_containers,
                 restart_policy="Never",
                 containers=[
                     client.V1Container(
-                        name=podname, image=pod_image, command=["sh", "-c"],
+                        name=podname,
+                        image=pod_image,
+                        command=["sh", "-c"],
                         args=[main_command_str],
                         env=env_vars,
                         volume_mounts=[
@@ -268,12 +299,19 @@ class K8sProcessManager(ProcessManager):
                             client.V1VolumeMount(name="cvmfs", mount_path="/cvmfs"),
                         ],
                         working_dir=boot_request.process_description.process_execution_directory,
-                        security_context=client.V1SecurityContext(run_as_user=os.getuid(), run_as_group=os.getgid()),
+                        security_context=client.V1SecurityContext(
+                            run_as_user=os.getuid(), run_as_group=os.getgid()
+                        ),
                     )
                 ],
                 volumes=[
-                    client.V1Volume(name="nfs", host_path=client.V1HostPathVolumeSource(path="/nfs")),
-                    client.V1Volume(name="cvmfs", host_path=client.V1HostPathVolumeSource(path="/cvmfs")),
+                    client.V1Volume(
+                        name="nfs", host_path=client.V1HostPathVolumeSource(path="/nfs")
+                    ),
+                    client.V1Volume(
+                        name="cvmfs",
+                        host_path=client.V1HostPathVolumeSource(path="/cvmfs"),
+                    ),
                 ],
             ),
         )
@@ -307,16 +345,19 @@ class K8sProcessManager(ProcessManager):
         uuids = self._get_process_uid(log_request.query)
         # Add in_boot_request=True to check the correct dictionary
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
-        
+
         podname = self.boot_request[uuid].process_description.metadata.name
         session = self.boot_request[uuid].process_description.metadata.session
         try:
             logs = self._core_v1_api.read_namespaced_pod_log(
                 podname, session, tail_lines=log_request.how_far or 100
             )
-            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=logs.split('\n'))
+            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=logs.split("\n"))
         except self._api_error_v1_api as e:
-            return LogLines(uuid=ProcessUUID(uuid=uuid), lines=[f"Could not retrieve logs: {e.reason}"])
+            return LogLines(
+                uuid=ProcessUUID(uuid=uuid),
+                lines=[f"Could not retrieve logs: {e.reason}"],
+            )
 
     def _boot_impl(self, boot_request: BootRequest) -> ProcessInstance:
         return self.__boot(boot_request, str(uuid.uuid4()))
@@ -326,7 +367,7 @@ class K8sProcessManager(ProcessManager):
         podname = boot_request.process_description.metadata.name
         if uuid in self.boot_request:
             raise DruncCommandException(f'"{session}.{podname}":{uuid} already exists!')
-        
+
         self.boot_request[uuid] = BootRequest()
         self.boot_request[uuid].CopyFrom(boot_request)
 
@@ -340,57 +381,82 @@ class K8sProcessManager(ProcessManager):
         pr.CopyFrom(self.boot_request[uuid].process_restriction)
 
         return ProcessInstance(
-            process_description=pd, process_restriction=pr,
-            status_code=ProcessInstance.StatusCode.RUNNING, uuid=pu,
+            process_description=pd,
+            process_restriction=pr,
+            status_code=ProcessInstance.StatusCode.RUNNING,
+            uuid=pu,
         )
 
     def _ps_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         queried_uuids = self._get_process_uid(query)
-        if not queried_uuids: return ProcessInstanceList()
+        if not queried_uuids:
+            return ProcessInstanceList()
 
         all_pods = self._core_v1_api.list_pod_for_all_namespaces(
             label_selector=self._get_creator_label_selector()
         )
+        uuid_to_pod = {
+            p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in all_pods.items
+        }
 
-        uuid_to_pod = {p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in all_pods.items}
-        
         ret = []
-        for uuid in queried_uuids:
-            if uuid not in self.boot_request: continue
-            
-            pod = uuid_to_pod.get(uuid)
+        for proc_uuid in queried_uuids:  # Renamed 'uuid' to 'proc_uuid'
+            if proc_uuid not in self.boot_request:
+                continue
+
+            pod = uuid_to_pod.get(proc_uuid)
             status_code = ProcessInstance.StatusCode.DEAD
             return_code = None
             if pod:
-                if pod.status.phase == 'Running':
+                if pod.status.phase == "Running":
                     status_code = ProcessInstance.StatusCode.RUNNING
-                elif pod.status.phase in ['Succeeded', 'Failed']:
-                    if pod.status.container_statuses and pod.status.container_statuses[0].state.terminated:
-                        return_code = pod.status.container_statuses[0].state.terminated.exit_code
+                elif pod.status.phase in ["Succeeded", "Failed"]:
+                    if (
+                        pod.status.container_statuses
+                        and pod.status.container_statuses[0].state.terminated
+                    ):
+                        return_code = pod.status.container_statuses[
+                            0
+                        ].state.terminated.exit_code
 
-            pd, pr, pu = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=uuid)
-            pd.CopyFrom(self.boot_request[uuid].process_description)
-            pr.CopyFrom(self.boot_request[uuid].process_restriction)
+            pd, pr, pu = (
+                ProcessDescription(),
+                ProcessRestriction(),
+                ProcessUUID(uuid=proc_uuid),
+            )
+            pd.CopyFrom(self.boot_request[proc_uuid].process_description)
+            pr.CopyFrom(self.boot_request[proc_uuid].process_restriction)
 
-            ret.append(ProcessInstance(
-                process_description=pd, process_restriction=pr,
-                status_code=status_code, return_code=return_code, uuid=pu,
-            ))
+            ret.append(
+                ProcessInstance(
+                    process_description=pd,
+                    process_restriction=pr,
+                    status_code=status_code,
+                    return_code=return_code,
+                    uuid=pu,
+                )
+            )
         return ProcessInstanceList(values=ret)
 
-    def _restart_impl(self, query: ProcessQuery) -> ProcessInstance: # Corrected the return type hint
+    def _restart_impl(
+        self, query: ProcessQuery
+    ) -> ProcessInstance:  # Corrected the return type hint
         uuids = self._get_process_uid(query)
         uuid = self._ensure_one_process(uuids, in_boot_request=True)
 
         if uuid not in self.boot_request:
-            raise DruncCommandException(f"Cannot restart process with UUID {uuid}: Not found.")
+            raise DruncCommandException(
+                f"Cannot restart process with UUID {uuid}: Not found."
+            )
 
         br_copy = BootRequest()
         br_copy.CopyFrom(self.boot_request[uuid])
 
         pd = self.boot_request[uuid].process_description
         podname, session = pd.metadata.name, pd.metadata.session
-        self.log.info(f"Restarting pod '{session}/{podname}'. First, killing the old one.")
+        self.log.info(
+            f"Restarting pod '{session}/{podname}'. First, killing the old one."
+        )
         self._kill_pod(podname, session)
         self._kill_if_empty_session(session)
 
@@ -403,7 +469,8 @@ class K8sProcessManager(ProcessManager):
         try:
             self._core_v1_api.delete_namespaced_pod(podname, session)
         except self._api_error_v1_api as e:
-            if e.status != 404: raise e
+            if e.status != 404:
+                raise e
 
     def _kill_if_empty_session(self, session):
         # If we have already started deleting this session, do nothing.
@@ -428,28 +495,37 @@ class K8sProcessManager(ProcessManager):
     def _kill_impl(self, query: ProcessQuery) -> ProcessInstanceList:
         ret = []
         uuids_to_kill = self._get_process_uid(query)
-        
+
         for proc_uuid in uuids_to_kill:
-            if proc_uuid not in self.boot_request: continue
+            if proc_uuid not in self.boot_request:
+                continue
 
             pd = self.boot_request[proc_uuid].process_description
             podname, session = pd.metadata.name, pd.metadata.session
             self.log.info(f'Killing pod "{session}/{podname}" (UUID {proc_uuid})')
-            
+
             try:
                 self._kill_pod(podname, session)
             except Exception as e:
                 self.log.error(f"Failed to issue kill for pod {podname}: {e}")
                 continue
-            
-            pd_copy, pr_copy, pu_copy = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=proc_uuid)
+
+            pd_copy, pr_copy, pu_copy = (
+                ProcessDescription(),
+                ProcessRestriction(),
+                ProcessUUID(uuid=proc_uuid),
+            )
             pd_copy.CopyFrom(self.boot_request[proc_uuid].process_description)
             pr_copy.CopyFrom(self.boot_request[proc_uuid].process_restriction)
-            
-            ret.append(ProcessInstance(
-                process_description=pd_copy, process_restriction=pr_copy,
-                status_code=ProcessInstance.StatusCode.DEAD, uuid=pu_copy,
-            ))
+
+            ret.append(
+                ProcessInstance(
+                    process_description=pd_copy,
+                    process_restriction=pr_copy,
+                    status_code=ProcessInstance.StatusCode.DEAD,
+                    uuid=pu_copy,
+                )
+            )
             del self.boot_request[proc_uuid]
 
         # The check for empty sessions is no longer done here
@@ -460,13 +536,13 @@ class K8sProcessManager(ProcessManager):
         if not self.boot_request:
             self.log.info("No processes to terminate.")
             return ProcessInstanceList()
-        
+
         # This correctly creates a query to kill all processes known to this manager,
         # identical to the SSHProcessManager's behavior.
         all_processes_query = ProcessQuery(names=[".*"])
         return self._kill_impl(all_processes_query)
-    
-    def flush(self, request: 'Request', context: 'ServicerContext') -> Response:
+
+    def flush(self, request: "Request", context: "ServicerContext") -> Response:
         self.log.info(
             "The 'flush' command is not needed for the K8sProcessManager. "
             "Cleanup of dead processes is handled automatically in real-time."
@@ -480,4 +556,3 @@ class K8sProcessManager(ProcessManager):
             flag=ResponseFlag.EXECUTED_SUCCESSFULLY,
             children=[],
         )
-    


### PR DESCRIPTION
# Description
This PR aims to achieve two things:
- bring in rework of the k8s process manager
- bring in recent changes in develop (to allow testing with more recent nightlies)

Addresses issue # 
This PR builds on https://github.com/DUNE-DAQ/drunc/pull/519, finishing complete rework on the k8s process manager, bringing functionality in-line with the ssh pm, also allowing running with local connect service. 
Additionally, changes from develop are included to allow testing with more recent versions of code. 

Fixes # (issue)
https://github.com/DUNE-DAQ/drunc/issues/508
 https://github.com/DUNE-DAQ/drunc/issues/511
 https://github.com/DUNE-DAQ/drunc/issues/512
 https://github.com/DUNE-DAQ/drunc/issues/515

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [~] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))