### PR TITLE
[K8s] Reworking 8s networking, especially for local connectivity service case

### DIFF
--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -639,11 +639,6 @@ done
         if uuid in self.boot_request:
             raise DruncCommandException(f'"{session}.{podname}":{uuid} already exists!')
 
-        self._create_namespace(session)
-
-        self.boot_request[uuid] = BootRequest()
-        self.boot_request[uuid].CopyFrom(boot_request)
-
         # Extract ports for LCS
         if podname == self.connection_server_name:
             self.log.info(f"Waiting for '{podname}' to become ready...")
@@ -656,6 +651,28 @@ done
                 raise DruncException(
                     "Could not extract port from boot request for connection server"
                 )
+
+            # Check for NodePort collision
+            api = self._core_v1_api
+            all_services = api.list_service_for_all_namespaces()
+            for svc in all_services.items:
+                if not svc.spec.type == "NodePort":
+                    continue
+                for p in svc.spec.ports:
+                    if p.node_port == self.connection_server_node_port and (
+                        svc.metadata.namespace != session
+                        or svc.metadata.name != podname
+                    ):
+                        raise DruncException(
+                            f"NodePort {self.connection_server_node_port} is already in use by service "
+                            f"{svc.metadata.name} in namespace {svc.metadata.namespace}. "
+                            "Cannot start another local connection server with the same port."
+                        )
+
+        self._create_namespace(session)
+
+        self.boot_request[uuid] = BootRequest()
+        self.boot_request[uuid].CopyFrom(boot_request)
 
         self._create_pod(podname, session, boot_request)
         self._add_label(podname, "pod", "uuid", uuid, session=session)

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -632,6 +632,8 @@ done
         session = boot_request.process_description.metadata.session
         podname = boot_request.process_description.metadata.name
 
+        print(boot_request)
+
         if boot_request.process_restriction.allowed_hosts:
             hostname = boot_request.process_restriction.allowed_hosts[0]
             boot_request.process_description.metadata.hostname = hostname
@@ -643,13 +645,33 @@ done
         if podname == self.connection_server_name:
             self.log.info(f"Waiting for '{podname}' to become ready...")
 
-            port = self._extract_port_from_cmd(boot_request)
+            port = None
+            env_vars = boot_request.process_description.env
+
+            if "CONNECTION_PORT" in env_vars:
+                port_str = env_vars["CONNECTION_PORT"]
+                try:
+                    port = int(port_str)
+                    self.log.info(
+                        f"Using port {port} from 'CONNECTION_PORT' environment variable."
+                    )
+                except (ValueError, TypeError):
+                    raise DruncException(
+                        f"The provided CONNECTION_PORT '{port_str}' is not a valid integer."
+                    )
+
+            if port is None:
+                self.log.info(
+                    "CONNECTION_PORT not found in env, falling back to parsing gunicorn command."
+                )
+                port = self._extract_port_from_cmd(boot_request)
+
             if port:
                 self.connection_server_port = port
                 self.connection_server_node_port = port
             else:
                 raise DruncException(
-                    "Could not extract port from boot request for connection server"
+                    "Could not determine connection server port from 'CONNECTION_PORT' env var or gunicorn command."
                 )
 
             # Check for NodePort collision

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -132,14 +132,12 @@ class K8sProcessManager(ProcessManager):
         self.connection_server_name = settings.get(
             "connection_server_name", "local-connection-server"
         )
-        self.connection_server_port = settings.get("connection_server_port", 30000)
-        self.connection_server_node_port = settings.get(
-            "connection_server_node_port", 30000
-        )
         self.connection_server_hostname = settings.get(
             "connection_server_hostname", "localhost"
         )
-        self.nodeport_port = settings.get("nodeport_port", 30000)
+        self.connection_server_port = None
+        self.connection_server_node_port = None
+
         self.pod_ready_timeout = settings.get("pod_ready_timeout", 60)
         self.kill_timeout = settings.get("kill_timeout", 20)
         self.namespace_cleanup_timeout = settings.get("namespace_cleanup_timeout", 10)
@@ -341,7 +339,7 @@ class K8sProcessManager(ProcessManager):
                         protocol="TCP",
                         port=self.connection_server_port,
                         target_port=self.connection_server_port,
-                        node_port=self.nodeport_port,
+                        node_port=self.connection_server_node_port,
                     )
                 ],
             ),
