### PR TITLE
modify connection keepalive setting for grpc clients

### DIFF
--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -89,11 +89,7 @@ class GRPCDriver:
                 f"You need to provide a valid IP address for the driver. Provided '{address}'"
             )
         options = [
-            ("grpc.keepalive_time_ms", 60000),  # pings the server every 60 seconds
-            (
-                "grpc.keepalive_permit_without_calls",
-                True,
-            ),  # allows pings when the client is idle
+            ("grpc.keepalive_time_ms", 60000)  # pings the server every 60 seconds
         ]
         self.address = address
         self.channel = grpc.insecure_channel(self.address, options=options)

--- a/src/drunc/utils/shell_utils.py
+++ b/src/drunc/utils/shell_utils.py
@@ -88,9 +88,15 @@ class GRPCDriver:
             raise DruncSetupException(
                 f"You need to provide a valid IP address for the driver. Provided '{address}'"
             )
-
+        options = [
+            ("grpc.keepalive_time_ms", 60000),  # pings the server every 60 seconds
+            (
+                "grpc.keepalive_permit_without_calls",
+                True,
+            ),  # allows pings when the client is idle
+        ]
         self.address = address
-        self.channel = grpc.insecure_channel(self.address)
+        self.channel = grpc.insecure_channel(self.address, options=options)
         self.token = Token()
         self.token.CopyFrom(token)
 


### PR DESCRIPTION
# Description
Addresses issue #505
reduces the ping time of grpc clients from the default of two hours to one minute, which appears to fix the ping_timeout error from #505. Please see the [issue comment](https://github.com/DUNE-DAQ/drunc/issues/505#issuecomment-3214170640) for details and reasoning.

Fixes #505

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))