### PR TITLE
update tabulate process function to sort by session id too

### DIFF
--- a/src/drunc/process_manager/utils.py
+++ b/src/drunc/process_manager/utils.py
@@ -70,7 +70,11 @@ def tabulate_process_instance_list(pil, title, long=False):
         t.add_column("executable")
 
     sorted_pil = sorted(
-        pil.values, key=attrgetter("process_description.metadata.tree_id")
+        pil.values,
+        key=attrgetter(
+            "process_description.metadata.session",
+            "process_description.metadata.tree_id",
+        ),
     )
     tree_str = make_tree(sorted_pil)
     try:


### PR DESCRIPTION
# Description
Addresses issue #457 
When multiple sessions are booted from non-unified process manager the ps command now sorts by session first, then by process tree hierarchy

Fixes #457 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))