@@ -352,7 +350,7 @@ class K8sProcessManager(ProcessManager):
             )
             self.log.info(
                 f'Created NodePort service "{session}.{podname}" on port {self.connection_server_port} '
-                f"(NodePort: {self.nodeport_port} for external access)"
+                f"(NodePort: {self.connection_server_node_port} for external access)"
             )
         except self._api_error_v1_api as e:
             if e.status != 409:
@@ -547,6 +545,22 @@ done
             self.log.error(f"Failed to get connection server service IP: {e}")
             return None
 
+    def _extract_port_from_cmd(self, boot_request):
+        # Find the gunicorn port argument from exec_and_args_list
+        for e_and_a in boot_request.process_description.executable_and_arguments:
+            if "gunicorn" in e_and_a.exec or (
+                "gunicorn" in " ".join(list(e_and_a.args))
+            ):
+                all_args = [e_and_a.exec] + list(e_and_a.args)
+                arg_str = " ".join(all_args)
+                match = re.search(r"-b\s+[\w\.]+:(\d+)", arg_str)
+                if not match:
+                    # Try to match '--bind'
+                    match = re.search(r"--bind[\s=]+[\w\.]+:(\d+)", arg_str)
+                if match:
+                    return int(match.group(1))
+        return None
+
     def _get_process_uid(self, query: ProcessQuery, order_by: str = None):
         """
         Finds process UUIDs matching a query.
@@ -630,6 +644,19 @@ done
         self.boot_request[uuid] = BootRequest()
         self.boot_request[uuid].CopyFrom(boot_request)
 
+        # Extract ports for LCS
+        if podname == self.connection_server_name:
+            self.log.info(f"Waiting for '{podname}' to become ready...")
+
+            port = self._extract_port_from_cmd(boot_request)
+            if port:
+                self.connection_server_port = port
+                self.connection_server_node_port = port
+            else:
+                raise DruncException(
+                    "Could not extract port from boot request for connection server"
+                )
+
         self._create_pod(podname, session, boot_request)
         self._add_label(podname, "pod", "uuid", uuid, session=session)
         self.log.info(f'"{session}.{podname}":{uuid} boot request sent.')
@@ -637,6 +664,7 @@ done
         # Special handling only for the connection server
         if podname == self.connection_server_name:
             self.log.info(f"Waiting for '{podname}' to become ready...")
+
             start_time = time()
             while time() - start_time < self.pod_ready_timeout:
                 try:

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -29,13 +29,13 @@ from drunc.utils.utils import get_logger
 
 
 class K8sPodWatcherThread(threading.Thread):
-    def __init__(self, pm):
+    def __init__(self, pm) -> None:
         threading.Thread.__init__(self)
         self.pm = pm
         self.daemon = True
         self.processed_uuids = set()
 
-    def run(self):
+    def run(self) -> None:
         self.pm.log.info("K8sPodWatcherThread started")
         while True:
             try:
@@ -91,7 +91,7 @@ class K8sPodWatcherThread(threading.Thread):
 
 
 class K8sProcessManager(ProcessManager):
-    def __init__(self, configuration, **kwargs):
+    def __init__(self, configuration, **kwargs) -> None:
         """
         Manages processes as Kubernetes Pods.
         This ProcessManager interfaces with the Kubernetes API to start, stop, and monitor
@@ -165,14 +165,14 @@ class K8sProcessManager(ProcessManager):
         else:
             self.log.info("No active namespace created by drunc")
 
-    def _start_watcher(self):
+    def _start_watcher(self) -> None:
         """Starts the background thread that watches for Pod status changes."""
         self.log.debug("Starting K8s pod watcher thread")
         t = K8sPodWatcherThread(pm=self)
         t.start()
         self.watchers.append(t)
 
