### PR TITLE
make dotdrunc path modifable

### DIFF
--- a/src/drunc/fsm/actions/utils.py
+++ b/src/drunc/fsm/actions/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from drunc.fsm.exceptions import (
     DotDruncJsonIncorrectFormat,
@@ -21,15 +22,17 @@ def validate_run_type(run_type: str) -> str:
     return run_type
 
 
-def get_dotdrunc_json(path: str = "~/.drunc.json"):
+def get_dotdrunc_json(path: str = None):
+    # Resolution order: DOTDRUNC env var -> provided path -> default path
+    file_path = os.getenv("DOTDRUNC") or path or "~/.drunc.json"
     try:
-        f = open(expand_path(path))
+        f = open(expand_path(file_path))
         dotdrunc = json.load(f)
     except FileNotFoundError:
-        raise DotDruncJsonNotFound(f"dotdrunc file not found: '{path}'")
+        raise DotDruncJsonNotFound(f"dotdrunc file not found: '{file_path}'")
     except json.JSONDecodeError as exc:
         raise DotDruncJsonIncorrectFormat(
-            f"dotdrunc file is not a valid JSON: '{path}'"
+            f"dotdrunc file is not a valid JSON: '{file_path}'"
         ) from exc
 
     expected_keys = [


### PR DESCRIPTION
# Description
Fixes #409 

So that `.drunc.json` can be passed differently. Resolution order: DOTDRUNC env var -> provided path -> default path

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))