### PR TITLE
Miruuna/server side tests for session manager

### DIFF
--- a/src/drunc/tests/session_manager/test_session_manager_server.py
+++ b/src/drunc/tests/session_manager/test_session_manager_server.py
@@ -1,19 +1,18 @@
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from conffwk import Configuration
-from drunc.session_manager.session_manager import SessionManager
-from druncschema.session_manager_pb2_grpc import SessionManagerServicer
+import pytest
+from druncschema.description_pb2 import CommandDescription, Description
+from druncschema.request_response_pb2 import Request, ResponseFlag
 from druncschema.session_manager_pb2 import (
     ActiveSession,
     AllActiveSessions,
     AllConfigKeys,
     ConfigKey,
 )
-from druncschema.request_response_pb2 import Request, ResponseFlag
 from druncschema.token_pb2 import Token
-from druncschema.description_pb2 import CommandDescription, Description
+
+from drunc.session_manager.session_manager import SessionManager
 
 
 @pytest.fixture
@@ -65,7 +64,7 @@ def commands():
 
 def test_describe(session_manager, mock_request, mock_context, commands, mock_logger):
     response = session_manager.describe(mock_request, mock_context)
-    mock_logger.debug.assert_any_call(f"Initialized SessionManager")
+    mock_logger.debug.assert_any_call("Initialized SessionManager")
 
     assert isinstance(response, Description)
     assert response.name == "dummy_name"
