### PR TITLE
stop kill method in process manager deleting controller

### DIFF
--- a/src/drunc/process_manager/interface/commands.py
+++ b/src/drunc/process_manager/interface/commands.py
@@ -175,7 +175,6 @@ def kill(obj: ProcessManagerContext, query: ProcessQuery) -> None:
     obj.print(
         tabulate_process_instance_list(result, "Killed process", False)
     )  # rich tables require console printing
-    obj.delete_driver("controller")
 
 @click.command("flush")
 @add_query_options(at_least_one=False, all_processes_by_default=True)


### PR DESCRIPTION
# Description
Addresses issue #543
It looks like commit 0c9a37d reintroduced a bug that was fixed in 1d6ce1b. I'm presuming that the correct behaviour is that the controller is deleted if terminate command is used but not if the kill command is used. With this fixed I'm able to successfully recreate #516 

Fixes #543

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: #543)