-    def notify_termination(self, proc_uuid, exit_code, reason, session):
+    def notify_termination(self, proc_uuid, exit_code, reason, session) -> None:
         """Callback for when a pod terminates."""
         self.log.debug(
             f"notify_termination called for '{proc_uuid}'. Pending={self.uuids_pending_deletion}"
@@ -195,7 +195,7 @@ class K8sProcessManager(ProcessManager):
                 self.log.debug("All pending pods terminated, setting event.")
                 self.termination_complete_event.set()
 
-    def is_alive(self, podname, session):
+    def is_alive(self, podname, session) -> bool:
         """Checks if a pod is currently in the 'Running' phase."""
         try:
             pod_status = self._core_v1_api.read_namespaced_pod_status(podname, session)
@@ -206,7 +206,7 @@ class K8sProcessManager(ProcessManager):
             self.log.error(f"Error checking status for pod {session}.{podname}: {e}")
             return False
 
-    def _add_label(self, obj_name, obj_type, key, label, session=None):
+    def _add_label(self, obj_name, obj_type, key, label, session=None) -> None:
         """Adds a label to a Kubernetes object (Pod or Namespace)."""
         body = {"metadata": {"labels": {f"{key}.{self.drunc_label}": label}}}
 
@@ -237,15 +237,15 @@ class K8sProcessManager(ProcessManager):
         else:
             raise DruncException(f"Cannot add label to object type: {obj_type}")
 
-    def _add_creator_label(self, obj_name, obj_type):
+    def _add_creator_label(self, obj_name, obj_type) -> None:
         """Adds a 'creator' label to a Kubernetes object."""
         self._add_label(obj_name, obj_type, "creator", self.__class__.__name__)
 
-    def _get_creator_label_selector(self):
+    def _get_creator_label_selector(self) -> str:
         """Returns the label selector for objects created by this class."""
         return f"creator.{self.drunc_label}={self.__class__.__name__}"
 
-    def _create_namespace(self, session):
+    def _create_namespace(self, session) -> None:
         """Creates a Kubernetes namespace if it doesn't already exist."""
         if session in self.sessions_pending_deletion:
             self.sessions_pending_deletion.remove(session)
@@ -276,7 +276,7 @@ class K8sProcessManager(ProcessManager):
             else:
                 raise e
 
-    def _create_headless_service(self, podname, session, pod_uid):
+    def _create_headless_service(self, podname, session, pod_uid) -> None:
         """Creates a headless service for a pod."""
         service_manifest = client.V1Service(
             api_version="v1",
@@ -311,7 +311,7 @@ class K8sProcessManager(ProcessManager):
             if e.status != 409:
                 self.log.error(f"Failed to create headless service for {podname}: {e}")
 
-    def _create_nodeport_service(self, podname, session, pod_uid):
+    def _create_nodeport_service(self, podname, session, pod_uid) -> None:
         """Creates a NodePort service for the connection server (external + internal access)."""
         service_manifest = client.V1Service(
             api_version="v1",
@@ -356,7 +356,7 @@ class K8sProcessManager(ProcessManager):
             if e.status != 409:
                 self.log.error(f"Failed to create NodePort service for {podname}: {e}")
 
-    def _create_pod(self, podname, session, boot_request: BootRequest):
+    def _create_pod(self, podname, session, boot_request: BootRequest) -> None:
         """Constructs and creates a Kubernetes Pod manifest."""
         pod_image = self.configuration.data.image
         exec_and_args_list = boot_request.process_description.executable_and_arguments
@@ -534,7 +534,7 @@ done
             self.log.error(error_message)
             raise DruncException(error_message) from e
 
-    def _get_connection_server_cluster_ip(self, session):
+    def _get_connection_server_cluster_ip(self, session) -> str:
         """Gets the ClusterIP of the connection server service."""
         try:
             service = self._core_v1_api.read_namespaced_service(
@@ -545,7 +545,7 @@ done
             self.log.error(f"Failed to get connection server service IP: {e}")
             return None
 
-    def _extract_port_from_cmd(self, boot_request):
+    def _extract_port_from_cmd(self, boot_request) -> int | None:
         # Find the gunicorn port argument from exec_and_args_list
         for e_and_a in boot_request.process_description.executable_and_arguments:
             if "gunicorn" in e_and_a.exec or (
@@ -561,7 +561,7 @@ done
                     return int(match.group(1))
         return None
 
-    def _get_process_uid(self, query: ProcessQuery, order_by: str = None):
+    def _get_process_uid(self, query: ProcessQuery, order_by: str = None) -> list[str]:
         """
         Finds process UUIDs matching a query.
 
@@ -792,7 +792,7 @@ done
         restarted_process = self.__boot(br_copy, uuid)
         return ProcessInstanceList(values=[restarted_process])
 
-    def _kill_pod(self, podname, session, grace_period_seconds=None):
+    def _kill_pod(self, podname, session, grace_period_seconds=None) -> None:
         """Deletes a specific pod from a namespace."""
         try:
             self._core_v1_api.delete_namespaced_pod(
@@ -823,12 +823,12 @@ done
                 or pd.metadata.name == self.connection_server_name
             )
 
-            if is_controller or pd.metadata.name == self.connection_server_name:
+            if is_controller:
                 forced_apps.append(uuid_str)
             else:
                 graceful_apps.append(uuid_str)
 
-        def kill_and_wait(uuids, stage_name, grace_period=None):
+        def kill_and_wait(uuids, stage_name, grace_period=None) -> None:
             if not uuids:
                 return
             action = (

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -2,8 +2,6 @@
 import getpass
 import os
 import re
-import signal
-import subprocess
 import threading
 import uuid
 from time import sleep, time
@@ -99,8 +97,7 @@ class K8sProcessManager(ProcessManager):
         This ProcessManager interfaces with the Kubernetes API to start, stop, and monitor
         applications running in Pods. It includes special handling for a local connectivity
         service, which involves:
-        1.  Automating a `kubectl port-forward` in a background shell process for the orchestrator.
-        2.  Injecting a proxy sidecar container into other pods for transparent service discovery.
+        1.  Using a NodePort service for the orchestrator for external access.
         """
         self.session = getpass.getuser()
         super().__init__(configuration=configuration, session=self.session, **kwargs)
@@ -122,7 +119,6 @@ class K8sProcessManager(ProcessManager):
         self.uuids_pending_deletion = set()
         self.termination_complete_event = threading.Event()
         self.final_exit_codes = {}
-        self.port_forwards = {}
         self.local_connection_server_is_booted = False
 
         # Safely get settings from the configuration object
@@ -136,10 +132,15 @@ class K8sProcessManager(ProcessManager):
         self.connection_server_name = settings.get(
             "connection_server_name", "local-connection-server"
         )
-        self.connection_server_port = settings.get("connection_server_port", 5000)
-        self.sidecar_image = settings.get("sidecar_image", "alpine/socat")
+        self.connection_server_port = settings.get("connection_server_port", 30000)
+        self.connection_server_node_port = settings.get(
+            "connection_server_node_port", 30000
+        )
+        self.connection_server_hostname = settings.get(
+            "connection_server_hostname", "localhost"
+        )
+        self.nodeport_port = settings.get("nodeport_port", 30000)
         self.pod_ready_timeout = settings.get("pod_ready_timeout", 60)
-        self.port_forward_timeout = settings.get("port_forward_timeout", 15)
         self.kill_timeout = settings.get("kill_timeout", 20)
         self.namespace_cleanup_timeout = settings.get("namespace_cleanup_timeout", 10)
         self.restart_cleanup_time = float(settings.get("restart_cleanup_time", "10"))
@@ -312,8 +313,8 @@ class K8sProcessManager(ProcessManager):
             if e.status != 409:
                 self.log.error(f"Failed to create headless service for {podname}: {e}")
 
-    def _create_clusterip_service(self, podname, session, pod_uid):
-        """Creates a standard ClusterIP service for the connection server."""
+    def _create_nodeport_service(self, podname, session, pod_uid):
+        """Creates a NodePort service for the connection server (external + internal access)."""
         service_manifest = client.V1Service(
             api_version="v1",
             kind="Service",
@@ -333,12 +334,14 @@ class K8sProcessManager(ProcessManager):
                 ],
             ),
             spec=client.V1ServiceSpec(
+                type="NodePort",
                 selector={"app": podname},
                 ports=[
                     client.V1ServicePort(
                         protocol="TCP",
                         port=self.connection_server_port,
                         target_port=self.connection_server_port,
+                        node_port=self.nodeport_port,
                     )
                 ],
             ),
@@ -348,11 +351,12 @@ class K8sProcessManager(ProcessManager):
                 namespace=session, body=service_manifest
             )
             self.log.info(
-                f'Created ClusterIP service "{session}.{podname}" on port {self.connection_server_port}'
+                f'Created NodePort service "{session}.{podname}" on port {self.connection_server_port} '
+                f"(NodePort: {self.nodeport_port} for external access)"
             )
         except self._api_error_v1_api as e:
             if e.status != 409:
-                self.log.error(f"Failed to create ClusterIP service for {podname}: {e}")
+                self.log.error(f"Failed to create NodePort service for {podname}: {e}")
 
     def _create_pod(self, podname, session, boot_request: BootRequest):
         """Constructs and creates a Kubernetes Pod manifest."""
@@ -421,29 +425,6 @@ done
 
         all_containers = [main_container]
 
-        # If the local connection server is active, inject a proxy sidecar into all other pods.
-        if (
-            podname != self.connection_server_name
-            and self.local_connection_server_is_booted
-        ):
-            self.log.info(f"Adding proxy sidecar to pod '{podname}'")
-            sidecar_container = client.V1Container(
-                name="proxy-sidecar",
-                image=self.sidecar_image,
-                args=[
-                    f"TCP-LISTEN:{self.connection_server_port},fork,reuseaddr",
-                    f"TCP:{self.connection_server_name}.{session}:{self.connection_server_port}",
-                ],
-                # This hook delays the sidecar's termination, allowing the main C++ app
-                # to shut down gracefully while its network connection is still alive.
-                lifecycle=client.V1Lifecycle(
-                    pre_stop=client.V1LifecycleHandler(
-                        _exec=client.V1ExecAction(command=["/bin/sh", "-c", "sleep 10"])
-                    )
-                ),
-            )
-            all_containers.append(sidecar_container)
-
         node_selector = {}
         if self.forced_node:
             node_selector = {"kubernetes.io/hostname": self.forced_node}
@@ -456,6 +437,33 @@ done
             self.log.info(
                 f"Pod '{podname}' will be scheduled on node '{target_host}' (from boot request)"
             )
+
+        host_aliases = []
+        if (
+            podname != self.connection_server_name
+            and self.local_connection_server_is_booted
+        ):
+            # Wait for service to get ClusterIP
+            connection_server_ip = None
+            retry_count = 0
+            max_retries = 10
+            while not connection_server_ip and retry_count < max_retries:
+                connection_server_ip = self._get_connection_server_cluster_ip(session)
+                if not connection_server_ip:
+                    sleep(1)
+                    retry_count += 1
+
+            if connection_server_ip:
+                host_aliases = [
+                    client.V1HostAlias(ip=connection_server_ip, hostnames=["localhost"])
+                ]
+                self.log.info(
+                    f"Pod '{podname}' will resolve localhost to connection server IP {connection_server_ip}"
+                )
+            else:
+                self.log.warning(
+                    f"Could not get connection server ClusterIP for pod '{podname}'"
+                )
 
         pod_manifest = client.V1Pod(
             api_version="v1",
@@ -473,6 +481,7 @@ done
                 termination_grace_period_seconds=self.kill_timeout,
                 restart_policy="Never",
                 containers=all_containers,
+                host_aliases=host_aliases if host_aliases else None,
                 volumes=[
                     client.V1Volume(
                         name="nfs", host_path=client.V1HostPathVolumeSource(path="/nfs")
@@ -511,7 +520,7 @@ done
                     raise e
 
             if podname == self.connection_server_name:
-                self._create_clusterip_service(podname, session, pod_uid)
+                self._create_nodeport_service(podname, session, pod_uid)
             else:
                 self._create_headless_service(podname, session, pod_uid)
 
@@ -526,6 +535,17 @@ done
 
             self.log.error(error_message)
             raise DruncException(error_message) from e
+
+    def _get_connection_server_cluster_ip(self, session):
+        """Gets the ClusterIP of the connection server service."""
+        try:
+            service = self._core_v1_api.read_namespaced_service(
+                name=self.connection_server_name, namespace=session
+            )
+            return service.spec.cluster_ip
+        except self._api_error_v1_api as e:
+            self.log.error(f"Failed to get connection server service IP: {e}")
+            return None
 
     def _get_process_uid(self, query: ProcessQuery, order_by: str = None):
         """
@@ -592,7 +612,7 @@ done
     def __boot(self, boot_request: BootRequest, uuid: str) -> ProcessInstance:
         """
         Internal boot method. Handles pod creation and special logic for the connection server.
-        - For the connection server: Boot is BLOCKING, and a port-forward is automated.
+        - For the connection server: Wait for it to be ready and check the NodePort service
         - For all other pods: Boot is NON-BLOCKING.
         """
         session = boot_request.process_description.metadata.session
@@ -631,6 +651,13 @@ done
                             f"'{podname}' is ready with IP {pod_status.status.pod_ip}."
                         )
                         self.local_connection_server_is_booted = True
+
+                        # Log connection information using the NodePort service
+                        connection_url = f"http://{self.connection_server_hostname}:{self.connection_server_node_port}"
+                        self.log.info(
+                            f"Connection server available at: {connection_url}"
+                        )
+
                         break
                 except self._api_error_v1_api as e:
                     if e.status == 404:
@@ -642,77 +669,6 @@ done
                 raise DruncException(
                     f"'{podname}' did not become ready in {self.pod_ready_timeout} seconds."
                 )
-
-            kubeconfig_path = os.environ.get("KUBECONFIG")
-            proxy_unset_script = "~np04daq/bin/web_proxy.sh -u"
-
-            command_parts = []
-            if kubeconfig_path:
-                command_parts.append(f"export KUBECONFIG='{kubeconfig_path}'")
-            else:
-                self.log.warning(
-                    "KUBECONFIG env var not set; assuming kubectl is configured."
-                )
-
-            command_parts.append(f"source {proxy_unset_script}")
-            command_parts.append(
-                f"kubectl port-forward -n {session} pod/{podname} {self.connection_server_port}:{self.connection_server_port}"
-            )
-            command = "; ".join(command_parts)
-
-            self.log.info(
-                "Starting port-forward for orchestrator. Executing shell command..."
-            )
-            try:
-                # preexec_fn=os.setsid creates a new process group, allowing us to kill the shell and all its children.
-                proc = subprocess.Popen(
-                    command,
-                    shell=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    preexec_fn=os.setsid,
-                )
-                self.port_forwards[uuid] = proc
-                self.log.info(
-                    f"Port-forward process for '{podname}' started with PID {proc.pid}. Waiting for tunnel..."
-                )
-
-                output = {}
-
-                def read_output(pipe, storage):
-                    storage["line"] = pipe.readline()
-
-                thread = threading.Thread(
-                    target=read_output, args=(proc.stdout, output)
-                )
-                thread.start()
-                thread.join(timeout=self.port_forward_timeout)
-
-                if thread.is_alive():
-                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-                    raise DruncException(
-                        f"Port-forward for '{podname}' did not become ready in {self.port_forward_timeout} seconds."
-                    )
-
-                line = output.get("line", "").strip()
-                if "Forwarding from" in line:
-                    self.log.info(f"Port-forward is active: {line}")
-                else:
-                    error_output = proc.stderr.read()
-                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-                    raise DruncException(
-                        f"Port-forward for '{podname}' failed. Stdout: '{line}'. Stderr: '{error_output}'"
-                    )
-
-            except Exception as e:
-                self.log.error(
-                    f"Failed to start or validate port-forwarding for '{podname}': {e}"
-                )
-                if uuid in self.port_forwards:
-                    os.killpg(os.getpgid(self.port_forwards[uuid].pid), signal.SIGTERM)
-                    del self.port_forwards[uuid]
-                raise
 
         pd, pr, pu = ProcessDescription(), ProcessRestriction(), ProcessUUID(uuid=uuid)
         pd.CopyFrom(self.boot_request[uuid].process_description)
@@ -868,14 +824,6 @@ done
         kill_and_wait(graceful_apps, "Standalone C++ Applications")
 
         kill_and_wait(forced_apps, "Controllers & Local Session Apps", grace_period=0)
-
-        # Terminate port-forward if its pod was killed
-        for uuid_str in forced_apps:
-            if uuid_str in self.port_forwards:
-                self.log.info("Terminating port-forward process")
-                proc = self.port_forwards.pop(uuid_str)
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-                proc.wait()
 
         final_ret = []
         for proc_uuid in uuids_to_kill:

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -22,6 +22,7 @@ from druncschema.process_manager_pb2 import (
 
 # Third-Party Imports
 from kubernetes import client, config, watch
+from kubernetes.client.rest import ApiException
 
 from drunc.exceptions import DruncCommandException, DruncException
 from drunc.process_manager.process_manager import ProcessManager
@@ -85,9 +86,18 @@ class K8sPodWatcherThread(threading.Thread):
                             proc_uuid, exit_code, reason, session
                         )
 
+            except ApiException as e:
+                if e.status == 410:
+                    pass
+                else:
+                    self.pm.log.error(
+                        f"K8s API error in watcher: {e}. Restarting watch."
+                    )
+                sleep(3)
+
             except Exception as e:
                 self.pm.log.error(f"K8s watcher thread error: {e}. Restarting watch.")
-                sleep(5)
+                sleep(3)
 
 
 class K8sProcessManager(ProcessManager):
@@ -631,8 +641,6 @@ done
         """
         session = boot_request.process_description.metadata.session
         podname = boot_request.process_description.metadata.name
-
-        print(boot_request)
 
         if boot_request.process_restriction.allowed_hosts:
             hostname = boot_request.process_restriction.allowed_hosts[0]

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -795,13 +795,6 @@ done
 
         self.log.info(f"Starting termination of {len(uuids_to_kill)} pods...")
 
-        is_local_session = any(
-            self.boot_request[uuid].process_description.metadata.name
-            == self.connection_server_name
-            for uuid in uuids_to_kill
-            if uuid in self.boot_request
-        )
-
         graceful_apps, forced_apps = [], []
         for uuid_str in uuids_to_kill:
             if uuid_str not in self.boot_request:
@@ -813,7 +806,7 @@ done
                 or pd.metadata.name == self.connection_server_name
             )
 
-            if is_controller or is_local_session:
+            if is_controller or pd.metadata.name == self.connection_server_name:
                 forced_apps.append(uuid_str)
             else:
                 graceful_apps.append(uuid_str)

--- a/src/drunc/process_manager/k8s_process_manager.py
+++ b/src/drunc/process_manager/k8s_process_manager.py
@@ -731,11 +731,20 @@ done
         queried_uuids = self._get_process_uid(query)
         if not queried_uuids:
             return ProcessInstanceList(values=[])
-        all_pods = self._core_v1_api.list_pod_for_all_namespaces(
-            label_selector=self._get_creator_label_selector()
-        )
+
+        pod_list = None
+        if query.session:
+            pod_list = self._core_v1_api.list_namespaced_pod(
+                namespace=query.session,
+                label_selector=self._get_creator_label_selector(),
+            )
+        else:
+            pod_list = self._core_v1_api.list_pod_for_all_namespaces(
+                label_selector=self._get_creator_label_selector()
+            )
+
         uuid_to_pod = {
-            p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in all_pods.items
+            p.metadata.labels.get(f"uuid.{self.drunc_label}"): p for p in pod_list.items
         }
         ret = []
         for proc_uuid in queried_uuids:
@@ -838,10 +847,12 @@ done
             )
             self.log.info(f"Stage '{stage_name}': {action} {len(uuids)} pod(s)...")
 
-            self.uuids_pending_deletion.update(uuids)
             self.termination_complete_event.clear()
+            self.uuids_pending_deletion.update(uuids)
 
             for proc_uuid in uuids:
+                if proc_uuid not in self.boot_request:
+                    continue  # Sanity check
                 pd = self.boot_request[proc_uuid].process_description
                 self.log.info(
                     f'Killing pod "{pd.metadata.session}/{pd.metadata.name}" (UUID {proc_uuid})'
@@ -857,6 +868,7 @@ done
                 self.log.warning(
                     f"Timeout in stage '{stage_name}'. Remaining: {self.uuids_pending_deletion}"
                 )
+
             self.uuids_pending_deletion.clear()
 
         kill_and_wait(graceful_apps, "Standalone C++ Applications")


### PR DESCRIPTION
# Description

!!! Requires https://github.com/DUNE-DAQ/daqsystemtest/pull/244 !!!

Fixes part of https://github.com/DUNE-DAQ/drunc/issues/583.

This PR refactors the Kubernetes networking model. The previous approach, which relied on a manually managed kubectl port-forward subprocess and a socat proxy sidecar, has been replaced with a NodePort service and hostAliases.

Key Changes:
Replaced port-forward with a NodePort Service.
Now: The connection server pod is exposed via a standard Kubernetes NodePort service. This is the idiomatic way to expose a service to external traffic and is managed entirely by the Kubernetes cluster.

Replaced Proxy Sidecar with hostAliases.
Now: The sidecar has been removed. Pods now use the spec.hostAliases field to resolve localhost directly to the ClusterIP of the connection server's service. This is a more lightweight and direct networking approach.

Dynamic Port Extraction:
The connection server port is no longer a fixed configuration value. It is now dynamically extracted from the gunicorn command arguments in the BootRequest.

Code Simplification:
Removed all code related to managing the port-forward subprocess, including starting the process, monitoring its output, and ensuring it's killed correctly.

Removed the logic for injecting the sidecar container into pod manifests.
Removed configuration options like sidecar_image and port_forward_timeout that are no longer needed.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))