@@ -135,7 +134,8 @@ def test_list_all_configs_files_not_parsed(session_manager, mock_request, mock_c
         with patch("drunc.session_manager.session_manager.Configuration", side_effect=Exception("Config failed")):
             response = session_manager.list_all_configs(mock_request, mock_context)
 
-            assert mock_logger.error.call_count == 3 
+            assert mock_logger.error.call_count == 3 # should error 3 times - once per each file
+
             assert isinstance(response, AllConfigKeys)  
             assert response.name == "dummy_name"
             assert response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY 

--- a/src/drunc/tests/session_manager/test_session_manager_server.py
+++ b/src/drunc/tests/session_manager/test_session_manager_server.py
@@ -1,0 +1,177 @@
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from conffwk import Configuration
+from drunc.session_manager.session_manager import SessionManager
+from druncschema.session_manager_pb2_grpc import SessionManagerServicer
+from druncschema.session_manager_pb2 import (
+    ActiveSession,
+    AllActiveSessions,
+    AllConfigKeys,
+    ConfigKey,
+)
+from druncschema.request_response_pb2 import Request, ResponseFlag
+from druncschema.token_pb2 import Token
+from druncschema.description_pb2 import CommandDescription, Description
+
+
+@pytest.fixture
+def mock_request():
+    return Request(token=Token(user_name="abc", token="13"))
+
+
+@pytest.fixture
+def mock_context():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_logger():
+    with patch("drunc.session_manager.session_manager.get_logger") as mock_get_logger:
+        mock_logger_instance = MagicMock()
+        mock_get_logger.return_value = mock_logger_instance
+        yield mock_logger_instance 
+
+
+@pytest.fixture
+def session_manager(mock_logger):
+    dummy_conf_handler = MagicMock()
+    return SessionManager(name="dummy_name", configuration=dummy_conf_handler)
+
+@pytest.fixture
+def commands():
+    return [
+        CommandDescription(
+            name="describe",
+            data_type=["None"],
+            help="List the methods exposed by this endpoint.",
+            return_type="description_pb2.Description"
+        ),
+        CommandDescription(
+            name="list_all_sessions",
+            data_type=["None"],
+            help="List all active sessions.",
+            return_type="session_manager_pb2.AllActiveSessions"
+        ),
+        CommandDescription(
+            name="list_all_configs",
+            data_type=["None"],
+            help="List all available configurations.",
+            return_type="session_manager_pb2.AllConfigKeys"
+        ),
+    ]
+
+
+def test_describe(session_manager, mock_request, mock_context, commands, mock_logger):
+    response = session_manager.describe(mock_request, mock_context)
+    mock_logger.debug.assert_any_call(f"Initialized SessionManager")
+
+    assert isinstance(response, Description)
+    assert response.name == "dummy_name"
+    assert response.commands == commands
+    assert response.children == []
+    assert response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY
+
+
+def test_list_all_sessions(session_manager, mock_request, mock_context, mock_logger):
+    mock_config = ConfigKey(
+        file="dummy_config_file", 
+        session_id="dummy_config_session_id")
+
+    mock_session = ActiveSession(
+        name="dummy_session", 
+        user="dummy_user", 
+        config_key=mock_config)
+    
+    response = session_manager.list_all_sessions(mock_request, mock_context)
+    mock_logger.debug.assert_any_call(f"{response.name} running list_all_sessions")
+    
+    assert isinstance(response, AllActiveSessions)
+    assert response.name == "dummy_name"
+    assert response.active_sessions == [mock_session]
+    assert response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY
+
+
+def test_list_all_configs_no_db_path(session_manager, mock_request, mock_context, mock_logger, monkeypatch):
+    """
+    Test when the DUNEDAQ_DB_PATH environment variable is not set.
+    """
+    monkeypatch.delenv("DUNEDAQ_DB_PATH", raising=False) 
+
+    response = session_manager.list_all_configs(mock_request, mock_context)
+
+    mock_logger.error.assert_any_call("DUNEDAQ_DB_PATH not set")
+    assert isinstance(response, AllConfigKeys)
+    assert response.name == "dummy_name"
+    assert response.flag == ResponseFlag.FAILED
+    assert response.config_keys == []
+
+
+def test_list_all_configs_no_files_found(session_manager, mock_request, mock_context, mock_logger, monkeypatch):
+    """
+    Test when no configuration files are found in the database path.
+    """
+    monkeypatch.setenv("DUNEDAQ_DB_PATH", "valid_path/") 
+
+    with patch ("pathlib.Path.rglob", return_value=[]):
+        response = session_manager.list_all_configs(mock_request, mock_context)
+
+        assert isinstance(response, AllConfigKeys)    
+        assert response.name == "dummy_name"
+        assert response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY
+        assert response.config_keys == []
+
+
+def test_list_all_configs_files_not_parsed(session_manager, mock_request, mock_context, mock_logger, monkeypatch):
+    """
+    Test when configuration files are found but not parsed succesfully.
+    """
+    monkeypatch.setenv("DUNEDAQ_DB_PATH", "valid_path/") 
+    mock_files = [Path(f"mock_file_{i}.data.xml") for i in range(1, 4)]  
+
+    with patch("pathlib.Path.rglob", return_value=mock_files):
+        
+        with patch("drunc.session_manager.session_manager.Configuration", side_effect=Exception("Config failed")):
+            response = session_manager.list_all_configs(mock_request, mock_context)
+
+            assert mock_logger.error.call_count == 3 
+            assert isinstance(response, AllConfigKeys)  
+            assert response.name == "dummy_name"
+            assert response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY 
+            assert response.config_keys == []
+
+
+
+def test_list_all_configs_files_parsed(session_manager, mock_request, mock_context, mock_logger, monkeypatch):
+    """
+    Test when configuration files are found and parsed successfully.
+    """
+    monkeypatch.setenv("DUNEDAQ_DB_PATH", "valid_path/") 
+    mock_files = [Path(f"mock_file_{i}.data.xml") for i in range(1, 4)]  
+
+    with patch("pathlib.Path.rglob", return_value=mock_files):
+        
+        mockConfiguration = MagicMock()
+        mockConfiguration.get_dals.return_value = [
+            MagicMock(id="session_1"),
+            MagicMock(id="session_2")
+        ]
+        
+        expected_config_keys = [
+            ConfigKey(
+                file=f"mock_file_{i}.data.xml",
+                session_id=f"session_{j}"
+            ) 
+             for i in range(1, 4)
+             for j in range(1, 3)
+        ]
+
+        with patch("drunc.session_manager.session_manager.Configuration", return_value=mockConfiguration):
+            response = session_manager.list_all_configs(mock_request, mock_context)
+
+            assert isinstance(response, AllConfigKeys)    
+            assert response.name == "dummy_name"
+            assert response.flag == ResponseFlag.EXECUTED_SUCCESSFULLY 
+            assert len(response.config_keys) == 6  
+            assert response.config_keys == expected_config_keys


### PR DESCRIPTION
# Description
Addresses issue #534 
Addresses issue #537 

Add unit tests for the server side logic of Session Manager.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))