### PR TITLE
drunc throws when the druncjson is out of date

### DIFF
--- a/src/drunc/controller/controller.py
+++ b/src/drunc/controller/controller.py
@@ -45,6 +45,11 @@ from drunc.controller.utils import (
 from drunc.exceptions import DruncException
 from drunc.fsm.configuration import FSMConfHandler
 from drunc.fsm.utils import convert_fsm_transition
+from drunc.fsm.actions.utils import get_dotdrunc_json
+from drunc.fsm.exceptions import (
+    DotDruncJsonIncorrectFormat,
+    DotDruncJsonNotFound,
+)
 from drunc.utils.grpc_utils import UnpackingError, pack_to_any, unpack_any
 from drunc.utils.utils import get_logger
 
@@ -774,6 +779,13 @@ class Controller(ControllerServicer):
                 ctx=self,
             )
             if payload.command_name == "start":
+
+                try:
+                    get_dotdrunc_json()
+                except (DotDruncJsonIncorrectFormat, DotDruncJsonNotFound) as e:
+                    self.log.warning(f"ELisa Logbook entry will not be posted. {e}")
+                    
+
                 self.controller_publisher(
                     message=RunInfo(
                         run_type=self.runinfo.get("production_vs_test", ""),
@@ -789,6 +801,12 @@ class Controller(ControllerServicer):
                     ),
                     custom_origin=self.custom_origin,
                 )
+
+            if payload.command_name == "drain_dataflow":
+                try:
+                    get_dotdrunc_json()
+                except (DotDruncJsonIncorrectFormat, DotDruncJsonNotFound) as e:
+                    self.log.warning(f"ELisaLogbook entry will not be posted after drain-dataflow. {e}")
 
             self.stateful_node.propagate_transition_mark(transition)
 

--- a/src/drunc/controller/interface/shell_utils.py
+++ b/src/drunc/controller/interface/shell_utils.py
@@ -39,6 +39,11 @@ from drunc.utils.grpc_utils import (
 from drunc.utils.shell_utils import DecodedResponse
 from drunc.utils.utils import get_logger
 
+from drunc.fsm.actions.utils import get_dotdrunc_json
+from drunc.fsm.exceptions import (
+    DotDruncJsonIncorrectFormat,
+    DotDruncJsonNotFound,
+)
 
 def generate_none_status() -> Status:
     return Status(
@@ -603,8 +608,19 @@ def run_one_fsm_command(
 
 def generate_fsm_command(ctx, transition: FSMCommandDescription, controller_name: str):
     log = get_logger("controller.shell_utils")
-    cmd = partial(run_one_fsm_command, controller_name, transition.name)
-    cmd = click.pass_obj(cmd)
+
+    def wrapped_cmd(obj, *args, **kwargs):
+        """
+        Wrapper function to warn that ELisa Logbook are not posted if ~/.drunc.json is missing or malformed
+        """
+        if transition.name.lower() in ["start", "drain_dataflow"]:
+            try:
+                get_dotdrunc_json()
+            except (DotDruncJsonIncorrectFormat, DotDruncJsonNotFound) as e:
+                log.warning(f"ELisa Logbook entry will not be posted. {e}")
+        return run_one_fsm_command(controller_name, transition.name, obj, *args, **kwargs)
+
+    cmd = click.pass_obj(wrapped_cmd)
     cmd = click.option(
         "--target",
         type=str,

--- a/src/drunc/fsm/actions/usvc_elisa_logbook.py
+++ b/src/drunc/fsm/actions/usvc_elisa_logbook.py
@@ -45,26 +45,26 @@ class ElisaLogbook(FSMAction):
             self.API_PASS = ec.get("password")
 
             if not self.API_SOCKET or not self.API_USER or not self.API_PASS:
-                err_msg: str = (
+                warn_msg: str = (
                     "Malformed ~/.drunc.json, missing a key in 'elisa_configuration' "
                     "in your ~/.drunc.json, or the entire 'elisa_configuration' section"
                 )
-                raise DotDruncJsonIncorrectFormat(err_msg) from KeyError
+                self.log.warning(warn_msg)
         else:
 
-            err_msg: str = ""
+            warn_msg: str = ""
             if default_elisa_logbook:
-                err_msg = (
+                warn_msg = (
                     "You need to update your ~/.drunc.json: The default ELisA logbook "
                     "[yellow]pdsp[/yellow] does not have a configuration."
                 )
             else:
-                err_msg = (
+                warn_msg = (
                     "You need to update your ~/.drunc.json: you have specified an "
                     f"ELisA logbook ({self.elisa_hardware}) in your configuration, but your "
                     "current ~/.drunc.json doesn't support this one."
                 )
-            raise DotDruncJsonIncorrectFormat(err_msg) from None
+            self.log.warning(warn_msg)
 
         self.log.info(f"Using the following ELisA logbook '{self.elisa_hardware}'.")
         self.timeout = 5

--- a/src/drunc/fsm/actions/utils.py
+++ b/src/drunc/fsm/actions/utils.py
@@ -26,10 +26,10 @@ def get_dotdrunc_json(path: str = "~/.drunc.json"):
         f = open(expand_path(path))
         dotdrunc = json.load(f)
     except FileNotFoundError:
-        raise DotDruncJsonNotFound(f"dotdrunc file not found: '{path}'")
+        raise DotDruncJsonNotFound(f"~/.drunc.json file not found: '{path}'")
     except json.JSONDecodeError as exc:
         raise DotDruncJsonIncorrectFormat(
-            f"dotdrunc file is not a valid JSON: '{path}'"
+            f"~/.drunc.json file is not a valid JSON: '{path}'"
         ) from exc
 
     expected_keys = [
@@ -40,7 +40,7 @@ def get_dotdrunc_json(path: str = "~/.drunc.json"):
 
     if not all(key in dotdrunc for key in expected_keys):
         raise DotDruncJsonIncorrectFormat(
-            f"dotdrunc file is missing some expected keys: {expected_keys}"
+            f"~/.drunc.json file is outdated or is missing some expected keys: {expected_keys}"
         )
 
     return dotdrunc

--- a/src/drunc/tests/controller/data/.drunc.json
+++ b/src/drunc/tests/controller/data/.drunc.json
@@ -1,0 +1,17 @@
+{
+    "run_registry_configuration":{
+        "socket": "foosocket",
+        "user": "fooUsr",
+        "password": "barPass"
+    },
+    "run_number_configuration":{
+        "socket": "fooSocket",
+        "user": "fooUsr",
+        "password": "barPass"
+    },
+    "elisa_configuration": {
+        "socket": "fooSocket",
+        "user": "fooUsr",
+        "password": "barPass"
+    }
+}


### PR DESCRIPTION
# Description
Addresses issue # 556 
Fixes #556

When `.drunc.json`is missing or outdated, drunc previously raised errors when posting to the Run Registry/ ELisa logbook and when getting a new run number from the `usvc`. This work replaces the errors with warnings when Elisa logbook is updated. Errors are still raised when posting to the Run Registry or getting a new run number.

The main changes are for the two commands which involve posting to ELisa logbook without getting a new run number or updating the Run Registry:
- `start`
- `drain-dataflow`

The warnings are also displayed in the `drunc-unified-shell`. 

Tested using the `.drunc.json` file in `tests/controller/data`.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))